### PR TITLE
Separate Parquet statuses from Parquet definitions.

### DIFF
--- a/ParquetClassLibrary/Sandbox/MapChunk.cs
+++ b/ParquetClassLibrary/Sandbox/MapChunk.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using ParquetClassLibrary.Sandbox.Parquets;
 using ParquetClassLibrary.Sandbox.ID;
 using ParquetClassLibrary.Stubs;
 using ParquetClassLibrary.Utilities;
@@ -24,6 +25,10 @@ namespace ParquetClassLibrary.Sandbox
         #endregion
 
         #region Chunk Contents
+        /// <summary>The statuses of parquets in the chunk.</summary>
+        protected override ParquetStatus[,] _parquetStatus { get; } = new ParquetStatus[AssemblyInfo.ParquetsPerChunkDimension,
+                                                                                        AssemblyInfo.ParquetsPerChunkDimension];
+
         /// <summary>Floors and walkable terrain in the chunk.</summary>
         protected override EntityID[,] _floorLayer { get; } = new EntityID[AssemblyInfo.ParquetsPerChunkDimension,
                                                                            AssemblyInfo.ParquetsPerChunkDimension];

--- a/ParquetClassLibrary/Sandbox/MapParent.cs
+++ b/ParquetClassLibrary/Sandbox/MapParent.cs
@@ -40,6 +40,9 @@ namespace ParquetClassLibrary.Sandbox
         protected readonly List<SpecialPoint> _specialPoints = new List<SpecialPoint>();
 
         /// <summary>Floors and walkable terrain on the map.</summary>
+        protected abstract ParquetStatus[,] _parquetStatus { get; }
+
+        /// <summary>Floors and walkable terrain on the map.</summary>
         protected abstract EntityID[,] _floorLayer { get; }
 
         /// <summary>Walls and obstructing terrain on the map.</summary>
@@ -278,6 +281,23 @@ namespace ParquetClassLibrary.Sandbox
         #endregion
 
         #region State Query Methods
+        /// <summary>
+        /// Gets the statuses of any parquets at the position.
+        /// </summary>
+        /// <param name="in_position">The position whose status is sought.</param>
+        /// <returns>The status of parquets at the given position, or <c>null</c> if the position is invalid.</returns>
+        public ParquetStatus GetStatusAtPosition(Vector2Int in_position)
+        {
+            ParquetStatus result = null;
+
+            if (IsValidPosition(in_position))
+            {
+                result = _parquetStatus[in_position.X, in_position.Y];
+            }
+
+            return result;
+        }
+
         /// <summary>
         /// Gets any floor parquet at the position.
         /// </summary>

--- a/ParquetClassLibrary/Sandbox/MapRegion.cs
+++ b/ParquetClassLibrary/Sandbox/MapRegion.cs
@@ -2,6 +2,7 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ParquetClassLibrary.Sandbox.ID;
+using ParquetClassLibrary.Sandbox.Parquets;
 using ParquetClassLibrary.Stubs;
 using ParquetClassLibrary.Utilities;
 
@@ -46,6 +47,10 @@ namespace ParquetClassLibrary.Sandbox
         #endregion
 
         #region Map Contents
+        /// <summary>The statuses of parquets in the chunk.</summary>
+        protected override ParquetStatus[,] _parquetStatus { get; } = new ParquetStatus[AssemblyInfo.ParquetsPerRegionDimension,
+                                                                                        AssemblyInfo.ParquetsPerRegionDimension];
+
         /// <summary>Floors and walkable terrain in the region.</summary>
         protected override EntityID[,] _floorLayer { get; } = new EntityID[AssemblyInfo.ParquetsPerRegionDimension,
                                                                            AssemblyInfo.ParquetsPerRegionDimension];

--- a/ParquetClassLibrary/Sandbox/Parquets/Block.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Block.cs
@@ -15,7 +15,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         public const int LowestPossibleToughness = 0;
 
         /// <summary>Maximum toughness value to use when none is specified.</summary>
