### PR TITLE
Range<EntityID> Adjustments

### DIFF
--- a/Designer/Block.csv
+++ b/Designer/Block.csv
@@ -1,10 +1,10 @@
 ID,Name,AddsToBiome,GatherTool,GatherEffect,ItemID,CollectibleID,IsFlammable,IsLiquid,MaxToughness
--20000,2 Block Test Parquet,None,None,None,-50000,-40000,FALSE,FALSE,10
-20000,bush,None,Axe,Collectible,0,40000,TRUE,FALSE,1
-20001,tree,Forested,Axe,Collectible,0,40001,TRUE,FALSE,4
-20002,seed pod,Swampy,Axe,Collectible,0,40002,TRUE,FALSE,1
-20003,sandstone boulder,Deserted,Pick,None,0,0,FALSE,FALSE,10
-20004,ice boulder,Frozen,Pick,None,0,0,FALSE,FALSE,8
-20005,grey brick,None,Pick,None,0,0,FALSE,FALSE,8
-20006,fresh water,None,Bucket,Item,50001,0,FALSE,TRUE,1
-20007,lava,Volcanic,Bucket,Item,50002,0,FALSE,TRUE,1
+-40000,2 Block Test Parquet,None,None,None,-100000,-60000,FALSE,FALSE,10
+40000,bush,None,Axe,Collectible,0,60000,TRUE,FALSE,1
+40001,tree,Forested,Axe,Collectible,0,60001,TRUE,FALSE,4
+40002,seed pod,Swampy,Axe,Collectible,0,60002,TRUE,FALSE,1
+40003,sandstone boulder,Deserted,Pick,None,0,0,FALSE,FALSE,10
+40004,ice boulder,Frozen,Pick,None,0,0,FALSE,FALSE,8
+40005,grey brick,None,Pick,None,0,0,FALSE,FALSE,8
+40006,fresh water,None,Bucket,Item,100001,0,FALSE,TRUE,1
+40007,lava,Volcanic,Bucket,Item,100002,0,FALSE,TRUE,1

--- a/Designer/Collectible.csv
+++ b/Designer/Collectible.csv
@@ -1,11 +1,11 @@
 ID,Name,AddsToBiome,Effect,EffectAmount,ItemID
--40000,4 Collectible Test Parquet,None,None,0,-50000
-40000,Flower,None,Item,0,50000
-40001,Pinecone,Forested,Item,0,50001
-40002,Seeds,Swampy,Item,0,50002
-40003,Bones,Deserted,Item,0,50003
-40004,Ice Crystal,Frozen,Item,0,50004
-40005,Copper Ore,None,Item,0,50005
-40006,Heart,None,Health,10,0
-40007,Star,None,Mana,10,0
-40008,Coin,None,Money,1,0
+-60000,4 Collectible Test Parquet,None,None,0,-100000
+60000,Flower,None,Item,0,100000
+60001,Pinecone,Forested,Item,0,100001
+60002,Seeds,Swampy,Item,0,100002
+60003,Bones,Deserted,Item,0,100003
+60004,Ice Crystal,Frozen,Item,0,100004
+60005,Copper Ore,None,Item,0,100005
+60006,Heart,None,Health,10,0
+60007,Star,None,Mana,10,0
+60008,Coin,None,Money,1,0

--- a/Designer/Floor.csv
+++ b/Designer/Floor.csv
@@ -1,9 +1,9 @@
 ID,Name,AddsToBiome,ModTool,TrenchName,IsWalkable
--10000,1 Floor Test Parquet,None,None,dark hole,TRUE
-10000,grass,None,Shovel,dirty pit,TRUE
-10001,weeds,Swampy,Shovel,muddy pit,TRUE
-10002,sand,Deserted,Shovel,sandy pit,TRUE
-10003,snow,Frozen,Shovel,snowy pit,TRUE
-10004,stone floor,None,Hammer,stony trench,TRUE
-10005,red brick,None,Hammer,red brick channel,TRUE
-10006,spikes,None,Hammer,spike trap,FALSE
+-30000,1 Floor Test Parquet,None,None,dark hole,TRUE
+30000,grass,None,Shovel,dirty pit,TRUE
+30001,weeds,Swampy,Shovel,muddy pit,TRUE
+30002,sand,Deserted,Shovel,sandy pit,TRUE
+30003,snow,Frozen,Shovel,snowy pit,TRUE
+30004,stone floor,None,Hammer,stony trench,TRUE
+30005,red brick,None,Hammer,red brick channel,TRUE
+30006,spikes,None,Hammer,spike trap,FALSE

