### PR TITLE
Extend Collectable Parquets

### DIFF
--- a/Designer/Collectable.csv
+++ b/Designer/Collectable.csv
@@ -1,8 +1,11 @@
-ID,Name,AddsToBiome
--40000,4 Collectable Test Parquet,None
-40000,Flower,None
-40001,Pinecone,Forested
-40002,Seeds,Swamp
-40003,Bones,Desert
-40004,Ice Crystal,Tundra
-40005,Copper Ore,Cavern
+ID,Name,AddsToBiome,Effect,EffectAmount,ItemID
+-40000,4 Collectable Test Parquet,None,None,0,-50000
+40000,Flower,None,Item,0,50000
+40001,Pinecone,Forested,Item,0,50001
+40002,Seeds,Swamp,Item,0,50002
+40003,Bones,Desert,Item,0,50003
+40004,Ice Crystal,Tundra,Item,0,50004
+40005,Copper Ore,Cavern,Item,0,50005
+40006,Heart,None,Health,10,0
+40007,Star,None,Mana,10,0
+40008,Coin,None,Money,1,0

--- a/ParquetCSVImporter/EntityIDConverter.cs
+++ b/ParquetCSVImporter/EntityIDConverter.cs
@@ -9,25 +9,25 @@ namespace ParquetCSVImporter
     /// <summary>
     /// ID Converter for parquet identifiers.
     /// </summary>
-    public class ParquetIDConverter : DefaultTypeConverter
+    public class EntityIDConverter : DefaultTypeConverter
     {
         /// <summary>
-        /// Converts the given record column to <see cref="ParquetID"/>.
+        /// Converts the given record column to <see cref="EnitityID"/>.
         /// </summary>
         /// <param name="text">The record column to convert to an object.</param>
         /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
         /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
-        /// <returns>The <see cref="ParquetID"/> created from the record column.</returns>
+        /// <returns>The <see cref="EnitityID"/> created from the record column.</returns>
         public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
             var numberStyle = memberMapData.TypeConverterOptions.NumberStyle ?? NumberStyles.Integer;
 
             if (int.TryParse(text, numberStyle, memberMapData.TypeConverterOptions.CultureInfo, out var i))
             {
-                return (ParquetID)i;
+                return (EnitityID)i;
             }
 
-            return (ParquetID)base.ConvertFromString(text, row, memberMapData);
+            return (EnitityID)base.ConvertFromString(text, row, memberMapData);
         }
     }
 }

--- a/ParquetCSVImporter/EntityIDConverter.cs
+++ b/ParquetCSVImporter/EntityIDConverter.cs
@@ -12,22 +12,22 @@ namespace ParquetCSVImporter
     public class EntityIDConverter : DefaultTypeConverter
     {
         /// <summary>
-        /// Converts the given record column to <see cref="EnitityID"/>.
+        /// Converts the given record column to <see cref="EntityID"/>.
         /// </summary>
         /// <param name="text">The record column to convert to an object.</param>
         /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
         /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
-        /// <returns>The <see cref="EnitityID"/> created from the record column.</returns>
+        /// <returns>The <see cref="EntityID"/> created from the record column.</returns>
         public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
             var numberStyle = memberMapData.TypeConverterOptions.NumberStyle ?? NumberStyles.Integer;
 
             if (int.TryParse(text, numberStyle, memberMapData.TypeConverterOptions.CultureInfo, out var i))
             {
-                return (EnitityID)i;
+                return (EntityID)i;
             }
 
-            return (EnitityID)base.ConvertFromString(text, row, memberMapData);
+            return (EntityID)base.ConvertFromString(text, row, memberMapData);
         }
     }
 }