-        private const int defaultMaxToughness = 10;
+        public const int DefaultMaxToughness = 10;
 
         /// <summary>The set of values that are allowed for Block IDs.</summary>
         // TODO Test if we can remove this ignore tag.
@@ -53,20 +53,6 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         public int MaxToughness { get; private set; }
         #endregion
 
-        #region Block Status
-        /// <summary>The block's current toughness.</summary>
-        [JsonIgnore]
-        private int _toughness;
-
-        /// <summary>The block's current toughness, from 0 to <see cref="MaxToughness"/>.</summary>
-        [JsonIgnore]
-        public int Toughness
-        {
-            get => _toughness;
-            set => _toughness = value.Normalize(LowestPossibleToughness, MaxToughness);
-        }
-        #endregion
-
         #region Initialization
         /// <summary>
         /// Initializes a new instance of the <see cref="T:ParquetClassLibrary.Sandbox.Parquets.Block"/> class.
@@ -87,7 +73,7 @@ namespace ParquetClassLibrary.Sandbox.Parquets
                      GatheringEffect in_gatherEffect = GatheringEffect.None,
                      EntityID? in_itemID = null, EntityID? in_collectibleID = null,
                      bool in_isFlammable = false, bool in_isLiquid = false,
-                     int in_maxToughness = defaultMaxToughness)
+                     int in_maxToughness = DefaultMaxToughness)
                      : base(Bounds, in_id, in_name, in_addsToBiome)
         {
             var nonNullCollectibleID = in_collectibleID ?? EntityID.None;
@@ -108,7 +94,6 @@ namespace ParquetClassLibrary.Sandbox.Parquets
             IsFlammable = in_isFlammable;
             IsLiquid = in_isLiquid;
             MaxToughness = in_maxToughness;
-            Toughness = MaxToughness;
         }
         #endregion
     }

--- a/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Floor.cs
@@ -33,12 +33,6 @@ namespace ParquetClassLibrary.Sandbox.Parquets
         public bool IsWalkable { get; private set; }
         #endregion
 
-        #region Floor Status
-        /// <summary>The floor has been dug out.</summary>
-        [JsonIgnore]
-        public bool IsTrench { get; set; } = false;
-        #endregion
-
         #region Initialization
         /// <summary>
         /// Initializes a new instance of the <see cref="T:ParquetClassLibrary.Sandbox.Parquets.Floor"/> class.

--- a/ParquetClassLibrary/Sandbox/Parquets/ParquetStatus.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/ParquetStatus.cs
@@ -1,0 +1,60 @@
+using Newtonsoft.Json;
+
+namespace ParquetClassLibrary.Sandbox.Parquets
+{
+    /// <summary>
+    /// Models the status of a stack of sandbox-mode parquets.
+    /// </summary>
+    public class ParquetStatus
+    {
+        /// <summary>The parquets whose statuses this instance is tracking.</summary>
+        [JsonProperty(PropertyName = "in_thisStack")]
+        private readonly ParquetStack _thisStack;
+
+        /// <summary>The block's current toughness.</summary>
+        [JsonIgnore]
+        private int _toughness;
+
+        /// <summary>
+        /// The block's current toughness, from <see cref="Block.LowestPossibleToughness"/>
+        /// to <see cref="Block.MaxToughness"/>.
+        /// </summary>
+        [JsonProperty(PropertyName = "in_toughness")]
+        public int Toughness
+        {
+            get => _toughness;
+            set => _toughness = value.Normalize(Block.LowestPossibleToughness, _thisStack.Block?.MaxToughness ?? Block.DefaultMaxToughness);
+        }
+
+        /// <summary>If the floor has been dug out.</summary>
+        [JsonProperty(PropertyName = "in_isTrench")]
+        public bool IsTrench { get; set; }
+
+        #region Initialization
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:ParquetClassLibrary.Sandbox.Parquets.ParquetStatus"/> class.
+        /// </summary>
+        /// <param name="in_thisStack">The parquets whose status this instance is tracking.</param>
+        /// <param name="in_isTrench">Whether or not the <see cref="Floor"/> associated with this status has been dug out.</param>
+        /// <param name="in_toughness">The toughness of the <see cref="Block"/> associated with this status.</param>
+        [JsonConstructor]
+        public ParquetStatus(ParquetStack in_thisStack, bool in_isTrench = false, int? in_toughness = null)
+        {
+            _thisStack = in_thisStack;
+            IsTrench = in_isTrench;
+            Toughness = in_toughness ?? in_thisStack.Block?.MaxToughness ?? Block.DefaultMaxToughness;
+        }
+        #endregion
+
+        #region Utility Methods
+        /// <summary>
+        /// Returns a <see cref="string"/> that represents the current <see cref="ParquetStatus"/>.
+        /// </summary>
+        /// <returns>The representation.</returns>
+        public override string ToString()
+        {
+            return $"{Toughness} toughness, {(IsTrench ? "dug out" : "filled in")}";
+        }
+        #endregion
+    }
+}