--- a/Designer/Furnishing.csv
+++ b/Designer/Furnishing.csv
@@ -1,6 +1,6 @@
 ID,Name,AddsToBiome,IsWalkable,ItemID,SwapID
--30000,3 Furnishing Test Parquet,None,FALSE,-50000,0
-30000,Chair,None,TRUE,50003,0
-30001,Table,None,FALSE,50004,0
-30002,Wooden Door Open,None,TRUE,50005,30003
-30003,Wooden Door Closed,None,FALSE,50005,30002
+-50000,3 Furnishing Test Parquet,None,FALSE,-100000,0
+50000,Chair,None,TRUE,100003,0
+50001,Table,None,FALSE,100004,0
+50002,Wooden Door Open,None,TRUE,100005,50003
+50003,Wooden Door Closed,None,FALSE,100005,50002

--- a/ParquetClassLibrary/AssemblyInfo.cs
+++ b/ParquetClassLibrary/AssemblyInfo.cs
@@ -48,6 +48,29 @@ namespace ParquetClassLibrary
 
         #region EntityID Ranges
         /// <summary>
+        /// A subset of the values of <see cref="EntityID"/> set aside for <see cref="Characters.PlayerCharacter"/>s.
+        /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test Items.
+        /// </summary>
+        public static readonly Range<EntityID> PlayerCharacterIDs;
+
+        /// <summary>
+        /// A subset of the values of <see cref="EntityID"/> set aside for <see cref="Characters.Critter"/>s.
+        /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test Items.
+        /// </summary>
+        public static readonly Range<EntityID> CritterIDs;
+
+        /// <summary>
+        /// A subset of the values of <see cref="EntityID"/> set aside for <see cref="Characters.Being"/>s.
+        /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test Items.
+        /// </summary>
+        public static readonly Range<EntityID> NpcIDs;
+
+        /// <summary>
+        /// A collection containing all defined <see cref="Range{EntityID}"/>s of <see cref="Characters.Being"/>s.
+        /// </summary>
+        public static readonly List<Range<EntityID>> BeingIDs;
+
+        /// <summary>
         /// A subset of the values of <see cref="EntityID"/> set aside for <see cref="Sandbox.Parquets.Floor"/>s.
         /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test parquets.
         /// </summary>
@@ -74,36 +97,7 @@ namespace ParquetClassLibrary
         /// <summary>
         /// A collection containing all defined <see cref="Range{EntityID}"/>s of parquet types.
         /// </summary>
-        public static readonly List<Range<EntityID>> ParquetIDs = new List<Range<EntityID>>
-            {
-                FloorIDs, BlockIDs, FurnishingIDs, CollectibleIDs
-            };
-
-        /// <summary>
-        /// A subset of the values of <see cref="EntityID"/> set aside for <see cref="Characters.Critter"/>s.
-        /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test Items.
-        /// </summary>
-        public static readonly Range<EntityID> CritterIDs;
-
-        /// <summary>
-        /// A subset of the values of <see cref="EntityID"/> set aside for <see cref="Characters.Character"/>s.
-        /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test Items.
-        /// </summary>
-        public static readonly Range<EntityID> CharacterIDs;
-
-        /// <summary>
-        /// A subset of the values of <see cref="EntityID"/> set aside for <see cref="Characters.Player"/>s.
-        /// Valid identifiers may be positive or negative.  By convention, negative IDs indicate test Items.
-        /// </summary>
-        public static readonly Range<EntityID> PlayerIDs;
-
-        /// <summary>
-        /// A collection containing all defined <see cref="Range{EntityID}"/>s of <see cref="Characters.Being"/>s.
-        /// </summary>
-        public static readonly List<Range<EntityID>> BeingIDs = new List<Range<EntityID>>
-            {
-                CritterIDs, CharacterIDs, PlayerIDs
-            };
+        public static readonly List<Range<EntityID>> ParquetIDs;
 
         /// <summary>
         /// A subset of the values of <see cref="EntityID"/> set aside for <see cref="Sandbox.RoomRecipe"/>s.
