### PR TITLE
Define parquets.

### DIFF
--- a/Designer/Block.csv
+++ b/Designer/Block.csv
@@ -1,2 +1,11 @@
-﻿ID,Name,AddsToBiome,GatherTool,IsFlammable,IsLiquid,MaxToughness
--20000,Brick Block Test Parquet,None,None,False,False,0
+ID,Name,AddsToBiome,GatherTool,IsFlammable,IsLiquid,MaxToughness
+-20000,2 Block Test Parquet,None,None,FALSE,FALSE,10
+20000,bush,None,Axe,TRUE,FALSE,1
+20001,tree,Forested,Axe,TRUE,FALSE,4
+20002,seed pod,Swamp,Axe,TRUE,FALSE,1
+20003,sandstone boulder,Desert,Pick,FALSE,FALSE,10
+20004,ice boulder,Tundra,Pick,FALSE,FALSE,8
+20005,grey brick,Town,Pick,FALSE,FALSE,8
+20006,wooden door,Town,Key,TRUE,FALSE,1
+20007,fresh water,None,Bucket,FALSE,TRUE,1
+20008,lava,Volcanic,Bucket,FALSE,TRUE,1

--- a/Designer/Collectable.csv
+++ b/Designer/Collectable.csv
@@ -1,2 +1,8 @@
-﻿ID,Name,AddsToBiome
--40000,Flowers Collectable Test Parquet,None
+ID,Name,AddsToBiome
+-40000,4 Collectable Test Parquet,None
+40000,Flower,None
+40001,Pinecone,Forested
+40002,Seeds,Swamp
+40003,Bones,Desert
+40004,Ice Crystal,Tundra
+40005,Copper Ore,Cavern

--- a/Designer/Floor.csv
+++ b/Designer/Floor.csv
@@ -1,9 +1,9 @@
-ID,Name,AddsToBiome,ModTool,TrenchAdjective,IsWalkable
+ID,Name,AddsToBiome,ModTool,NameWhenHole,IsWalkable
 -10000,1 Floor Test Parquet,None,None,dark hole,TRUE
 10000,grass,None,Shovel,dirty pit,TRUE
 10001,weeds,Swamp,Shovel,muddy pit,TRUE
 10002,sand,Desert,Shovel,sandy pit,TRUE
 10003,snow,Tundra,Shovel,snowy pit,TRUE
-10004,stone floor,Cavern,Hammer,stony channel,TRUE
+10004,stone floor,Cavern,Hammer,stony trench,TRUE
 10005,red brick,Town,Hammer,red brick channel,TRUE
 10006,spikes,None,Hammer,spike trap,FALSE

--- a/Designer/Furnishing.csv
+++ b/Designer/Furnishing.csv
@@ -1,2 +1,4 @@
-﻿ID,Name,AddsToBiome
--30000,Chair Furnishing Test Parquet,None
+ID,Name,AddsToBiome
+-30000,3 Furnishing Test Parquet,None
+30000,Chair,Town
+30001,Table,Town

--- a/ParquetCSVImporter/ClassMaps/FloorClassMap.cs
+++ b/ParquetCSVImporter/ClassMaps/FloorClassMap.cs
@@ -17,7 +17,7 @@ namespace ParquetCSVImporter.ClassMaps
             Map(m => m.AddsToBiome).Index(2);
 
             Map(m => m.ModTool).Index(3);
-            Map(m => m.TrenchAdjective).Index(4);
+            Map(m => m.NameWhenHole).Index(4);
             Map(m => m.IsWalkable).Index(5);
         }
     }

--- a/ParquetCSVImporter/Shims/FloorShim.cs
+++ b/ParquetCSVImporter/Shims/FloorShim.cs
@@ -16,8 +16,8 @@ namespace ParquetCSVImporter.ClassMaps
         /// <summary>The tool used to dig out or fill in the floor.</summary>
         public ModificationTools ModTool;
 
-        /// <summary>An adjective to employ for trenches.</summary>
-        public string TrenchAdjective;
+        /// <summary>Player-facing name of the parquet, used when it has been dug out.</summary>
+        public string NameWhenHole;
 
         /// <summary>The floor may be walked on.</summary>
         public bool IsWalkable;