--- a/ParquetUnitTests/Sandbox/Parquets/BlockUnitTest.cs
+++ b/ParquetUnitTests/Sandbox/Parquets/BlockUnitTest.cs
@@ -34,27 +34,6 @@ namespace ParquetUnitTests.Sandbox.Parquets
         }
 
         [Fact]
-        public void ToughnessCannotBeSetBelowZeroTest()
-        {
-            var testBlock = TestParquets.TestBlock;
-
-            testBlock.Toughness = int.MinValue;
-
-            Assert.Equal(Block.LowestPossibleToughness, testBlock.Toughness);
-        }
-
-        [Fact]
-        public void ToughnessCannotBeAboveMaxToughnessTest()
-        {
-            var testBlock = TestParquets.TestBlock;
-            var priorToughness = testBlock.Toughness;
-
-            testBlock.Toughness = int.MaxValue;
-
-            Assert.Equal(priorToughness, testBlock.Toughness);
-        }
-
-        [Fact]
         public void ValidItemIDsArePermittedTest()
         {
             // TODO When we have a cannonical source of item IDs, use that instead.

--- a/ParquetUnitTests/Sandbox/Parquets/ParquetStatusUnitTest.cs
+++ b/ParquetUnitTests/Sandbox/Parquets/ParquetStatusUnitTest.cs
@@ -1,0 +1,34 @@
+using ParquetClassLibrary.Sandbox.Parquets;
+using Xunit;
+
+namespace ParquetUnitTests.Sandbox.Parquets
+{
+    public class ParquetStatusUnitTest
+    {
+        [Fact]
+        public void ToughnessCannotBeSetBelowZeroTest()
+        {
+            var validStack = new ParquetStack(TestParquets.TestFloor, TestParquets.TestBlock,
+                                              TestParquets.TestFurnishing, TestParquets.TestCollectible);
+            var testStatus = new ParquetStatus(validStack);
+
+            testStatus.Toughness = int.MinValue;
+
+            Assert.Equal(Block.LowestPossibleToughness, testStatus.Toughness);
+        }
+
+        [Fact]
+        public void ToughnessCannotBeAboveMaxToughnessTest()
+        {
+            var validStack = new ParquetStack(TestParquets.TestFloor, TestParquets.TestBlock,
+                                              TestParquets.TestFurnishing, TestParquets.TestCollectible);
+            var testStatus = new ParquetStatus(validStack);
+
+            var priorToughness = testStatus.Toughness;
+
+            testStatus.Toughness = int.MaxValue;
+
+            Assert.Equal(priorToughness, testStatus.Toughness);
+        }
+    }
+}


### PR DESCRIPTION
As originally implemented, parquet statuses were treated as a part of their definition.
This leads to a lot of problems; for example, if the player were to dig a hole in a grass floor it would dig that hole in every grass floor!

Statuses need to vary per-map location, not per-definition. This PR stores status information as an independent grid of objects.

Since there are as yet only two status to track, block toughness and floor dug-out-ness, (and since this number is not likely to grow much), this new implementation tracks them together as a single status object.

Any and all feedback on this approach is appreciated!
(I feel like I may have overlooked something....)