@@ -138,19 +132,33 @@ namespace ParquetClassLibrary
         static AssemblyInfo()
         {
             // By convention, the first EntityID in each Range is a multiple of this number.
-            // An exception is made for Critter, Character, and Player as they are treated as sub-ranges.
+            // An exception is made for PlayerCharacters as these values are undefined at designtime.
             var TargetMultiple = 10000;
 
-            FloorIDs = new Range<EntityID>(10000, 19000);
-            BlockIDs = new Range<EntityID>(20000, 29000);
-            FurnishingIDs = new Range<EntityID>(30000, 39000);
-            CollectibleIDs = new Range<EntityID>(40000, 49000);
-            CritterIDs = new Range<EntityID>(50000, 52900);
-            CharacterIDs = new Range<EntityID>(53000, 55900);
-            PlayerIDs = new Range<EntityID>(56000, 58900);
-            RoomRecipeIDs = new Range<EntityID>(60000, 69000);
-            CraftingRecipeIDs = new Range<EntityID>(70000, 79000);
-            QuestIDs = new Range<EntityID>(80000, 89000);
+            #region Define Ranges
+            PlayerCharacterIDs = new Range<EntityID>(1, 9999);
+            CritterIDs = new Range<EntityID>(10000, 19000);
+            NpcIDs = new Range<EntityID>(20000, 29000);
+
+            FloorIDs = new Range<EntityID>(30000, 39000);
+            BlockIDs = new Range<EntityID>(40000, 49000);
+            FurnishingIDs = new Range<EntityID>(50000, 59000);
+            CollectibleIDs = new Range<EntityID>(60000, 69000);
+
+            RoomRecipeIDs = new Range<EntityID>(70000, 79000);
+            CraftingRecipeIDs = new Range<EntityID>(80000, 89000);
+
+            QuestIDs = new Range<EntityID>(90000, 99000);
+            #endregion
+
+            #region Define Range Collections
+            BeingIDs = new List<Range<EntityID>> { PlayerCharacterIDs, CritterIDs, NpcIDs };
+            ParquetIDs = new List<Range<EntityID>> { FloorIDs, BlockIDs, FurnishingIDs, CollectibleIDs };
+            #endregion
+
+            // TODO Before Parquet-Release Candidate milestone (the one in the Unity project),
+            // replace all reflection and Linq in the main class library with hardcoded values.
+            // The tools and tests can continue to use Linq and reflection.
 
             // The largest Range.Maximum defined in AssemblyInfo, excluding ItemIDs.
             int MaximumIDNotCountingItems = typeof(AssemblyInfo).GetFields()
@@ -165,12 +173,12 @@ namespace ParquetClassLibrary
             // Since ItemIDs is being defined at runtime, its Range.Minimum must be chosen well above existing maxima.
             var ItemLowerBound = TargetMultiple * ((MaximumIDNotCountingItems + (TargetMultiple - 1)) / TargetMultiple);
 
-            // The largest Range.Maximum of any paruet IDs.
+            // The largest Range.Maximum of any parquet IDs.
             int MaximumParquetID = ParquetIDs
                 .Select(range => range.Maximum)
                 .Max();
 
-            // The smallest Range.Minimum of any paruet IDs.
+            // The smallest Range.Minimum of any parquet IDs.
             int MinimumParquetID = ParquetIDs
                 .Select(range => range.Minimum)
                 .Min();

--- a/ParquetClassLibrary/AssemblyInfo.cs
+++ b/ParquetClassLibrary/AssemblyInfo.cs
@@ -178,7 +178,7 @@ namespace ParquetClassLibrary
             // Since it is possible for every parquet to have a corresponding item, this range must be at least
             // as large as all four parquet ranges put together.  Therefore, the Range.Maximum is twice the combined
             // ranges of all parquets.
-            var ItemUpperBound = ItemLowerBound + 2 * (TargetMultiple / 10 + MaximumParquetID - MinimumParquetID);
+            var ItemUpperBound = ItemLowerBound + 2 * ((TargetMultiple / 10) + MaximumParquetID - MinimumParquetID);
 
             ItemIDs = new Range<EntityID>(ItemLowerBound, ItemUpperBound);
         }

--- a/ParquetClassLibrary/Characters/Behavior.cs
+++ b/ParquetClassLibrary/Characters/Behavior.cs
@@ -1,0 +1,14 @@
+namespace ParquetClassLibrary.Characters
+{
+    /// <summary>
+    /// The way a <see cref="Being"/> acts, on their own on the <see cref="ParquetClassLibrary.Sandbox.MapRegion"/>.
+    /// </summary>
+    public enum Behavior
+    {
+        // TODO Update these with more reasonable values.
+        // TODO Will this actually be expanded into a class that governs behavior?
+        Still,
+        Homebody,
+        Adventurer,
+    }
+}