@@ -36,7 +36,7 @@ namespace ParquetCSVImporter.ClassMaps
 
             if (typeof(T) == typeof(Floor))
             {
-                result = (T)(ParquetParent)new Floor(ID, Name, AddsToBiome, ModTool, TrenchAdjective, IsWalkable);
+                result = (T)(ParquetParent)new Floor(ID, Name, AddsToBiome, ModTool, NameWhenHole, IsWalkable);
             }
             else
             {

--- a/ParquetClassLibrary/Sandbox/Parquets/Block.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Block.cs
@@ -10,6 +10,9 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     public class Block : ParquetParent
     {
         #region Class Defaults
+        /// <summary>Minimum toughness value.</summary>
+        public const int LowestPossibleToughness = 0;
+
         /// <summary>Maximum toughness value to use when none is specified.</summary>
         private const int DefaultMaxToughness = 10;
 
@@ -46,7 +49,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         public int Toughness
         {
             get => _toughness;
-            set => _toughness = value.Normalize(0, MaxToughness);
+            set => _toughness = value.Normalize(LowestPossibleToughness, MaxToughness);
         }
         #endregion
 

--- a/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
@@ -10,8 +10,8 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     public class Floor : ParquetParent
     {
         #region Class Defaults
-        /// <summary>An adjective to employ for trenches if none is provided.</summary>
-        private const string DefaultTrenchAdjective = "dark hole";
+        /// <summary>A name to employ for parquets when IsHole is set, if none is provided.</summary>
+        private const string DefaultNameWhenHole = "dark hole";
 
         /// <summary>The set of values that are allowed for Floor's allowed ParquetIDs.</summary>
         [JsonIgnore]
@@ -23,15 +23,13 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         [JsonProperty(PropertyName = "in_modTool")]
         public ModificationTools ModTool { get; private set; }
 
-        /// <summary>An adjective to employ for trenches.</summary>
-        [JsonProperty(PropertyName = "in_trenchAdjective")]
-        public string TrenchAdjective { get; private set; }
+        /// <summary>Player-facing name of the parquet, used when it has been dug out.</summary>
+        [JsonProperty(PropertyName = "in_nameWhenHole")]
+        public string NameWhenHole { get; private set; }
 
         /// <summary>The floor may be walked on.</summary>
         [JsonProperty(PropertyName = "in_isWalkable")]
         public bool IsWalkable { get; private set; }
-
-        // IDEA: Add isFlyable
         #endregion
 
         #region Floor Status
@@ -48,16 +46,16 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <param name="in_name">Player-friendly name of the parquet.  Cannot be null.</param>
         /// <param name="in_addsToBiome">A set of flags indicating which, if any, <see cref="T:ParquetClassLibrary.Sandbox.Biome"/> this parquet helps to generate.</param>
         /// <param name="in_modTool">The tool used to gather this block.</param>
-        /// <param name="in_trenchAdjective">In trench adjective.</param>
+        /// <param name="in_nameWhenHole">The name to use for this tile when it has been dug out.</param>
         /// <param name="in_isWalkable">If <c>true</c> this block may burn.</param>
         [JsonConstructor]
         public Floor(ParquetID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None,
                      ModificationTools in_modTool = ModificationTools.None,
-                     string in_trenchAdjective = DefaultTrenchAdjective, bool in_isWalkable = true)
+                     string in_nameWhenHole = DefaultNameWhenHole, bool in_isWalkable = true)
                      : base(in_ID, in_name, in_addsToBiome)
         {
             ModTool = in_modTool;
-            TrenchAdjective = in_trenchAdjective;
+            NameWhenHole = in_nameWhenHole;
             IsWalkable = in_isWalkable;
         }
         #endregion

--- a/ParquetUnitTests/Sandbox/Parquets/BlockUnitTest.cs
+++ b/ParquetUnitTests/Sandbox/Parquets/BlockUnitTest.cs
@@ -10,11 +10,10 @@ namespace ParquetUnitTests.Sandbox.Parquets
         public void ToughnessCannotBeSetBelowZeroTest()
         {
             var testBlock = TestParquets.TestBlock;
-            var priorToughness = testBlock.Toughness;
 
             testBlock.Toughness = int.MinValue;
 
-            Assert.Equal(priorToughness, testBlock.Toughness);
+            Assert.Equal(Block.LowestPossibleToughness, testBlock.Toughness);
         }
 
         [Fact]

--- a/ParquetUnitTests/Sandbox/Parquets/BlockUnitTest.cs
+++ b/ParquetUnitTests/Sandbox/Parquets/BlockUnitTest.cs
@@ -1,5 +1,4 @@
-﻿using ParquetClassLibrary;
-using ParquetClassLibrary.Sandbox.Parquets;
+﻿using ParquetClassLibrary.Sandbox.Parquets;
 using Xunit;
 
 namespace ParquetUnitTests.Sandbox.Parquets


### PR DESCRIPTION
Adds definitions for all the basic parquets defined in theParquet wiki.
These are not final products but merely a starting place for game design.