--- a/ParquetCSVImporter/ImportProgram.cs
+++ b/ParquetCSVImporter/ImportProgram.cs
@@ -81,8 +81,8 @@ namespace ParquetCSVImporter
             {
                 using (var csv = new CsvReader(reader))
                 {
-                    csv.Configuration.TypeConverterCache.AddConverter(typeof(ParquetID), new ParquetIDConverter());
-                    csv.Configuration.TypeConverterOptionsCache.AddOptions(typeof(ParquetID), IdentifierOptions);
+                    csv.Configuration.TypeConverterCache.AddConverter(typeof(EnitityID), new EntityIDConverter());
+                    csv.Configuration.TypeConverterOptionsCache.AddOptions(typeof(EnitityID), IdentifierOptions);
                     csv.Configuration.RegisterClassMapFor<T>();
                     records = csv.GetRecordsViaShim<T>();
                 }

--- a/ParquetCSVImporter/ImportProgram.cs
+++ b/ParquetCSVImporter/ImportProgram.cs
@@ -81,8 +81,8 @@ namespace ParquetCSVImporter
             {
                 using (var csv = new CsvReader(reader))
                 {
-                    csv.Configuration.TypeConverterCache.AddConverter(typeof(EnitityID), new EntityIDConverter());
-                    csv.Configuration.TypeConverterOptionsCache.AddOptions(typeof(EnitityID), IdentifierOptions);
+                    csv.Configuration.TypeConverterCache.AddConverter(typeof(EntityID), new EntityIDConverter());
+                    csv.Configuration.TypeConverterOptionsCache.AddOptions(typeof(EntityID), IdentifierOptions);
                     csv.Configuration.RegisterClassMapFor<T>();
                     records = csv.GetRecordsViaShim<T>();
                 }

--- a/ParquetCSVImporter/ParquetCSVImporter.csproj
+++ b/ParquetCSVImporter/ParquetCSVImporter.csproj
@@ -54,7 +54,7 @@
     <Compile Include="Shims\FloorShim.cs" />
     <Compile Include="Shims\FurnishingShim.cs" />
     <Compile Include="Shims\ParquetParentShim.cs" />
-    <Compile Include="ParquetIDConverter.cs" />
+    <Compile Include="EntityIDConverter.cs" />
     <Compile Include="ClassMaps\IReaderConfigurationExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ParquetCSVImporter/Shims/CollectableShim.cs
+++ b/ParquetCSVImporter/Shims/CollectableShim.cs
@@ -1,4 +1,5 @@
-﻿using ParquetClassLibrary.Sandbox.Parquets;
+﻿using ParquetClassLibrary.Sandbox.ID;
+using ParquetClassLibrary.Sandbox.Parquets;
 
 namespace ParquetCSVImporter.ClassMaps
 {
@@ -12,6 +13,18 @@ namespace ParquetCSVImporter.ClassMaps
     /// </summary>
     public class CollectableShim : ParquetParentShim
     {
+        /// <summary>The effect generated when a character encounters this Collectable.</summary>
+        public CollectionEffect Effect;
+
+        /// <summary>
+        /// The scale in points of the effect.  That is, how much to alter a stat if the
+        /// <see cref="T:ParquetClassLibrary.Sandbox.ID.CollectionEffect"/> is set to alter a stat.
+        /// </summary>
+        public int EffectAmount;
+
+        /// <summary>The item spawned when a character encounters this Collectable.</summary>
+        public EnitityID ItemID;
+
         /// <summary>
         /// Converts a shim into the class is corresponds to.
         /// </summary>
@@ -26,7 +39,7 @@ namespace ParquetCSVImporter.ClassMaps
 
             if (typeof(T) == typeof(Collectable))
             {
-                result = (T)(ParquetParent)new Collectable(ID, Name, AddsToBiome);
+                result = (T)(ParquetParent)new Collectable(ID, Name, AddsToBiome, Effect, EffectAmount, ItemID);
             }
             else
             {

--- a/ParquetCSVImporter/Shims/CollectableShim.cs
+++ b/ParquetCSVImporter/Shims/CollectableShim.cs
@@ -23,7 +23,7 @@ namespace ParquetCSVImporter.ClassMaps
         public int EffectAmount;
 
         /// <summary>The item spawned when a character encounters this Collectable.</summary>
-        public EnitityID ItemID;
+        public EntityID ItemID;
 
         /// <summary>
         /// Converts a shim into the class is corresponds to.

--- a/ParquetCSVImporter/Shims/ParquetParentShim.cs
+++ b/ParquetCSVImporter/Shims/ParquetParentShim.cs
@@ -10,7 +10,7 @@ namespace ParquetCSVImporter.ClassMaps
     public abstract class ParquetParentShim
     {
         /// <summary>Unique identifier of the parquet.</summary>
-        public ParquetID ID;
+        public EnitityID ID;
 
         /// <summary>Player-facing name of the parquet.</summary>
         public string Name;

--- a/ParquetCSVImporter/Shims/ParquetParentShim.cs
+++ b/ParquetCSVImporter/Shims/ParquetParentShim.cs
@@ -10,7 +10,7 @@ namespace ParquetCSVImporter.ClassMaps
     public abstract class ParquetParentShim
     {
         /// <summary>Unique identifier of the parquet.</summary>
-        public EnitityID ID;
+        public EntityID ID;
 
         /// <summary>Player-facing name of the parquet.</summary>
         public string Name;

--- a/ParquetClassLibrary/Assembly.cs
+++ b/ParquetClassLibrary/Assembly.cs
@@ -1,6 +1,7 @@
-using ParquetClassLibrary.Sandbox.ID;
+﻿using ParquetClassLibrary.Sandbox.ID;
 using ParquetClassLibrary.Utilities;
 
+// Allow unit tests to access classes and members with internal accessibility.
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ParquetUnitTests")]
 
 namespace ParquetClassLibrary
@@ -13,30 +14,36 @@ namespace ParquetClassLibrary
         /// <summary>Describes the version of the serialized data that this class understands.</summary>
         public const string SupportedDataVersion = "0.1.0";
 
-        #region Sandbox Parquet ID Ranges
+        #region Sandbox Parquet and Item ID Ranges
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ParquetID"/> set aside for Floors.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Floors.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
         public static readonly Range<EnitityID> FloorIDs = new Range<EnitityID>(10000, 19000);
 
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ParquetID"/> set aside for Blocks.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Blocks.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
         public static readonly Range<EnitityID> BlockIDs = new Range<EnitityID>(20000, 29000);
 
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ParquetID"/> set aside for Furnishings.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Furnishings.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
         public static readonly Range<EnitityID> FurnishingIDs = new Range<EnitityID>(30000, 39000);
 
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ParquetID"/> set aside for Collectables.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Collectables.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
         public static readonly Range<EnitityID> CollectableIDs = new Range<EnitityID>(40000, 49000);
+
+        /// <summary>
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Items.
+        /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test items.
+        /// </summary>
+        public static readonly Range<EnitityID> ItemIDs = new Range<EnitityID>(50000, 59000);
         #endregion
 
         #region Sandbox Map Element Dimensions

--- a/ParquetClassLibrary/Assembly.cs
+++ b/ParquetClassLibrary/Assembly.cs
@@ -18,25 +18,25 @@ namespace ParquetClassLibrary
         /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ParquetID"/> set aside for Floors.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
-        public static readonly Range<ParquetID> FloorIDs = new Range<ParquetID>(10000, 19000);
+        public static readonly Range<EnitityID> FloorIDs = new Range<EnitityID>(10000, 19000);
 
         /// <summary>
         /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ParquetID"/> set aside for Blocks.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
-        public static readonly Range<ParquetID> BlockIDs = new Range<ParquetID>(20000, 29000);
+        public static readonly Range<EnitityID> BlockIDs = new Range<EnitityID>(20000, 29000);
 
         /// <summary>
         /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ParquetID"/> set aside for Furnishings.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
-        public static readonly Range<ParquetID> FurnishingIDs = new Range<ParquetID>(30000, 39000);
+        public static readonly Range<EnitityID> FurnishingIDs = new Range<EnitityID>(30000, 39000);
 
         /// <summary>
         /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ParquetID"/> set aside for Collectables.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
-        public static readonly Range<ParquetID> CollectableIDs = new Range<ParquetID>(40000, 49000);
+        public static readonly Range<EnitityID> CollectableIDs = new Range<EnitityID>(40000, 49000);
         #endregion
 
         #region Sandbox Map Element Dimensions

--- a/ParquetClassLibrary/Assembly.cs
+++ b/ParquetClassLibrary/Assembly.cs
@@ -16,34 +16,34 @@ namespace ParquetClassLibrary
 
         #region Sandbox Parquet and Item ID Ranges
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Floors.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EntityID"/> set aside for Floors.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
-        public static readonly Range<EnitityID> FloorIDs = new Range<EnitityID>(10000, 19000);
+        public static readonly Range<EntityID> FloorIDs = new Range<EntityID>(10000, 19000);
 
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Blocks.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EntityID"/> set aside for Blocks.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
-        public static readonly Range<EnitityID> BlockIDs = new Range<EnitityID>(20000, 29000);
+        public static readonly Range<EntityID> BlockIDs = new Range<EntityID>(20000, 29000);
 
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Furnishings.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EntityID"/> set aside for Furnishings.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
-        public static readonly Range<EnitityID> FurnishingIDs = new Range<EnitityID>(30000, 39000);
+        public static readonly Range<EntityID> FurnishingIDs = new Range<EntityID>(30000, 39000);
 
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Collectables.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EntityID"/> set aside for Collectables.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
-        public static readonly Range<EnitityID> CollectableIDs = new Range<EnitityID>(40000, 49000);
+        public static readonly Range<EntityID> CollectableIDs = new Range<EntityID>(40000, 49000);
 
         /// <summary>
-        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/> set aside for Items.
+        /// A subset of the values of <see cref="T:ParquetClassLibrary.Sandbox.ID.EntityID"/> set aside for Items.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test items.
         /// </summary>
-        public static readonly Range<EnitityID> ItemIDs = new Range<EnitityID>(50000, 59000);
+        public static readonly Range<EntityID> ItemIDs = new Range<EntityID>(50000, 59000);
         #endregion
 
         #region Sandbox Map Element Dimensions

--- a/ParquetClassLibrary/Sandbox/ID/CollectionEffect.cs
+++ b/ParquetClassLibrary/Sandbox/ID/CollectionEffect.cs
@@ -1,0 +1,14 @@
+﻿namespace ParquetClassLibrary.Sandbox.ID
+{
+    /// <summary>
+    /// IDs for effects that can happen when a character encounters a Collectable.
+    /// </summary>
+    public enum CollectionEffect
+    {
+        None,
+        Item,
+        Health,
+        Mana,
+        Money,
+    }
+}

--- a/ParquetClassLibrary/Sandbox/ID/EnitityID.cs
+++ b/ParquetClassLibrary/Sandbox/ID/EnitityID.cs
@@ -4,26 +4,36 @@ using Newtonsoft.Json;
 namespace ParquetClassLibrary.Sandbox.ID
 {
     /// <summary>
-    /// Uniquely identifies every defined parquet.
+    /// Uniquely identifies every defined game entity.
     /// 
-    /// To be clear: there are multiple parquet subtypes, and
-    /// each of these subtypes has multiple definitions.
+    /// <see cref="ParquetClassLibrary.Sandbox.Parquets.ParquetParent"/>
+    /// 
+    /// To be clear: there are multiple parquet and item subtypes,
+    /// and each of these subtypes has multiple definitions.
     /// The definitions are purely data-driven, read in from
     /// JSON or CSV files, and not type-checked by the compiler.
     /// 
-    /// Multiple identicle parquet IDs may be assigned to MapChunks or
-    /// MapRegions.  The IDs provide a means for the library to
-    /// look up information about the parqut definition when
-    /// other game elements interact with it.
+    /// Multiple identicle parquet IDs may be assigned to MapChunks
+    /// or MapRegions, and multiple duplicate item IDs may be spawned.
+    /// The IDs provide a means for the library to look up
+    /// the game entity definition when other game elements interact
+    /// with it.
+    /// 
+    /// Although the compiler does not provide type-checking for
+    /// IDs, within the scope of their usage the library defines
+    /// valid ranges for their use and these are checked by
+    /// library code.  <see cref="ParquetClassLibrary.Assembly"/>
     /// 
     /// TODO: Move this explanation into the Wiki and expand it.
     /// </summary>
-    public struct ParquetID : IComparable<ParquetID>
+    public struct EnitityID : IComparable<EnitityID>
     {
-        /// <summary>Indicates the lack of a Parquet.</summary>
-        public static readonly ParquetID None = 0;
+        /// <summary>Indicates the lack of a game entity associated with this identifier (e.g., parquet).</summary>
+        public static readonly EnitityID None = 0;
 
         /// <summary>Backing type for the identifier.</summary>
+        // Currently this is implemented as an int rather than a GUID in order
+        // to aid in range validation and human-readability of design documents.
         [JsonProperty]
         private int _id;
 
@@ -32,9 +42,9 @@ namespace ParquetClassLibrary.Sandbox.ID
         /// </summary>
         /// <param name="in_value">Any valid identifier value.</param>
         /// <returns>The given identifier value.</returns>
-        public static implicit operator ParquetID(int in_value)
+        public static implicit operator EnitityID(int in_value)
         {
-            return new ParquetID { _id = in_value };
+            return new EnitityID { _id = in_value };
         }
 
         /// <summary>
@@ -42,7 +52,7 @@ namespace ParquetClassLibrary.Sandbox.ID
         /// </summary>
         /// <param name="in_identifier">Any valid identifier value.</param>
         /// <returns>The given identifier value.</returns>
-        public static implicit operator int(ParquetID in_identifier)
+        public static implicit operator int(EnitityID in_identifier)
         {
             return in_identifier._id;
         }
@@ -58,7 +68,7 @@ namespace ParquetClassLibrary.Sandbox.ID
         /// Zero indicates that the current instance occurs in the same position in the sort order as the given identifier.
         /// Greater than zero indicates that the current instance follows the given identifier in the sort order.
         /// </returns>
-        public int CompareTo(ParquetID in_identifier)
+        public int CompareTo(EnitityID in_identifier)
         {
             return _id.CompareTo(in_identifier._id);
         }

--- a/ParquetClassLibrary/Sandbox/ID/EnitityID.cs
+++ b/ParquetClassLibrary/Sandbox/ID/EnitityID.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using Newtonsoft.Json;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Sandbox.ID
 {
@@ -37,6 +38,7 @@ namespace ParquetClassLibrary.Sandbox.ID
         [JsonProperty]
         private int _id;
 
+        #region IComparable Methods
         /// <summary>
         /// Enables identifiers to be treated as their backing type.
         /// </summary>
@@ -72,14 +74,29 @@ namespace ParquetClassLibrary.Sandbox.ID
         {
             return _id.CompareTo(in_identifier._id);
         }
+        #endregion
+
+        #region Utility Methods
+        /// <summary>
+        /// Validates the current ID.  An ID is valid if:
+        /// 1) it is <see cref="ParquetClassLibrary.Sandbox.ID.EnitityID.None"/>
+        /// 2) it is defined within the given range, regardless of sign.
+        /// </summary>
+        /// <returns><c>true</c>, if the identifier is valid given the range, <c>false</c> otherwise.</returns>
+        /// <param name="in_range">The range within which the absolute value of the ID must fall.</param>
+        public bool IsValidForRange(Range<EnitityID> in_range)
+        {
+            return _id == None || in_range.ContainsValue(Math.Abs(_id));
+        }
 
         /// <summary>
-        /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:ParquetClassLibrary.Sandbox.ID.ParquetID"/>.
+        /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/>.
         /// </summary>
         /// <returns>The representation.</returns>
         public override string ToString()
         {
             return _id.ToString();
         }
+        #endregion
     }
 }

--- a/ParquetClassLibrary/Sandbox/ID/EntityID.cs
+++ b/ParquetClassLibrary/Sandbox/ID/EntityID.cs
@@ -27,10 +27,10 @@ namespace ParquetClassLibrary.Sandbox.ID
     /// 
     /// TODO: Move this explanation into the Wiki and expand it.
     /// </summary>
-    public struct EnitityID : IComparable<EnitityID>
+    public struct EntityID : IComparable<EntityID>
     {
         /// <summary>Indicates the lack of a game entity associated with this identifier (e.g., parquet).</summary>
-        public static readonly EnitityID None = 0;
+        public static readonly EntityID None = 0;
 
         /// <summary>Backing type for the identifier.</summary>
         // Currently this is implemented as an int rather than a GUID in order
@@ -44,9 +44,9 @@ namespace ParquetClassLibrary.Sandbox.ID
         /// </summary>
         /// <param name="in_value">Any valid identifier value.</param>
         /// <returns>The given identifier value.</returns>
-        public static implicit operator EnitityID(int in_value)
+        public static implicit operator EntityID(int in_value)
         {
-            return new EnitityID { _id = in_value };
+            return new EntityID { _id = in_value };
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace ParquetClassLibrary.Sandbox.ID
         /// </summary>
         /// <param name="in_identifier">Any valid identifier value.</param>
         /// <returns>The given identifier value.</returns>
-        public static implicit operator int(EnitityID in_identifier)
+        public static implicit operator int(EntityID in_identifier)
         {
             return in_identifier._id;
         }
@@ -70,7 +70,7 @@ namespace ParquetClassLibrary.Sandbox.ID
         /// Zero indicates that the current instance occurs in the same position in the sort order as the given identifier.
         /// Greater than zero indicates that the current instance follows the given identifier in the sort order.
         /// </returns>
-        public int CompareTo(EnitityID in_identifier)
+        public int CompareTo(EntityID in_identifier)
         {
             return _id.CompareTo(in_identifier._id);
         }
@@ -79,18 +79,19 @@ namespace ParquetClassLibrary.Sandbox.ID
         #region Utility Methods
         /// <summary>
         /// Validates the current ID.  An ID is valid if:
-        /// 1) it is <see cref="ParquetClassLibrary.Sandbox.ID.EnitityID.None"/>
+        /// 1) it is <see cref="ParquetClassLibrary.Sandbox.ID.EntityID.None"/>
         /// 2) it is defined within the given range, regardless of sign.
         /// </summary>
         /// <returns><c>true</c>, if the identifier is valid given the range, <c>false</c> otherwise.</returns>
         /// <param name="in_range">The range within which the absolute value of the ID must fall.</param>
-        public bool IsValidForRange(Range<EnitityID> in_range)
+        public bool IsValidForRange(Range<EntityID> in_range)
         {
             return _id == None || in_range.ContainsValue(Math.Abs(_id));
         }
 
         /// <summary>
-        /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:ParquetClassLibrary.Sandbox.ID.EnitityID"/>.
+        /// Returns a <see cref="T:System.String"/> that represents the current
+        /// <see cref="T:ParquetClassLibrary.Sandbox.ID.EntityID"/>.
         /// </summary>
         /// <returns>The representation.</returns>
         public override string ToString()

--- a/ParquetClassLibrary/Sandbox/MapChunk.cs
+++ b/ParquetClassLibrary/Sandbox/MapChunk.cs
@@ -22,19 +22,19 @@ namespace ParquetClassLibrary.Sandbox
 
         #region Chunk Contents
         /// <summary>Floors and walkable terrain in the region.</summary>
-        protected override EnitityID[,] _floorLayer { get; } = new EnitityID[Assembly.ParquetsPerChunkDimension,
+        protected override EntityID[,] _floorLayer { get; } = new EntityID[Assembly.ParquetsPerChunkDimension,
                                                                              Assembly.ParquetsPerChunkDimension];
 
         /// <summary>Walls and obstructing terrain in the region.</summary>
-        protected override EnitityID[,] _blockLayer { get; } = new EnitityID[Assembly.ParquetsPerChunkDimension,
+        protected override EntityID[,] _blockLayer { get; } = new EntityID[Assembly.ParquetsPerChunkDimension,
                                                                              Assembly.ParquetsPerChunkDimension];
 
         /// <summary>Furniture and natural items in the region.</summary>
-        protected override EnitityID[,] _furnishingLayer { get; } = new EnitityID[Assembly.ParquetsPerChunkDimension,
+        protected override EntityID[,] _furnishingLayer { get; } = new EntityID[Assembly.ParquetsPerChunkDimension,
                                                                                   Assembly.ParquetsPerChunkDimension];
 
         /// <summary>Collectable materials in the region.</summary>
-        protected override EnitityID[,] _collectableLayer { get; } = new EnitityID[Assembly.ParquetsPerChunkDimension,
+        protected override EntityID[,] _collectableLayer { get; } = new EntityID[Assembly.ParquetsPerChunkDimension,
                                                                                    Assembly.ParquetsPerChunkDimension];
         #endregion
 

--- a/ParquetClassLibrary/Sandbox/MapChunk.cs
+++ b/ParquetClassLibrary/Sandbox/MapChunk.cs
@@ -22,19 +22,19 @@ namespace ParquetClassLibrary.Sandbox
 
         #region Chunk Contents
         /// <summary>Floors and walkable terrain in the region.</summary>
-        protected override ParquetID[,] _floorLayer { get; } = new ParquetID[Assembly.ParquetsPerChunkDimension,
+        protected override EnitityID[,] _floorLayer { get; } = new EnitityID[Assembly.ParquetsPerChunkDimension,
                                                                              Assembly.ParquetsPerChunkDimension];
 
         /// <summary>Walls and obstructing terrain in the region.</summary>
-        protected override ParquetID[,] _blockLayer { get; } = new ParquetID[Assembly.ParquetsPerChunkDimension,
+        protected override EnitityID[,] _blockLayer { get; } = new EnitityID[Assembly.ParquetsPerChunkDimension,
                                                                              Assembly.ParquetsPerChunkDimension];
 
         /// <summary>Furniture and natural items in the region.</summary>
-        protected override ParquetID[,] _furnishingLayer { get; } = new ParquetID[Assembly.ParquetsPerChunkDimension,
+        protected override EnitityID[,] _furnishingLayer { get; } = new EnitityID[Assembly.ParquetsPerChunkDimension,
                                                                                   Assembly.ParquetsPerChunkDimension];
 
         /// <summary>Collectable materials in the region.</summary>
-        protected override ParquetID[,] _collectableLayer { get; } = new ParquetID[Assembly.ParquetsPerChunkDimension,
+        protected override EnitityID[,] _collectableLayer { get; } = new EnitityID[Assembly.ParquetsPerChunkDimension,
                                                                                    Assembly.ParquetsPerChunkDimension];
         #endregion
 

--- a/ParquetClassLibrary/Sandbox/MapParent.cs
+++ b/ParquetClassLibrary/Sandbox/MapParent.cs
@@ -38,16 +38,16 @@ namespace ParquetClassLibrary.Sandbox
         protected readonly List<SpecialPoint> _specialPoints = new List<SpecialPoint>();
 
         /// <summary>Floors and walkable terrain in the region.</summary>
-        protected abstract EnitityID[,] _floorLayer { get; }
+        protected abstract EntityID[,] _floorLayer { get; }
 
         /// <summary>Walls and obstructing terrain in the region.</summary>
-        protected abstract EnitityID[,] _blockLayer { get; }
+        protected abstract EntityID[,] _blockLayer { get; }
 
         /// <summary>Furniture and natural items in the region.</summary>
-        protected abstract EnitityID[,] _furnishingLayer { get; }
+        protected abstract EntityID[,] _furnishingLayer { get; }
 
         /// <summary>Collectable materials in the region.</summary>
-        protected abstract EnitityID[,] _collectableLayer { get; }
+        protected abstract EntityID[,] _collectableLayer { get; }
         #endregion
 
         #region Parquets Replacement Methods
@@ -57,7 +57,7 @@ namespace ParquetClassLibrary.Sandbox
         /// <param name="in_floorID">ID for the new floor to set.</param>
         /// <param name="in_position">The position to set.</param>
         /// <returns><c>true</c>, if the floor was set, <c>false</c> otherwise.</returns>
-        public bool TrySetFloor(EnitityID in_floorID, Vector2Int in_position)
+        public bool TrySetFloor(EntityID in_floorID, Vector2Int in_position)
         {
             return TrySetParquet(in_floorID, in_position, _floorLayer);
         }
@@ -68,7 +68,7 @@ namespace ParquetClassLibrary.Sandbox
         /// <param name="in_blockID">ID for the new block to set.</param>
         /// <param name="in_position">The position to set.</param>
         /// <returns><c>true</c>, if the block was set, <c>false</c> otherwise.</returns>
-        public bool TrySetBlock(EnitityID in_blockID, Vector2Int in_position)
+        public bool TrySetBlock(EntityID in_blockID, Vector2Int in_position)
         {
             return TrySetParquet(in_blockID, in_position, _blockLayer);
         }
@@ -79,7 +79,7 @@ namespace ParquetClassLibrary.Sandbox
         /// <param name="in_furnishingID">ID for the new furnishing to set.</param>
         /// <param name="in_position">The position to set.</param>
         /// <returns><c>true</c>, if the furnishing was set, <c>false</c> otherwise.</returns>
-        public bool TrySetFurnishing(EnitityID in_furnishingID, Vector2Int in_position)
+        public bool TrySetFurnishing(EntityID in_furnishingID, Vector2Int in_position)
         {
             return TrySetParquet(in_furnishingID, in_position, _furnishingLayer);
         }
@@ -90,7 +90,7 @@ namespace ParquetClassLibrary.Sandbox
         /// <param name="in_collectableID">ID for the new collectable to set.</param>
         /// <param name="in_position">The position to set.</param>
         /// <returns><c>true</c>, if the collectable was set, <c>false</c> otherwise.</returns>
-        public bool TrySetCollectable(EnitityID in_collectableID, Vector2Int in_position)
+        public bool TrySetCollectable(EntityID in_collectableID, Vector2Int in_position)
         {
             return TrySetParquet(in_collectableID, in_position, _collectableLayer);
         }
@@ -100,10 +100,10 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_position">The position to clear.</param>
         /// <returns><c>true</c>, if the parquet was removed, <c>false</c> otherwise.</returns>
-        private bool TrySetParquet(EnitityID in_parquetID, Vector2Int in_position, EnitityID[,] in_parquetLayer)
+        private bool TrySetParquet(EntityID in_parquetID, Vector2Int in_position, EntityID[,] in_parquetLayer)
         {
             var result = false;
-            if (IsValidPosition(in_position) && EnitityID.None != in_parquetID)
+            if (IsValidPosition(in_position) && EntityID.None != in_parquetID)
             {
                 in_parquetLayer[in_position.x, in_position.y] = in_parquetID;
                 result = true;
@@ -169,12 +169,12 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_position">The position to clear.</param>
         /// <returns><c>true</c>, if the parquet was removed, <c>false</c> otherwise.</returns>
-        private bool TryRemoveParquet(Vector2Int in_position, EnitityID[,] in_parquetLayer)
+        private bool TryRemoveParquet(Vector2Int in_position, EntityID[,] in_parquetLayer)
         {
             var result = false;
             if (IsValidPosition(in_position))
             {
-                in_parquetLayer[in_position.x, in_position.y] = EnitityID.None;
+                in_parquetLayer[in_position.x, in_position.y] = EntityID.None;
                 result = true;
             }
             return result;
@@ -356,14 +356,14 @@ namespace ParquetClassLibrary.Sandbox
             {
                 for (var y = 0; y < DimensionsInParquets.y; y++)
                 {
-                    EnitityID parquetID = _floorLayer[x, y];
-                    if (EnitityID.None != parquetID) { result.Add(AllParquets.Get<Floor>(parquetID)); }
+                    EntityID parquetID = _floorLayer[x, y];
+                    if (EntityID.None != parquetID) { result.Add(AllParquets.Get<Floor>(parquetID)); }
                     parquetID = _blockLayer[x, y];
-                    if (EnitityID.None != parquetID) { result.Add(AllParquets.Get<Block>(parquetID)); }
+                    if (EntityID.None != parquetID) { result.Add(AllParquets.Get<Block>(parquetID)); }
                     parquetID = _furnishingLayer[x, y];
-                    if (EnitityID.None != parquetID) { result.Add(AllParquets.Get<Furnishing>(parquetID)); }
+                    if (EntityID.None != parquetID) { result.Add(AllParquets.Get<Furnishing>(parquetID)); }
                     parquetID = _collectableLayer[x, y];
-                    if (EnitityID.None != parquetID) { result.Add(AllParquets.Get<Collectable>(parquetID)); }
+                    if (EntityID.None != parquetID) { result.Add(AllParquets.Get<Collectable>(parquetID)); }
                 }
             }
 
@@ -422,13 +422,13 @@ namespace ParquetClassLibrary.Sandbox
                 for (var y = 0; y < DimensionsInParquets.y; y++)
                 {
                     // TODO: This fails with TestParquet values.  Do we want to support ToStringing test values??
-                    var parquet = EnitityID.None != _collectableLayer[x, y]
+                    var parquet = EntityID.None != _collectableLayer[x, y]
                         ? AllParquets.Get<ParquetParent>(_collectableLayer[x, y]) 
-                        : EnitityID.None != _furnishingLayer[x, y]
+                        : EntityID.None != _furnishingLayer[x, y]
                             ? AllParquets.Get<ParquetParent>(_furnishingLayer[x, y])
-                            : EnitityID.None != _blockLayer[x, y]
+                            : EntityID.None != _blockLayer[x, y]
                                 ? AllParquets.Get<ParquetParent>(_blockLayer[x, y])
-                                : EnitityID.None != _floorLayer[x, y]
+                                : EntityID.None != _floorLayer[x, y]
                                     ? AllParquets.Get<ParquetParent>(_floorLayer[x, y])
                                     : null;
 

--- a/ParquetClassLibrary/Sandbox/MapParent.cs
+++ b/ParquetClassLibrary/Sandbox/MapParent.cs
@@ -38,16 +38,16 @@ namespace ParquetClassLibrary.Sandbox
         protected readonly List<SpecialPoint> _specialPoints = new List<SpecialPoint>();
 
         /// <summary>Floors and walkable terrain in the region.</summary>
-        protected abstract ParquetID[,] _floorLayer { get; }
+        protected abstract EnitityID[,] _floorLayer { get; }
 
         /// <summary>Walls and obstructing terrain in the region.</summary>
-        protected abstract ParquetID[,] _blockLayer { get; }
+        protected abstract EnitityID[,] _blockLayer { get; }
 
         /// <summary>Furniture and natural items in the region.</summary>
-        protected abstract ParquetID[,] _furnishingLayer { get; }
+        protected abstract EnitityID[,] _furnishingLayer { get; }
 
         /// <summary>Collectable materials in the region.</summary>
-        protected abstract ParquetID[,] _collectableLayer { get; }
+        protected abstract EnitityID[,] _collectableLayer { get; }
         #endregion
 
         #region Parquets Replacement Methods
@@ -57,7 +57,7 @@ namespace ParquetClassLibrary.Sandbox
         /// <param name="in_floorID">ID for the new floor to set.</param>
         /// <param name="in_position">The position to set.</param>
         /// <returns><c>true</c>, if the floor was set, <c>false</c> otherwise.</returns>
-        public bool TrySetFloor(ParquetID in_floorID, Vector2Int in_position)
+        public bool TrySetFloor(EnitityID in_floorID, Vector2Int in_position)
         {
             return TrySetParquet(in_floorID, in_position, _floorLayer);
         }
@@ -68,7 +68,7 @@ namespace ParquetClassLibrary.Sandbox
         /// <param name="in_blockID">ID for the new block to set.</param>
         /// <param name="in_position">The position to set.</param>
         /// <returns><c>true</c>, if the block was set, <c>false</c> otherwise.</returns>
-        public bool TrySetBlock(ParquetID in_blockID, Vector2Int in_position)
+        public bool TrySetBlock(EnitityID in_blockID, Vector2Int in_position)
         {
             return TrySetParquet(in_blockID, in_position, _blockLayer);
         }
@@ -79,7 +79,7 @@ namespace ParquetClassLibrary.Sandbox
         /// <param name="in_furnishingID">ID for the new furnishing to set.</param>
         /// <param name="in_position">The position to set.</param>
         /// <returns><c>true</c>, if the furnishing was set, <c>false</c> otherwise.</returns>
-        public bool TrySetFurnishing(ParquetID in_furnishingID, Vector2Int in_position)
+        public bool TrySetFurnishing(EnitityID in_furnishingID, Vector2Int in_position)
         {
             return TrySetParquet(in_furnishingID, in_position, _furnishingLayer);
         }
@@ -90,7 +90,7 @@ namespace ParquetClassLibrary.Sandbox
         /// <param name="in_collectableID">ID for the new collectable to set.</param>
         /// <param name="in_position">The position to set.</param>
         /// <returns><c>true</c>, if the collectable was set, <c>false</c> otherwise.</returns>
-        public bool TrySetCollectable(ParquetID in_collectableID, Vector2Int in_position)
+        public bool TrySetCollectable(EnitityID in_collectableID, Vector2Int in_position)
         {
             return TrySetParquet(in_collectableID, in_position, _collectableLayer);
         }
@@ -100,10 +100,10 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_position">The position to clear.</param>
         /// <returns><c>true</c>, if the parquet was removed, <c>false</c> otherwise.</returns>
-        private bool TrySetParquet(ParquetID in_parquetID, Vector2Int in_position, ParquetID[,] in_parquetLayer)
+        private bool TrySetParquet(EnitityID in_parquetID, Vector2Int in_position, EnitityID[,] in_parquetLayer)
         {
             var result = false;
-            if (IsValidPosition(in_position) && ParquetID.None != in_parquetID)
+            if (IsValidPosition(in_position) && EnitityID.None != in_parquetID)
             {
                 in_parquetLayer[in_position.x, in_position.y] = in_parquetID;
                 result = true;
@@ -169,12 +169,12 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_position">The position to clear.</param>
         /// <returns><c>true</c>, if the parquet was removed, <c>false</c> otherwise.</returns>
-        private bool TryRemoveParquet(Vector2Int in_position, ParquetID[,] in_parquetLayer)
+        private bool TryRemoveParquet(Vector2Int in_position, EnitityID[,] in_parquetLayer)
         {
             var result = false;
             if (IsValidPosition(in_position))
             {
-                in_parquetLayer[in_position.x, in_position.y] = ParquetID.None;
+                in_parquetLayer[in_position.x, in_position.y] = EnitityID.None;
                 result = true;
             }
             return result;
@@ -356,14 +356,14 @@ namespace ParquetClassLibrary.Sandbox
             {
                 for (var y = 0; y < DimensionsInParquets.y; y++)
                 {
-                    ParquetID parquetID = _floorLayer[x, y];
-                    if (ParquetID.None != parquetID) { result.Add(AllParquets.Get<Floor>(parquetID)); }
+                    EnitityID parquetID = _floorLayer[x, y];
+                    if (EnitityID.None != parquetID) { result.Add(AllParquets.Get<Floor>(parquetID)); }
                     parquetID = _blockLayer[x, y];
-                    if (ParquetID.None != parquetID) { result.Add(AllParquets.Get<Block>(parquetID)); }
+                    if (EnitityID.None != parquetID) { result.Add(AllParquets.Get<Block>(parquetID)); }
                     parquetID = _furnishingLayer[x, y];
-                    if (ParquetID.None != parquetID) { result.Add(AllParquets.Get<Furnishing>(parquetID)); }
+                    if (EnitityID.None != parquetID) { result.Add(AllParquets.Get<Furnishing>(parquetID)); }
                     parquetID = _collectableLayer[x, y];
-                    if (ParquetID.None != parquetID) { result.Add(AllParquets.Get<Collectable>(parquetID)); }
+                    if (EnitityID.None != parquetID) { result.Add(AllParquets.Get<Collectable>(parquetID)); }
                 }
             }
 
@@ -422,13 +422,13 @@ namespace ParquetClassLibrary.Sandbox
                 for (var y = 0; y < DimensionsInParquets.y; y++)
                 {
                     // TODO: This fails with TestParquet values.  Do we want to support ToStringing test values??
-                    var parquet = ParquetID.None != _collectableLayer[x, y]
+                    var parquet = EnitityID.None != _collectableLayer[x, y]
                         ? AllParquets.Get<ParquetParent>(_collectableLayer[x, y]) 
-                        : ParquetID.None != _furnishingLayer[x, y]
+                        : EnitityID.None != _furnishingLayer[x, y]
                             ? AllParquets.Get<ParquetParent>(_furnishingLayer[x, y])
-                            : ParquetID.None != _blockLayer[x, y]
+                            : EnitityID.None != _blockLayer[x, y]
                                 ? AllParquets.Get<ParquetParent>(_blockLayer[x, y])
-                                : ParquetID.None != _floorLayer[x, y]
+                                : EnitityID.None != _floorLayer[x, y]
                                     ? AllParquets.Get<ParquetParent>(_floorLayer[x, y])
                                     : null;
 

--- a/ParquetClassLibrary/Sandbox/MapRegion.cs
+++ b/ParquetClassLibrary/Sandbox/MapRegion.cs
@@ -45,19 +45,19 @@ namespace ParquetClassLibrary.Sandbox
 
         #region Map Contents
         /// <summary>Floors and walkable terrain in the region.</summary>
-        protected override EnitityID[,] _floorLayer { get; } = new EnitityID[Assembly.ParquetsPerRegionDimension,
+        protected override EntityID[,] _floorLayer { get; } = new EntityID[Assembly.ParquetsPerRegionDimension,
                                                                              Assembly.ParquetsPerRegionDimension];
 
         /// <summary>Walls and obstructing terrain in the region.</summary>
-        protected override EnitityID[,] _blockLayer { get; } = new EnitityID[Assembly.ParquetsPerRegionDimension,
+        protected override EntityID[,] _blockLayer { get; } = new EntityID[Assembly.ParquetsPerRegionDimension,
                                                                              Assembly.ParquetsPerRegionDimension];
 
         /// <summary>Furniture and natural items in the region.</summary>
-        protected override EnitityID[,] _furnishingLayer { get; } = new EnitityID[Assembly.ParquetsPerRegionDimension,
+        protected override EntityID[,] _furnishingLayer { get; } = new EntityID[Assembly.ParquetsPerRegionDimension,
                                                                                   Assembly.ParquetsPerRegionDimension];
 
         /// <summary>Collectable materials in the region.</summary>
-        protected override EnitityID[,] _collectableLayer { get; } = new EnitityID[Assembly.ParquetsPerRegionDimension,
+        protected override EntityID[,] _collectableLayer { get; } = new EntityID[Assembly.ParquetsPerRegionDimension,
                                                                                    Assembly.ParquetsPerRegionDimension];
         #endregion
 
@@ -162,16 +162,16 @@ namespace ParquetClassLibrary.Sandbox
             {
                 for (var y = 0; y < DimensionsInParquets.y; y++)
                 {
-                    floorRepresentation.Append(EnitityID.None != _floorLayer[x, y]
+                    floorRepresentation.Append(EntityID.None != _floorLayer[x, y]
                         ? _floorLayer[x, y].ToString()
                         : "~");
-                    blocksRepresentation.Append(EnitityID.None != _blockLayer[x, y]
+                    blocksRepresentation.Append(EntityID.None != _blockLayer[x, y]
                         ? _blockLayer[x, y].ToString()
                         : " ");
-                    furnishingsRepresentation.Append(EnitityID.None != _furnishingLayer[x, y]
+                    furnishingsRepresentation.Append(EntityID.None != _furnishingLayer[x, y]
                         ? _furnishingLayer[x, y].ToString()
                         : " ");
-                    collectablesRepresentation.Append(EnitityID.None != _collectableLayer[x, y]
+                    collectablesRepresentation.Append(EntityID.None != _collectableLayer[x, y]
                         ? _collectableLayer[x, y].ToString()
                         : " ");
                 }

--- a/ParquetClassLibrary/Sandbox/MapRegion.cs
+++ b/ParquetClassLibrary/Sandbox/MapRegion.cs
@@ -45,19 +45,19 @@ namespace ParquetClassLibrary.Sandbox
 
         #region Map Contents
         /// <summary>Floors and walkable terrain in the region.</summary>
-        protected override ParquetID[,] _floorLayer { get; } = new ParquetID[Assembly.ParquetsPerRegionDimension,
+        protected override EnitityID[,] _floorLayer { get; } = new EnitityID[Assembly.ParquetsPerRegionDimension,
                                                                              Assembly.ParquetsPerRegionDimension];
 
         /// <summary>Walls and obstructing terrain in the region.</summary>
-        protected override ParquetID[,] _blockLayer { get; } = new ParquetID[Assembly.ParquetsPerRegionDimension,
+        protected override EnitityID[,] _blockLayer { get; } = new EnitityID[Assembly.ParquetsPerRegionDimension,
                                                                              Assembly.ParquetsPerRegionDimension];
 
         /// <summary>Furniture and natural items in the region.</summary>
-        protected override ParquetID[,] _furnishingLayer { get; } = new ParquetID[Assembly.ParquetsPerRegionDimension,
+        protected override EnitityID[,] _furnishingLayer { get; } = new EnitityID[Assembly.ParquetsPerRegionDimension,
                                                                                   Assembly.ParquetsPerRegionDimension];
 
         /// <summary>Collectable materials in the region.</summary>
-        protected override ParquetID[,] _collectableLayer { get; } = new ParquetID[Assembly.ParquetsPerRegionDimension,
+        protected override EnitityID[,] _collectableLayer { get; } = new EnitityID[Assembly.ParquetsPerRegionDimension,
                                                                                    Assembly.ParquetsPerRegionDimension];
         #endregion
 
@@ -162,16 +162,16 @@ namespace ParquetClassLibrary.Sandbox
             {
                 for (var y = 0; y < DimensionsInParquets.y; y++)
                 {
-                    floorRepresentation.Append(ParquetID.None != _floorLayer[x, y]
+                    floorRepresentation.Append(EnitityID.None != _floorLayer[x, y]
                         ? _floorLayer[x, y].ToString()
                         : "~");
-                    blocksRepresentation.Append(ParquetID.None != _blockLayer[x, y]
+                    blocksRepresentation.Append(EnitityID.None != _blockLayer[x, y]
                         ? _blockLayer[x, y].ToString()
                         : " ");
-                    furnishingsRepresentation.Append(ParquetID.None != _furnishingLayer[x, y]
+                    furnishingsRepresentation.Append(EnitityID.None != _furnishingLayer[x, y]
                         ? _furnishingLayer[x, y].ToString()
                         : " ");
-                    collectablesRepresentation.Append(ParquetID.None != _collectableLayer[x, y]
+                    collectablesRepresentation.Append(EnitityID.None != _collectableLayer[x, y]
                         ? _collectableLayer[x, y].ToString()
                         : " ");
                 }

--- a/ParquetClassLibrary/Sandbox/MapRegionEditor.cs
+++ b/ParquetClassLibrary/Sandbox/MapRegionEditor.cs
@@ -41,16 +41,16 @@ namespace ParquetClassLibrary.Sandbox
         }
 
         /// <summary>Identifier for the selected floor.</summary>
-        private EnitityID _floorToPaint;
+        private EntityID _floorToPaint;
 
         /// <summary>Identifier for the selected block.</summary>
-        private EnitityID _blockToPaint;
+        private EntityID _blockToPaint;
 
         /// <summary>Identifier for the selected furnishing.</summary>
-        private EnitityID _furnishingToPaint;
+        private EntityID _furnishingToPaint;
 
         /// <summary>Identifier for the selected collectable.</summary>
-        private EnitityID _collectableToPaint;
+        private EntityID _collectableToPaint;
 
         #region New, Save, Load Methods
         /// <summary>
@@ -148,7 +148,7 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_floorID">The parquet ID to select.  Must represent a valid Floor.</param>
         // TODO Improve handling of IDs (especially in Unity version).
-        public void SetFloorToPaint(EnitityID in_floorID)
+        public void SetFloorToPaint(EntityID in_floorID)
         {
             //Adds bounds-checking using the Ranges defined in Assembly.
             if (in_floorID.IsValidForRange(Assembly.FloorIDs))
@@ -166,7 +166,7 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_blockID">The parquet ID to select.  Must represent a valid Block.</param>
         // TODO Improve handling of IDs (especially in Unity version).
-        public void SetBlockToPaint(EnitityID in_blockID)
+        public void SetBlockToPaint(EntityID in_blockID)
         {
             if (in_blockID.IsValidForRange(Assembly.BlockIDs))
             {
@@ -183,7 +183,7 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_furnishingID">The parquet ID to select.  Must represent a valid Furnishing.</param>
         // TODO Improve handling of IDs (especially in Unity version).
-        public void SetFurnishingToPaint(EnitityID in_furnishingID)
+        public void SetFurnishingToPaint(EntityID in_furnishingID)
         {
             if (in_furnishingID.IsValidForRange(Assembly.FurnishingIDs))
             {
@@ -200,7 +200,7 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_collectableID">The parquet ID to select.  Must represent a valid Collectable.</param>
         // TODO Improve handling of IDs (especially in Unity version).
-        public void SetCollectableToPaint(EnitityID in_collectableID)
+        public void SetCollectableToPaint(EntityID in_collectableID)
         {
             if (in_collectableID.IsValidForRange(Assembly.CollectableIDs))
             {

--- a/ParquetClassLibrary/Sandbox/MapRegionEditor.cs
+++ b/ParquetClassLibrary/Sandbox/MapRegionEditor.cs
@@ -151,7 +151,7 @@ namespace ParquetClassLibrary.Sandbox
         public void SetFloorToPaint(EnitityID in_floorID)
         {
             //Adds bounds-checking using the Ranges defined in Assembly.
-            if (Assembly.FloorIDs.ContainsValue(in_floorID))
+            if (in_floorID.IsValidForRange(Assembly.FloorIDs))
             {
                 _floorToPaint = in_floorID;
             }
@@ -168,7 +168,7 @@ namespace ParquetClassLibrary.Sandbox
         // TODO Improve handling of IDs (especially in Unity version).
         public void SetBlockToPaint(EnitityID in_blockID)
         {
-            if (Assembly.BlockIDs.ContainsValue(in_blockID))
+            if (in_blockID.IsValidForRange(Assembly.BlockIDs))
             {
                 _blockToPaint = in_blockID;
             }
@@ -185,7 +185,7 @@ namespace ParquetClassLibrary.Sandbox
         // TODO Improve handling of IDs (especially in Unity version).
         public void SetFurnishingToPaint(EnitityID in_furnishingID)
         {
-            if (Assembly.FurnishingIDs.ContainsValue(in_furnishingID))
+            if (in_furnishingID.IsValidForRange(Assembly.FurnishingIDs))
             {
                 _furnishingToPaint = in_furnishingID;
             }
@@ -202,7 +202,7 @@ namespace ParquetClassLibrary.Sandbox
         // TODO Improve handling of IDs (especially in Unity version).
         public void SetCollectableToPaint(EnitityID in_collectableID)
         {
-            if (Assembly.CollectableIDs.ContainsValue(in_collectableID))
+            if (in_collectableID.IsValidForRange(Assembly.CollectableIDs))
             {
                 _collectableToPaint = in_collectableID;
             }

--- a/ParquetClassLibrary/Sandbox/MapRegionEditor.cs
+++ b/ParquetClassLibrary/Sandbox/MapRegionEditor.cs
@@ -41,16 +41,16 @@ namespace ParquetClassLibrary.Sandbox
         }
 
         /// <summary>Identifier for the selected floor.</summary>
-        private ParquetID _floorToPaint;
+        private EnitityID _floorToPaint;
 
         /// <summary>Identifier for the selected block.</summary>
-        private ParquetID _blockToPaint;
+        private EnitityID _blockToPaint;
 
         /// <summary>Identifier for the selected furnishing.</summary>
-        private ParquetID _furnishingToPaint;
+        private EnitityID _furnishingToPaint;
 
         /// <summary>Identifier for the selected collectable.</summary>
-        private ParquetID _collectableToPaint;
+        private EnitityID _collectableToPaint;
 
         #region New, Save, Load Methods
         /// <summary>
@@ -148,7 +148,7 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_floorID">The parquet ID to select.  Must represent a valid Floor.</param>
         // TODO Improve handling of IDs (especially in Unity version).
-        public void SetFloorToPaint(ParquetID in_floorID)
+        public void SetFloorToPaint(EnitityID in_floorID)
         {
             //Adds bounds-checking using the Ranges defined in Assembly.
             if (Assembly.FloorIDs.ContainsValue(in_floorID))
@@ -166,7 +166,7 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_blockID">The parquet ID to select.  Must represent a valid Block.</param>
         // TODO Improve handling of IDs (especially in Unity version).
-        public void SetBlockToPaint(ParquetID in_blockID)
+        public void SetBlockToPaint(EnitityID in_blockID)
         {
             if (Assembly.BlockIDs.ContainsValue(in_blockID))
             {
@@ -183,7 +183,7 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_furnishingID">The parquet ID to select.  Must represent a valid Furnishing.</param>
         // TODO Improve handling of IDs (especially in Unity version).
-        public void SetFurnishingToPaint(ParquetID in_furnishingID)
+        public void SetFurnishingToPaint(EnitityID in_furnishingID)
         {
             if (Assembly.FurnishingIDs.ContainsValue(in_furnishingID))
             {
@@ -200,7 +200,7 @@ namespace ParquetClassLibrary.Sandbox
         /// </summary>
         /// <param name="in_collectableID">The parquet ID to select.  Must represent a valid Collectable.</param>
         // TODO Improve handling of IDs (especially in Unity version).
-        public void SetCollectableToPaint(ParquetID in_collectableID)
+        public void SetCollectableToPaint(EnitityID in_collectableID)
         {
             if (Assembly.CollectableIDs.ContainsValue(in_collectableID))
             {

--- a/ParquetClassLibrary/Sandbox/Parquets/AllParquets.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/AllParquets.cs
@@ -13,9 +13,9 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     public static class AllParquets
     {
         /// <summary>A collection of all defined parquets of all subtypes.  All IDs must be unique.</summary>
-        private static Dictionary<EnitityID, ParquetParent> ParquetDefinitions { get; set; } = new Dictionary<EnitityID, ParquetParent>
+        private static Dictionary<EntityID, ParquetParent> ParquetDefinitions { get; set; } = new Dictionary<EntityID, ParquetParent>
         {
-            { EnitityID.None, null }
+            { EntityID.None, null }
         };
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <exception cref="System.InvalidCastException">
         /// Thrown when the specified type does not correspond to the given ID.
         /// </exception>
-        public static T Get<T>(EnitityID in_ID) where T : ParquetParent
+        public static T Get<T>(EntityID in_ID) where T : ParquetParent
         {
             return (T)ParquetDefinitions[in_ID];
         }
@@ -101,7 +101,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
             {
                 try
                 {
-                    ParquetDefinitions = JsonConvert.DeserializeObject<Dictionary<EnitityID, ParquetParent>>(in_serializedParquets);
+                    ParquetDefinitions = JsonConvert.DeserializeObject<Dictionary<EntityID, ParquetParent>>(in_serializedParquets);
                     result = true;
                 }
                 catch (JsonReaderException exception)

--- a/ParquetClassLibrary/Sandbox/Parquets/AllParquets.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/AllParquets.cs
@@ -13,9 +13,9 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     public static class AllParquets
     {
         /// <summary>A collection of all defined parquets of all subtypes.  All IDs must be unique.</summary>
-        private static Dictionary<ParquetID, ParquetParent> ParquetDefinitions { get; set; } = new Dictionary<ParquetID, ParquetParent>
+        private static Dictionary<EnitityID, ParquetParent> ParquetDefinitions { get; set; } = new Dictionary<EnitityID, ParquetParent>
         {
-            { ParquetID.None, null }
+            { EnitityID.None, null }
         };
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <exception cref="System.InvalidCastException">
         /// Thrown when the specified type does not correspond to the given ID.
         /// </exception>
-        public static T Get<T>(ParquetID in_ID) where T : ParquetParent
+        public static T Get<T>(EnitityID in_ID) where T : ParquetParent
         {
             return (T)ParquetDefinitions[in_ID];
         }
@@ -101,7 +101,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
             {
                 try
                 {
-                    ParquetDefinitions = JsonConvert.DeserializeObject<Dictionary<ParquetID, ParquetParent>>(in_serializedParquets);
+                    ParquetDefinitions = JsonConvert.DeserializeObject<Dictionary<EnitityID, ParquetParent>>(in_serializedParquets);
                     result = true;
                 }
                 catch (JsonReaderException exception)

--- a/ParquetClassLibrary/Sandbox/Parquets/Block.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Block.cs
@@ -16,7 +16,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <summary>Maximum toughness value to use when none is specified.</summary>
         private const int DefaultMaxToughness = 10;
 
-        /// <summary>The set of values that are allowed for Block's allowed ParquetIDs.</summary>
+        /// <summary>The set of values that are allowed for Block's allowed parquet IDs.</summary>
         [JsonIgnore]
         protected override Range<EnitityID> Bounds { get { return Assembly.BlockIDs; } }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Block.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Block.cs
@@ -18,10 +18,10 @@ namespace ParquetClassLibrary.Sandbox.Parquets
 
         /// <summary>The set of values that are allowed for Block's allowed ParquetIDs.</summary>
         [JsonIgnore]
-        protected override Range<ParquetID> Bounds { get { return Assembly.BlockIDs; } }
+        protected override Range<EnitityID> Bounds { get { return Assembly.BlockIDs; } }
         #endregion
 
-        #region Block Physics
+        #region Parquet Mechanics
         /// <summary>The tool used to remove the block.</summary>
         [JsonProperty(PropertyName = "in_gatherTool")]
         public GatheringTools GatherTool { get; private set; }
@@ -65,7 +65,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <param name="in_isLiquid">If <c>true</c> this block will flow.</param>
         /// <param name="in_maxToughness">Representation of the difficulty involved in gathering this block.</param>
         [JsonConstructor]
-        public Block(ParquetID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None, GatheringTools in_gatherTool = GatheringTools.None,
+        public Block(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None, GatheringTools in_gatherTool = GatheringTools.None,
                      bool in_isFlammable = false, bool in_isLiquid = false, int in_maxToughness = DefaultMaxToughness)
                      : base(in_ID, in_name, in_addsToBiome)
         {

--- a/ParquetClassLibrary/Sandbox/Parquets/Block.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Block.cs
@@ -18,7 +18,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
 
         /// <summary>The set of values that are allowed for Block IDs.</summary>
         [JsonIgnore]
-        protected override Range<EnitityID> Bounds { get { return Assembly.BlockIDs; } }
+        protected override Range<EntityID> Bounds { get { return Assembly.BlockIDs; } }
         #endregion
 
         #region Parquet Mechanics
@@ -65,7 +65,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <param name="in_isLiquid">If <c>true</c> this block will flow.</param>
         /// <param name="in_maxToughness">Representation of the difficulty involved in gathering this block.</param>
         [JsonConstructor]
-        public Block(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None, GatheringTools in_gatherTool = GatheringTools.None,
+        public Block(EntityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None, GatheringTools in_gatherTool = GatheringTools.None,
                      bool in_isFlammable = false, bool in_isLiquid = false, int in_maxToughness = DefaultMaxToughness)
                      : base(in_ID, in_name, in_addsToBiome)
         {

--- a/ParquetClassLibrary/Sandbox/Parquets/Block.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Block.cs
@@ -16,7 +16,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <summary>Maximum toughness value to use when none is specified.</summary>
         private const int DefaultMaxToughness = 10;
 
-        /// <summary>The set of values that are allowed for Block's allowed parquet IDs.</summary>
+        /// <summary>The set of values that are allowed for Block IDs.</summary>
         [JsonIgnore]
         protected override Range<EnitityID> Bounds { get { return Assembly.BlockIDs; } }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Collectable.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Collectable.cs
@@ -13,7 +13,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         #region Class Defaults
         /// <summary>The set of values that are allowed for Collectable IDs.</summary>
         [JsonIgnore]
-        protected override Range<EnitityID> Bounds { get { return Assembly.CollectableIDs; } }
+        protected override Range<EntityID> Bounds { get { return Assembly.CollectableIDs; } }
         #endregion
 
         #region Parquet Mechanics
@@ -30,7 +30,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
 
         /// <summary>The item spawned when a character encounters this Collectable.</summary>
         [JsonProperty(PropertyName = "in_itemID")]
-        public EnitityID ItemID { get; private set; }
+        public EntityID ItemID { get; private set; }
         #endregion
 
         #region Initialization
@@ -48,12 +48,12 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// </param>
         /// <param name="in_itemID">The item that this collectable corresponds to, if any.</param>
         [JsonConstructor]
-        public Collectable(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None,
+        public Collectable(EntityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None,
                            CollectionEffect in_effect = CollectionEffect.None, int in_effectAmount = 0,
-                           EnitityID? in_itemID = null)
+                           EntityID? in_itemID = null)
             : base(in_ID, in_name, in_addsToBiome)
         {
-            var nonNullItemID = in_itemID ?? EnitityID.None;
+            var nonNullItemID = in_itemID ?? EntityID.None;
             if (!nonNullItemID.IsValidForRange(Assembly.ItemIDs))
             {
                 throw new ArgumentOutOfRangeException(nameof(in_itemID));

--- a/ParquetClassLibrary/Sandbox/Parquets/Collectable.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Collectable.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using ParquetClassLibrary.Sandbox.ID;
 using ParquetClassLibrary.Utilities;
 
@@ -10,9 +11,26 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     public class Collectable : ParquetParent
     {
         #region Class Defaults
-        /// <summary>The set of values that are allowed for Floor's allowed ParquetIDs.</summary>
+        /// <summary>The set of values that are allowed for Floor's allowed parquet IDs.</summary>
         [JsonIgnore]
         protected override Range<EnitityID> Bounds { get { return Assembly.CollectableIDs; } }
+        #endregion
+
+        #region Parquet Mechanics
+        /// <summary>The effect generated when a character encounters this Collectable.</summary>
+        [JsonProperty(PropertyName = "in_effect")]
+        public CollectionEffect Effect { get; private set; }
+
+        /// <summary>
+        /// The scale in points of the effect.  That is, how much to alter a stat if the
+        /// <see cref="T:ParquetClassLibrary.Sandbox.ID.CollectionEffect"/> is set to alter a stat.
+        /// </summary>
+        [JsonProperty(PropertyName = "in_effectAmount")]
+        public int EffectAmount { get; private set; }
+
+        /// <summary>The item spawned when a character encounters this Collectable.</summary>
+        [JsonProperty(PropertyName = "in_itemID")]
+        public EnitityID ItemID { get; private set; }
         #endregion
 
         #region Initialization
@@ -24,10 +42,27 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <param name="in_addsToBiome">
         /// A set of flags indicating which, if any, <see cref="T:ParquetClassLibrary.Sandbox.Biome"/> this parquet helps to generate.
         /// </param>
+        /// <param name="in_effect">Effect of this collectable.</param>
+        /// <param name="in_effectAmount">
+        /// The scale in points of the effect.  That is, how much to alter a stat if in_effect is set to alter a stat.
+        /// </param>
+        /// <param name="in_itemID">The item that this collectable corresponds to, if any.</param>
         [JsonConstructor]
-        public Collectable(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
+        public Collectable(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None,
+                           CollectionEffect in_effect = CollectionEffect.None, int in_effectAmount = 0,
+                           EnitityID? in_itemID = null)
             : base(in_ID, in_name, in_addsToBiome)
-        { }
+        {
+            var nonNullItemID = in_itemID ?? EnitityID.None;
+            if (!nonNullItemID.IsValidForRange(Assembly.ItemIDs))
+            {
+                throw new ArgumentOutOfRangeException(nameof(in_itemID));
+            }
+
+            Effect = in_effect;
+            EffectAmount = in_effectAmount;
+            ItemID = nonNullItemID;
+        }
         #endregion
     }
 }

--- a/ParquetClassLibrary/Sandbox/Parquets/Collectable.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Collectable.cs
@@ -11,7 +11,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     public class Collectable : ParquetParent
     {
         #region Class Defaults
-        /// <summary>The set of values that are allowed for Floor's allowed parquet IDs.</summary>
+        /// <summary>The set of values that are allowed for Collectable IDs.</summary>
         [JsonIgnore]
         protected override Range<EnitityID> Bounds { get { return Assembly.CollectableIDs; } }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Collectable.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Collectable.cs
@@ -12,7 +12,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         #region Class Defaults
         /// <summary>The set of values that are allowed for Floor's allowed ParquetIDs.</summary>
         [JsonIgnore]
-        protected override Range<ParquetID> Bounds { get { return Assembly.CollectableIDs; } }
+        protected override Range<EnitityID> Bounds { get { return Assembly.CollectableIDs; } }
         #endregion
 
         #region Initialization
@@ -25,7 +25,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// A set of flags indicating which, if any, <see cref="T:ParquetClassLibrary.Sandbox.Biome"/> this parquet helps to generate.
         /// </param>
         [JsonConstructor]
-        public Collectable(ParquetID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
+        public Collectable(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
             : base(in_ID, in_name, in_addsToBiome)
         { }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
@@ -15,10 +15,10 @@ namespace ParquetClassLibrary.Sandbox.Parquets
 
         /// <summary>The set of values that are allowed for Floor's allowed ParquetIDs.</summary>
         [JsonIgnore]
-        protected override Range<ParquetID> Bounds { get { return Assembly.FloorIDs; } }
+        protected override Range<EnitityID> Bounds { get { return Assembly.FloorIDs; } }
         #endregion
 
-        #region Parquet Physics
+        #region Parquet Mechanics
         /// <summary>The tool used to dig out or fill in the floor.</summary>
         [JsonProperty(PropertyName = "in_modTool")]
         public ModificationTools ModTool { get; private set; }
@@ -49,7 +49,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <param name="in_nameWhenHole">The name to use for this tile when it has been dug out.</param>
         /// <param name="in_isWalkable">If <c>true</c> this block may burn.</param>
         [JsonConstructor]
-        public Floor(ParquetID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None,
+        public Floor(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None,
                      ModificationTools in_modTool = ModificationTools.None,
                      string in_nameWhenHole = DefaultNameWhenHole, bool in_isWalkable = true)
                      : base(in_ID, in_name, in_addsToBiome)

--- a/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
@@ -15,7 +15,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
 
         /// <summary>The set of values that are allowed for Floor IDs.</summary>
         [JsonIgnore]
-        protected override Range<EnitityID> Bounds { get { return Assembly.FloorIDs; } }
+        protected override Range<EntityID> Bounds { get { return Assembly.FloorIDs; } }
         #endregion
 
         #region Parquet Mechanics
@@ -49,7 +49,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <param name="in_nameWhenHole">The name to use for this tile when it has been dug out.</param>
         /// <param name="in_isWalkable">If <c>true</c> this block may burn.</param>
         [JsonConstructor]
-        public Floor(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None,
+        public Floor(EntityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None,
                      ModificationTools in_modTool = ModificationTools.None,
                      string in_nameWhenHole = DefaultNameWhenHole, bool in_isWalkable = true)
                      : base(in_ID, in_name, in_addsToBiome)

--- a/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
@@ -13,7 +13,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <summary>A name to employ for parquets when IsHole is set, if none is provided.</summary>
         private const string DefaultNameWhenHole = "dark hole";
 
-        /// <summary>The set of values that are allowed for Floor's allowed parquet IDs.</summary>
+        /// <summary>The set of values that are allowed for Floor IDs.</summary>
         [JsonIgnore]
         protected override Range<EnitityID> Bounds { get { return Assembly.FloorIDs; } }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
@@ -13,7 +13,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// <summary>A name to employ for parquets when IsHole is set, if none is provided.</summary>
         private const string DefaultNameWhenHole = "dark hole";
 
-        /// <summary>The set of values that are allowed for Floor's allowed ParquetIDs.</summary>
+        /// <summary>The set of values that are allowed for Floor's allowed parquet IDs.</summary>
         [JsonIgnore]
         protected override Range<EnitityID> Bounds { get { return Assembly.FloorIDs; } }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
@@ -10,7 +10,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     public class Furnishing : ParquetParent
     {
         #region Class Defaults
-        /// <summary>The set of values that are allowed for Block's allowed ParquetIDs.</summary>
+        /// <summary>The set of values that are allowed for Block's allowed parquet IDs.</summary>
         [JsonIgnore]
         protected override Range<EnitityID> Bounds { get { return Assembly.FurnishingIDs; } }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
@@ -12,7 +12,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         #region Class Defaults
         /// <summary>The set of values that are allowed for Furnishing IDs.</summary>
         [JsonIgnore]
-        protected override Range<EnitityID> Bounds { get { return Assembly.FurnishingIDs; } }
+        protected override Range<EntityID> Bounds { get { return Assembly.FurnishingIDs; } }
         #endregion
 
         #region Initialization
@@ -25,7 +25,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// A set of flags indicating which, if any, <see cref="T:ParquetClassLibrary.Sandbox.Biome"/> this parquet helps to generate.
         /// </param>
         [JsonConstructor]
-        public Furnishing(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
+        public Furnishing(EntityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
             : base(in_ID, in_name, in_addsToBiome)
         { }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
@@ -10,7 +10,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     public class Furnishing : ParquetParent
     {
         #region Class Defaults
-        /// <summary>The set of values that are allowed for Block's allowed parquet IDs.</summary>
+        /// <summary>The set of values that are allowed for Furnishing IDs.</summary>
         [JsonIgnore]
         protected override Range<EnitityID> Bounds { get { return Assembly.FurnishingIDs; } }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
@@ -12,7 +12,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         #region Class Defaults
         /// <summary>The set of values that are allowed for Block's allowed ParquetIDs.</summary>
         [JsonIgnore]
-        protected override Range<ParquetID> Bounds { get { return Assembly.FurnishingIDs; } }
+        protected override Range<EnitityID> Bounds { get { return Assembly.FurnishingIDs; } }
         #endregion
 
         #region Initialization
@@ -25,7 +25,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// A set of flags indicating which, if any, <see cref="T:ParquetClassLibrary.Sandbox.Biome"/> this parquet helps to generate.
         /// </param>
         [JsonConstructor]
-        public Furnishing(ParquetID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
+        public Furnishing(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
             : base(in_ID, in_name, in_addsToBiome)
         { }
         #endregion

--- a/ParquetClassLibrary/Sandbox/Parquets/ParquetParent.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/ParquetParent.cs
@@ -10,7 +10,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     /// </summary>
     public abstract class ParquetParent : IEquatable<ParquetParent>
     {
-        /// <summary>The set of values that are allowed for specific ParquetIDs.  Defined by child classes.</summary>
+        /// <summary>The set of values that are allowed for specific parquet IDs.  Defined by child classes.</summary>
         [JsonIgnore]
         protected abstract Range<EnitityID> Bounds { get; }
 

--- a/ParquetClassLibrary/Sandbox/Parquets/ParquetParent.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/ParquetParent.cs
@@ -12,11 +12,11 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     {
         /// <summary>The set of values that are allowed for specific parquet IDs.  Defined by child classes.</summary>
         [JsonIgnore]
-        protected abstract Range<EnitityID> Bounds { get; }
+        protected abstract Range<EntityID> Bounds { get; }
 
         /// <summary>Unique identifier of the parquet.</summary>
         [JsonProperty(PropertyName = "in_ID")]
-        public EnitityID ID { get; private set; }
+        public EntityID ID { get; private set; }
 
         /// <summary>Player-facing name of the parquet.</summary>
         [JsonProperty(PropertyName = "in_name")]
@@ -40,7 +40,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// this parquet helps to generate.
         /// </param>
         [JsonConstructor]
-        protected ParquetParent(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
+        protected ParquetParent(EntityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
         {
             if (!in_ID.IsValidForRange(Bounds))
             {

--- a/ParquetClassLibrary/Sandbox/Parquets/ParquetParent.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/ParquetParent.cs
@@ -12,11 +12,11 @@ namespace ParquetClassLibrary.Sandbox.Parquets
     {
         /// <summary>The set of values that are allowed for specific ParquetIDs.  Defined by child classes.</summary>
         [JsonIgnore]
-        protected abstract Range<ParquetID> Bounds { get; }
+        protected abstract Range<EnitityID> Bounds { get; }
 
         /// <summary>Unique identifier of the parquet.</summary>
         [JsonProperty(PropertyName = "in_ID")]
-        public ParquetID ID { get; private set; }
+        public EnitityID ID { get; private set; }
 
         /// <summary>Player-facing name of the parquet.</summary>
         [JsonProperty(PropertyName = "in_name")]
@@ -40,7 +40,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         /// this parquet helps to generate.
         /// </param>
         [JsonConstructor]
-        protected ParquetParent(ParquetID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
+        protected ParquetParent(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
         {
             // Ensures that the absolute value of the given parquet identifier lies withint a specified range.
             var absID = Math.Abs(in_ID);

--- a/ParquetClassLibrary/Sandbox/Parquets/ParquetParent.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/ParquetParent.cs
@@ -42,9 +42,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         [JsonConstructor]
         protected ParquetParent(EnitityID in_ID, string in_name, BiomeMask in_addsToBiome = BiomeMask.None)
         {
-            // Ensures that the absolute value of the given parquet identifier lies withint a specified range.
-            var absID = Math.Abs(in_ID);
-            if (!Bounds.ContainsValue(absID))
+            if (!in_ID.IsValidForRange(Bounds))
             {
                 throw new ArgumentOutOfRangeException(nameof(in_ID));
             }

--- a/ParquetUnitTests/AssemblyUnitTest.cs
+++ b/ParquetUnitTests/AssemblyUnitTest.cs
@@ -37,7 +37,7 @@ namespace ParquetUnitTests
         [Fact]
         public void NoneIsAValidFloorTest()
         {
-            var result = EnitityID.None.IsValidForRange(Assembly.FloorIDs);
+            var result = EntityID.None.IsValidForRange(Assembly.FloorIDs);
 
             Assert.True(result);
         }
@@ -45,7 +45,7 @@ namespace ParquetUnitTests
         [Fact]
         public void NoneIsAValidBlockTest()
         {
-            var result = EnitityID.None.IsValidForRange(Assembly.BlockIDs);
+            var result = EntityID.None.IsValidForRange(Assembly.BlockIDs);
 
             Assert.True(result);
         }
@@ -53,7 +53,7 @@ namespace ParquetUnitTests
         [Fact]
         public void NoneIsAValidFurnishingTest()
         {
-            var result = EnitityID.None.IsValidForRange(Assembly.FurnishingIDs);
+            var result = EntityID.None.IsValidForRange(Assembly.FurnishingIDs);
 
             Assert.True(result);
         }
@@ -61,7 +61,7 @@ namespace ParquetUnitTests
         [Fact]
         public void NoneIsAValidCollectableTest()
         {
-            var result = EnitityID.None.IsValidForRange(Assembly.CollectableIDs);
+            var result = EntityID.None.IsValidForRange(Assembly.CollectableIDs);
 
             Assert.True(result);
         }
@@ -69,7 +69,7 @@ namespace ParquetUnitTests
         [Fact]
         public void NoneIsAValidItemTest()
         {
-            var result = EnitityID.None.IsValidForRange(Assembly.ItemIDs);
+            var result = EntityID.None.IsValidForRange(Assembly.ItemIDs);
 
             Assert.True(result);
         }

--- a/ParquetUnitTests/AssemblyUnitTest.cs
+++ b/ParquetUnitTests/AssemblyUnitTest.cs
@@ -1,0 +1,127 @@
+﻿using Xunit;
+using System;
+using ParquetClassLibrary;
+using ParquetClassLibrary.Sandbox.ID;
+
+namespace ParquetUnitTests
+{
+    public class AssemblyUnitTest
+    {
+        #region Values for Tests
+        private const string InvalidDataVersion = "0.0.0";
+        private const int UpperBound = 10;
+        #endregion
+
+        [Fact]
+        public void SupportedDataVersionIsDefinedTest()
+        {
+            Assert.False(string.IsNullOrEmpty(Assembly.SupportedDataVersion));
+        }
+
+        [Fact]
+        public void SupportedDataVersionIsNotInvalidTest()
+        {
+            Assert.NotEqual(InvalidDataVersion, Assembly.SupportedDataVersion);
+        }
+
+        [Fact]
+        public void AllDimensionsAreGreaterThanZeroTest()
+        {
+            // TODO Does this type of sanity check make sense?
+            var result = Assembly.ParquetsPerChunkDimension > 0
+                         && Assembly.ChunksPerRegionDimension > 0
+                         && Assembly.ParquetsPerRegionDimension > 0;
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void NoneIsAValidFloorTest()
+        {
+            var result = EnitityID.None.IsValidForRange(Assembly.FloorIDs);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void NoneIsAValidBlockTest()
+        {
+            var result = EnitityID.None.IsValidForRange(Assembly.BlockIDs);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void NoneIsAValidFurnishingTest()
+        {
+            var result = EnitityID.None.IsValidForRange(Assembly.FurnishingIDs);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void NoneIsAValidCollectableTest()
+        {
+            var result = EnitityID.None.IsValidForRange(Assembly.CollectableIDs);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void NoneIsAValidItemTest()
+        {
+            var result = EnitityID.None.IsValidForRange(Assembly.ItemIDs);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void MinimumIsAValidFloorTest()
+        {
+            var range = Assembly.FloorIDs;
+            var floor = range.Minimum;
+            var result = floor.IsValidForRange(range);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void MinimumIsAValidBlockTest()
+        {
+            var range = Assembly.BlockIDs;
+            var block = range.Minimum;
+            var result = block.IsValidForRange(range);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void MinimumIsAValidFurnishingTest()
+        {
+            var range = Assembly.FurnishingIDs;
+            var furnishing = range.Minimum;
+            var result = furnishing.IsValidForRange(range);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void MinimumIsAValidCollectableTest()
+        {
+            var range = Assembly.CollectableIDs;
+            var collectable = range.Minimum;
+            var result = collectable.IsValidForRange(range);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void MinimumIsAValidItemTest()
+        {
+            var range = Assembly.ItemIDs;
+            var item = range.Minimum;
+            var result = item.IsValidForRange(range);
+
+            Assert.True(result);
+        }
+    }
+}

--- a/ParquetUnitTests/Sandbox/MapChunkUnitTest.cs
+++ b/ParquetUnitTests/Sandbox/MapChunkUnitTest.cs
@@ -30,7 +30,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var chunk = new MapChunk();
 
-            var result = chunk.TrySetFloor(EnitityID.None, Vector2Int.ZeroVector);
+            var result = chunk.TrySetFloor(EntityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -62,7 +62,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var chunk = new MapChunk();
 
-            var result = chunk.TrySetBlock(EnitityID.None, Vector2Int.ZeroVector);
+            var result = chunk.TrySetBlock(EntityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -94,7 +94,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var chunk = new MapChunk();
 
-            var result = chunk.TrySetFurnishing(EnitityID.None, Vector2Int.ZeroVector);
+            var result = chunk.TrySetFurnishing(EntityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -126,7 +126,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var chunk = new MapChunk();
 
-            var result = chunk.TrySetCollectable(EnitityID.None, Vector2Int.ZeroVector);
+            var result = chunk.TrySetCollectable(EntityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }

--- a/ParquetUnitTests/Sandbox/MapChunkUnitTest.cs
+++ b/ParquetUnitTests/Sandbox/MapChunkUnitTest.cs
@@ -30,7 +30,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var chunk = new MapChunk();
 
-            var result = chunk.TrySetFloor(ParquetID.None, Vector2Int.ZeroVector);
+            var result = chunk.TrySetFloor(EnitityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -62,7 +62,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var chunk = new MapChunk();
 
-            var result = chunk.TrySetBlock(ParquetID.None, Vector2Int.ZeroVector);
+            var result = chunk.TrySetBlock(EnitityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -94,7 +94,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var chunk = new MapChunk();
 
-            var result = chunk.TrySetFurnishing(ParquetID.None, Vector2Int.ZeroVector);
+            var result = chunk.TrySetFurnishing(EnitityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -126,7 +126,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var chunk = new MapChunk();
 
-            var result = chunk.TrySetCollectable(ParquetID.None, Vector2Int.ZeroVector);
+            var result = chunk.TrySetCollectable(EnitityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }

--- a/ParquetUnitTests/Sandbox/MapRegionUnitTest.cs
+++ b/ParquetUnitTests/Sandbox/MapRegionUnitTest.cs
@@ -57,7 +57,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var region = new MapRegion();
 
-            var result = region.TrySetFloor(ParquetID.None, Vector2Int.ZeroVector);
+            var result = region.TrySetFloor(EnitityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -89,7 +89,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var region = new MapRegion();
 
-            var result = region.TrySetBlock(ParquetID.None, Vector2Int.ZeroVector);
+            var result = region.TrySetBlock(EnitityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -121,7 +121,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var region = new MapRegion();
 
-            var result = region.TrySetFurnishing(ParquetID.None, Vector2Int.ZeroVector);
+            var result = region.TrySetFurnishing(EnitityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -153,7 +153,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var region = new MapRegion();
 
-            var result = region.TrySetCollectable(ParquetID.None, Vector2Int.ZeroVector);
+            var result = region.TrySetCollectable(EnitityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }

--- a/ParquetUnitTests/Sandbox/MapRegionUnitTest.cs
+++ b/ParquetUnitTests/Sandbox/MapRegionUnitTest.cs
@@ -57,7 +57,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var region = new MapRegion();
 
-            var result = region.TrySetFloor(EnitityID.None, Vector2Int.ZeroVector);
+            var result = region.TrySetFloor(EntityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -89,7 +89,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var region = new MapRegion();
 
-            var result = region.TrySetBlock(EnitityID.None, Vector2Int.ZeroVector);
+            var result = region.TrySetBlock(EntityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -121,7 +121,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var region = new MapRegion();
 
-            var result = region.TrySetFurnishing(EnitityID.None, Vector2Int.ZeroVector);
+            var result = region.TrySetFurnishing(EntityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }
@@ -153,7 +153,7 @@ namespace ParquetUnitTests.Sandbox
         {
             var region = new MapRegion();
 
-            var result = region.TrySetCollectable(EnitityID.None, Vector2Int.ZeroVector);
+            var result = region.TrySetCollectable(EntityID.None, Vector2Int.ZeroVector);
 
             Assert.False(result);
         }

--- a/ParquetUnitTests/Sandbox/Parquets/TestParquets.cs
+++ b/ParquetUnitTests/Sandbox/Parquets/TestParquets.cs
@@ -25,7 +25,7 @@ namespace ParquetUnitTests.Sandbox.Parquets
         #endregion
 
         /// <summary>A collection of all test parquets of all subtypes.</summary>
-        private static readonly Dictionary<ParquetID, ParquetParent> _parquetDefinitions = new Dictionary<ParquetID, ParquetParent>
+        private static readonly Dictionary<EnitityID, ParquetParent> _parquetDefinitions = new Dictionary<EnitityID, ParquetParent>
         {
             { TestFloor.ID, TestFloor },
             { TestBlock.ID, TestBlock },
@@ -42,7 +42,7 @@ namespace ParquetUnitTests.Sandbox.Parquets
         /// <exception cref="System.InvalidCastException">
         /// Thrown when the specified type does not correspond to the given ID.
         /// </exception>
-        public static T Get<T>(ParquetID in_ID) where T : ParquetParent
+        public static T Get<T>(EnitityID in_ID) where T : ParquetParent
         {
             return (T)_parquetDefinitions[in_ID];
         }

--- a/ParquetUnitTests/Sandbox/Parquets/TestParquets.cs
+++ b/ParquetUnitTests/Sandbox/Parquets/TestParquets.cs
@@ -25,7 +25,7 @@ namespace ParquetUnitTests.Sandbox.Parquets
         #endregion
 
         /// <summary>A collection of all test parquets of all subtypes.</summary>
-        private static readonly Dictionary<EnitityID, ParquetParent> _parquetDefinitions = new Dictionary<EnitityID, ParquetParent>
+        private static readonly Dictionary<EntityID, ParquetParent> _parquetDefinitions = new Dictionary<EntityID, ParquetParent>
         {
             { TestFloor.ID, TestFloor },
             { TestBlock.ID, TestBlock },
@@ -42,7 +42,7 @@ namespace ParquetUnitTests.Sandbox.Parquets
         /// <exception cref="System.InvalidCastException">
         /// Thrown when the specified type does not correspond to the given ID.
         /// </exception>
-        public static T Get<T>(EnitityID in_ID) where T : ParquetParent
+        public static T Get<T>(EntityID in_ID) where T : ParquetParent
         {
             return (T)_parquetDefinitions[in_ID];
         }


### PR DESCRIPTION
Adds support in Collectables to take one of several actions when the player encounters them.
• Add an Items to the players inventory
• Directly alter a player stat such as Health, Mana, or Money

Note that Items and Players are not yet modeled, so this only implements the details that are part of the collectable itself.