--- a/ParquetClassLibrary/Characters/Being.cs
+++ b/ParquetClassLibrary/Characters/Being.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using ParquetClassLibrary.Sandbox;
 using ParquetClassLibrary.Sandbox.IDs;
 using ParquetClassLibrary.Utilities;
 
@@ -12,23 +11,11 @@ namespace ParquetClassLibrary.Characters
     public abstract class Being : Entity
     {
         #region Characteristics
-        /// <summary>
-        /// Describes the version of serialized data.
-        /// Allows selecting data files that can be successfully deserialized.
-        /// </summary>
-        protected readonly string DataVersion = AssemblyInfo.SupportedDataVersion;
-
-        /// <summary>Tracks how many times the data structure has been serialized.</summary>
-        public int Revision { get; private set; }
-
         /// <summary>The <see cref="Biome"/> in which this character is at home.</summary>
         public Biome NativeBiome { get; set; }
 
         /// <summary>The <see cref="Behavior"/> governing the way this character acts.</summary>
-        public Behavior CurrentBehavior { get; set; }
-
-        /// <summary>The <see cref="Location"/> of this character acts.</summary>
-        public Location CurrentLocation { get; set; }
+        public Behavior PrimaryBehavior { get; set; }
 
         /// <summary>Types of parquets this critter avoids, if any.</summary>
         public readonly List<EntityID> Avoids = new List<EntityID>();
@@ -48,13 +35,11 @@ namespace ParquetClassLibrary.Characters
         /// <param name="in_id">Unique identifier for the <see cref="Being"/>.  Cannot be null.</param>
         /// <param name="in_name">Player-friendly name of the <see cref="Being"/>.  Cannot be null or empty.</param>
         /// <param name="in_nativeBiome">The <see cref="Biome"/> in which this <see cref="Being"/> is most comfortable.</param>
-        /// <param name="in_currentBehavior">The rules that govern how this <see cref="Being"/> acts.  Cannot be null.</param>
-        /// <param name="in_currentLocation">Where this <see cref="Being"/> currently is.</param>
+        /// <param name="in_primaryBehavior">The rules that govern how this <see cref="Being"/> acts.  Cannot be null.</param>
         /// <param name="in_avoids">Any parquets this <see cref="Being"/> avoids.</param>
         /// <param name="in_seeks">Any parquets this <see cref="Being"/> seeks.</param>
         protected Being(Range<EntityID> in_bounds, EntityID in_id, string in_name, Biome in_nativeBiome,
-                        Behavior in_currentBehavior, Location in_currentLocation,
-                       List<EntityID> in_avoids = null, List<EntityID> in_seeks = null)
+                        Behavior in_primaryBehavior, List<EntityID> in_avoids = null, List<EntityID> in_seeks = null)
             : base(in_bounds, in_id, in_name)
         {
             if (!AssemblyInfo.BeingIDs.ContainsRange(in_bounds))
@@ -77,8 +62,7 @@ namespace ParquetClassLibrary.Characters
             }
 
             NativeBiome = in_nativeBiome;
-            CurrentBehavior = in_currentBehavior;
-            CurrentLocation = in_currentLocation;
+            PrimaryBehavior = in_primaryBehavior;
             Avoids.AddRange(in_avoids);
             Seeks.AddRange(in_seeks);
         }

--- a/ParquetClassLibrary/Characters/Being.cs
+++ b/ParquetClassLibrary/Characters/Being.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using ParquetClassLibrary.Sandbox;
+using ParquetClassLibrary.Sandbox.IDs;
+using ParquetClassLibrary.Utilities;
+
+namespace ParquetClassLibrary.Characters
+{
+    /// <summary>
+    /// Models the basic definitions shared by any in-game actor.
+    /// </summary>
+    public abstract class Being : Entity
+    {
+        #region Characteristics
+        /// <summary>
+        /// Describes the version of serialized data.
+        /// Allows selecting data files that can be successfully deserialized.
+        /// </summary>
+        protected readonly string DataVersion = AssemblyInfo.SupportedDataVersion;
+
+        /// <summary>Tracks how many times the data structure has been serialized.</summary>
+        public int Revision { get; private set; }
+
+        /// <summary>The <see cref="Biome"/> in which this character is at home.</summary>
+        public Biome NativeBiome { get; set; }
+
+        /// <summary>The <see cref="Behavior"/> governing the way this character acts.</summary>
+        public Behavior CurrentBehavior { get; set; }
+
+        /// <summary>The <see cref="Location"/> of this character acts.</summary>
+        public Location CurrentLocation { get; set; }
+
+        /// <summary>Types of parquets this critter avoids, if any.</summary>
+        public readonly List<EntityID> Avoids = new List<EntityID>();
+
+        /// <summary>Types of parquets this critter seeks out, if any.</summary>
+        public readonly List<EntityID> Seeks = new List<EntityID>();
+        #endregion
+
+        #region Initialization
+        /// <summary>
+        /// Used by <see cref="Being"/> subtypes.
+        /// </summary>
+        /// <param name="in_bounds">
+        /// The bounds within which the <see cref="Being"/>'s <see cref="EntityID"/> is defined.
+        /// Must be one of <see cref="AssemblyInfo.BeingIDs"/>.
+        /// </param>
+        /// <param name="in_id">Unique identifier for the <see cref="Being"/>.  Cannot be null.</param>
+        /// <param name="in_name">Player-friendly name of the <see cref="Being"/>.  Cannot be null or empty.</param>
+        /// <param name="in_nativeBiome">The <see cref="Biome"/> in which this <see cref="Being"/> is most comfortable.</param>
+        /// <param name="in_currentBehavior">The rules that govern how this <see cref="Being"/> acts.  Cannot be null.</param>
+        /// <param name="in_currentLocation">Where this <see cref="Being"/> currently is.</param>
+        /// <param name="in_avoids">Any parquets this <see cref="Being"/> avoids.</param>
+        /// <param name="in_seeks">Any parquets this <see cref="Being"/> seeks.</param>
+        protected Being(Range<EntityID> in_bounds, EntityID in_id, string in_name, Biome in_nativeBiome,
+                        Behavior in_currentBehavior, Location in_currentLocation,
+                       List<EntityID> in_avoids = null, List<EntityID> in_seeks = null)
+            : base(in_bounds, in_id, in_name)
+        {
+            if (!AssemblyInfo.BeingIDs.ContainsRange(in_bounds))
+            {
+                throw new ArgumentOutOfRangeException(nameof(in_bounds));
+            }
+            foreach (var parquetID in in_avoids)
+            {
+                if (!parquetID.IsValidForRange(AssemblyInfo.ParquetIDs))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(in_avoids));
+                }
+            }
+            foreach (var parquetID in in_seeks)
+            {
+                if (!parquetID.IsValidForRange(AssemblyInfo.ParquetIDs))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(in_seeks));
+                }
+            }
+
+            NativeBiome = in_nativeBiome;
+            CurrentBehavior = in_currentBehavior;
+            CurrentLocation = in_currentLocation;
+            Avoids.AddRange(in_avoids);
+            Seeks.AddRange(in_seeks);
+        }
+        #endregion
+    }
+}

--- a/ParquetClassLibrary/Characters/BeingStatus.cs
+++ b/ParquetClassLibrary/Characters/BeingStatus.cs
@@ -1,0 +1,49 @@
+using Newtonsoft.Json;
+using ParquetClassLibrary.Sandbox;
+
+namespace ParquetClassLibrary.Characters
+{
+    public class BeingStatus
+    {
+        /// <summary>The <see cref="Being"/> whose status is being tracked.</summary>
+        [JsonProperty(PropertyName = "in_beingDefinition")]
+        public Being BeingDefinition { get; }
+
+        /// <summary>The <see cref="Location"/> the tracked <see cref="Being"/> occupies.</summary>
+        [JsonProperty(PropertyName = "in_currentLocation")]
+        public Location CurrentLocation { get; set; }
+
+        /// <summary>The <see cref="Behavior"/> currently governing the tracked <see cref="Being"/>.</summary>
+        [JsonProperty(PropertyName = "in_currentBehavior")]
+        public Behavior CurrentBehavior { get; set; }
+
+        // IDEA I expect more will be added here as design goes on.
+
+        #region Initialization
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BeingStatus"/> class.
+        /// </summary>
+        /// <param name="in_beingDefinition">The parquets whose status this instance is tracking.</param>
+        /// <param name="in_currentLocation">Whether or not the <see cref="Floor"/> associated with this status has been dug out.</param>
+        /// <param name="in_currentBehavior">The <see cref="Behavior"/> currently governing .</param>
+        [JsonConstructor]
+        public BeingStatus(Being in_beingDefinition, Location in_currentLocation, Behavior in_currentBehavior)
+        {
+            BeingDefinition = in_beingDefinition;
+            CurrentLocation = in_currentLocation;
+            CurrentBehavior = in_currentBehavior;
+        }
+        #endregion
+
+        #region Utility Methods
+        /// <summary>
+        /// Returns a <see langword="string"/> that represents the current <see cref="BeingStatus"/>.
+        /// </summary>
+        /// <returns>The representation.</returns>
+        public override string ToString()
+        {
+            return $"{BeingDefinition.Name}";
+        }
+        #endregion
+    }
+}

--- a/ParquetClassLibrary/Characters/Character.cs
+++ b/ParquetClassLibrary/Characters/Character.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using ParquetClassLibrary.Sandbox;
+using ParquetClassLibrary.Sandbox.IDs;
+using ParquetClassLibrary.Utilities;
+
+namespace ParquetClassLibrary.Characters
+{
+    public abstract class Character : Being
+    {
+        #region Class Defaults
+        /// <summary>A pronoun to use when none is specified.</summary>
+        // TODO This is just a place-holder, I am not sure yet how we will handle pronouns.
+        public const string DefaultPronoun = "they";
+        #endregion
+
+
+        #region Characteristics
+        /// <summary>The pronouns the <see cref="Character"/> uses.</summary>
+        // TODO This is just a place-holder, I am not sure yet how we will handle pronouns.
+        public string Pronoun { get; }
+
+        /// <summary>Types of parquets this <see cref="Character"/> avoids.</summary>
+        public readonly List<EntityID> Quests = new List<EntityID>();
+
+        /// <summary>Dialogue lines this <see cref="Character"/> can say.</summary>
+        // TODO This is just a place-holder, I am not at all sure how we will handle this.
+        public readonly List<string> Dialogue = new List<string>();
+
+        /// <summary>This <see cref="Character"/>'s belongings.</summary>
+        // TODO This is just a place-holder, inventory may need its own class.
+        public readonly List<EntityID> Inventory = new List<EntityID>();
+        #endregion
+
+        #region Initialization
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Character"/> class.
+        /// </summary>
+        /// <param name="in_bounds">
+        /// The bounds within which the <see cref="Character"/>'s <see cref="EntityID"/> is defined.
+        /// Must be one of <see cref="AssemblyInfo.BeingIDs"/>.
+        /// </param>
+        /// <param name="in_id">Unique identifier for the <see cref="Character"/>.  Cannot be null.</param>
+        /// <param name="in_name">Player-friendly name of the <see cref="Character"/>.  Cannot be null or empty.</param>
+        /// <param name="in_nativeBiome">The <see cref="Biome"/> in which this <see cref="Character"/> is most comfortable.</param>
+        /// <param name="in_primaryBehavior">The rules that govern how this <see cref="Character"/> acts.  Cannot be null.</param>
+        /// <param name="in_avoids">Any parquets this <see cref="Character"/> avoids.</param>
+        /// <param name="in_seeks">Any parquets this <see cref="Character"/> seeks.</param>
+        /// <param name="in_quests">Any quests this <see cref="Character"/> has to offer.</param>
+        /// <param name="in_dialogue">All dialogue this <see cref="Character"/> may say.</param>
+        /// <param name="in_inventory">Any items this <see cref="Character"/> owns.</param>
+        /// <param name="in_pronoun">How to refer to this <see cref="Character"/>.</param>
+        protected Character(Range<EntityID> in_bounds, EntityID in_id, string in_name, Biome in_nativeBiome,
+                            Behavior in_primaryBehavior, List<EntityID> in_avoids = null,
+                            List<EntityID> in_seeks = null, List<EntityID> in_quests = null,
+                            List<string> in_dialogue = null, List<EntityID> in_inventory = null,
+                            string in_pronoun = DefaultPronoun)
+            : base(in_bounds, in_id, in_name, in_nativeBiome, in_primaryBehavior, in_avoids, in_seeks)
+        {
+            foreach (var questID in in_quests)
+            {
+                if (!questID.IsValidForRange(AssemblyInfo.QuestIDs))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(in_quests));
+                }
+            }
+            foreach (var itemID in in_inventory)
+            {
+                if (!itemID.IsValidForRange(AssemblyInfo.ItemIDs))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(in_inventory));
+                }
+            }
+            var nonNullPronoun = string.IsNullOrEmpty(in_pronoun) ? DefaultPronoun : in_pronoun;
+
+            Pronoun = nonNullPronoun;
+            Quests.AddRange(in_quests);
+            Dialogue.AddRange(in_dialogue);
+            Inventory.AddRange(in_inventory);
+        }
+        #endregion
+    }
+}

--- a/ParquetClassLibrary/Characters/Critter.cs
+++ b/ParquetClassLibrary/Characters/Critter.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using ParquetClassLibrary.Sandbox;
 using ParquetClassLibrary.Sandbox.IDs;
-using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Characters
 {
@@ -20,15 +18,12 @@ namespace ParquetClassLibrary.Characters
         /// </param>
         /// <param name="in_name">Player-friendly name of the <see cref="Critter"/>.  Cannot be null or empty.</param>
         /// <param name="in_nativeBiome">The <see cref="Biome"/> in which this <see cref="Critter"/> is most comfortable.</param>
-        /// <param name="in_currentBehavior">The rules that govern how this <see cref="Critter"/> acts.  Cannot be null.</param>
-        /// <param name="in_currentLocation">Where this <see cref="Critter"/> currently is.</param>
+        /// <param name="in_primaryBehavior">The rules that govern how this <see cref="Critter"/> acts.  Cannot be null.</param>
         /// <param name="in_avoids">Any parquets this <see cref="Critter"/> avoids.</param>
         /// <param name="in_seeks">Any parquets this <see cref="Critter"/> seeks.</param>
-        public Critter(EntityID in_id, string in_name, Biome in_nativeBiome,
-                       Behavior in_currentBehavior, Location in_currentLocation,
+        public Critter(EntityID in_id, string in_name, Biome in_nativeBiome, Behavior in_primaryBehavior,
                        List<EntityID> in_avoids = null, List<EntityID> in_seeks = null)
-            : base(AssemblyInfo.CritterIDs, in_id, in_name, in_nativeBiome, in_currentBehavior, in_currentLocation,
-                   in_avoids, in_seeks)
+            : base(AssemblyInfo.CritterIDs, in_id, in_name, in_nativeBiome, in_primaryBehavior, in_avoids, in_seeks)
         {
             if (!in_id.IsValidForRange(AssemblyInfo.CritterIDs))
             {

--- a/ParquetClassLibrary/Characters/Critter.cs
+++ b/ParquetClassLibrary/Characters/Critter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using ParquetClassLibrary.Sandbox;
+using ParquetClassLibrary.Sandbox.IDs;
+using ParquetClassLibrary.Utilities;
+
+namespace ParquetClassLibrary.Characters
+{
+    /// <summary>
+    /// Models the definition for a simple in-game actor, such as a friendly mob with limited interaction.
+    /// </summary>
+    public sealed class Critter : Being
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Critter"/> class.
+        /// </summary>
+        /// <param name="in_id">
+        /// Unique identifier for the <see cref="Critter"/>.  Cannot be null.
+        /// Must be a <see cref="AssemblyInfo.CritterIDs"/>.
+        /// </param>
+        /// <param name="in_name">Player-friendly name of the <see cref="Critter"/>.  Cannot be null or empty.</param>
+        /// <param name="in_nativeBiome">The <see cref="Biome"/> in which this <see cref="Critter"/> is most comfortable.</param>
+        /// <param name="in_currentBehavior">The rules that govern how this <see cref="Critter"/> acts.  Cannot be null.</param>
+        /// <param name="in_currentLocation">Where this <see cref="Critter"/> currently is.</param>
+        /// <param name="in_avoids">Any parquets this <see cref="Critter"/> avoids.</param>
+        /// <param name="in_seeks">Any parquets this <see cref="Critter"/> seeks.</param>
+        public Critter(EntityID in_id, string in_name, Biome in_nativeBiome,
+                       Behavior in_currentBehavior, Location in_currentLocation,
+                       List<EntityID> in_avoids = null, List<EntityID> in_seeks = null)
+            : base(AssemblyInfo.CritterIDs, in_id, in_name, in_nativeBiome, in_currentBehavior, in_currentLocation,
+                   in_avoids, in_seeks)
+        {
+            if (!in_id.IsValidForRange(AssemblyInfo.CritterIDs))
+            {
+                throw new ArgumentOutOfRangeException(nameof(in_id));
+            }
+        }
+    }
+}

--- a/ParquetClassLibrary/Characters/NPC.cs
+++ b/ParquetClassLibrary/Characters/NPC.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using ParquetClassLibrary.Sandbox;
+using ParquetClassLibrary.Sandbox.IDs;
+
+namespace ParquetClassLibrary.Characters
+{
+    /// <summary>
+    /// Models the definition for a non-player character, such as a shop keeper.
+    /// </summary>
+    public sealed class NPC : Character
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NPC"/> class.
+        /// </summary>
+        /// <param name="in_id">
+        /// Unique identifier for the <see cref="NPC"/>.  Cannot be null.
+        /// Must be a valid <see cref="AssemblyInfo.NpcIDs"/>.
+        /// </param>
+        /// <param name="in_name">Player-friendly name of the <see cref="NPC"/>.  Cannot be null or empty.</param>
+        /// <param name="in_nativeBiome">The <see cref="Biome"/> in which this <see cref="NPC"/> is most comfortable.</param>
+        /// <param name="in_currentBehavior">The rules that govern how this <see cref="NPC"/> acts.  Cannot be null.</param>
+        /// <param name="in_avoids">Any parquets this <see cref="NPC"/> avoids.</param>
+        /// <param name="in_seeks">Any parquets this <see cref="NPC"/> seeks.</param>
+        /// <param name="in_quests">Any quests this <see cref="NPC"/> has to offer.</param>
+        /// <param name="in_dialogue">All dialogue this <see cref="NPC"/> may say.</param>
+        /// <param name="in_inventory">Any items this <see cref="NPC"/> owns.</param>
+        /// <param name="in_pronoun">How to refer to this <see cref="NPC"/>.</param>
+        public NPC(EntityID in_id, string in_name, Biome in_nativeBiome, Behavior in_currentBehavior,
+                   List<EntityID> in_avoids = null, List<EntityID> in_seeks = null,
+                   List<EntityID> in_quests = null, List<string> in_dialogue = null,
+                   List<EntityID> in_inventory = null, string in_pronoun = DefaultPronoun)
+            : base(AssemblyInfo.NpcIDs, in_id, in_name, in_nativeBiome, in_currentBehavior,
+                   in_avoids, in_seeks, in_quests, in_dialogue, in_inventory, in_pronoun)
+        {
+            if (!in_id.IsValidForRange(AssemblyInfo.NpcIDs))
+            {
+                throw new ArgumentOutOfRangeException(nameof(in_id));
+            }
+        }
+    }
+}

--- a/ParquetClassLibrary/Sandbox/Location.cs
+++ b/ParquetClassLibrary/Sandbox/Location.cs
@@ -1,0 +1,26 @@
+using System;
+using ParquetClassLibrary.Stubs;
+
+namespace ParquetClassLibrary.Sandbox
+{
+    /// <summary>
+    /// Represents a specific position within a specific <see cref="MapRegion"/>.
+    /// </summary>
+    public struct Location
+    {
+        /// <summary>The identifier for the <see cref="MapRegion"/> this character is located in.</summary>
+        public Guid RegionID;
+
+        /// <summary>The position within the current <see cref="MapRegion"/> where this character is located.</summary>
+        public Vector2Int Position;
+
+        /// <summary>
+        /// Describes the <see cref="Location"/> as a <see cref="string"/>.
+        /// </summary>
+        /// <returns>A <see cref="string"/> that represents the current <see cref="Location"/>.</returns>
+        public override string ToString()
+        {
+            return $"{Position} in {RegionID}";
+        }
+    }
+}

--- a/ParquetRunner/RunnerProgram.cs
+++ b/ParquetRunner/RunnerProgram.cs
@@ -16,6 +16,7 @@ namespace ParquetRunner
         {
             var region = new MapRegion();
             Console.WriteLine(region);
+            Console.WriteLine($"Item range = {AssemblyInfo.ItemIDs}");
         }
     }
 }


### PR DESCRIPTION
These are adjustments (hopefully improvements) made to the entity ID ranges in AssemblyInfo during the course of implementing character classes.

There are two main things to look for here:
1) Moving all initialization into a static constructor so that runtime calculation of ItemIDs is independent of variable declaration order.
2) Making PlayerIDs = 1...9999 and moving them and other character-related IDs before (both numerically and in the file) the ParquetIDs.

You may also notice that I introduced IDs for recipes and quests.
These are not being used yet but I plan to use them soon in another branch.

Almost all of the work is in AssemblyInfo.cs this time.
This PR is pretty self-contained, so I don't think any sample code is required?  Let me know if I'm wrong!  :)