### PR TITLE
Replace Precondition Boilerplate in Constructors

### DIFF
--- a/ParquetCSVImporter/Shims/BlockShim.cs
+++ b/ParquetCSVImporter/Shims/BlockShim.cs
@@ -3,6 +3,7 @@ using ParquetClassLibrary;
 using ParquetClassLibrary.Items;
 using ParquetClassLibrary.Sandbox.IDs;
 using ParquetClassLibrary.Sandbox.Parquets;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetCSVImporter.Shims
 {
@@ -38,28 +39,16 @@ namespace ParquetCSVImporter.Shims
         /// <summary>
         /// Converts a shim into the class is corresponds to.
         /// </summary>
-        /// <typeparam name="T">The type to convert this shim to.</typeparam>
+        /// <typeparam name="TargetType">The type to convert this shim to.</typeparam>
         /// <returns>
         /// An instance of a child class of <see cref="ParquetParent"/>.
         /// </returns>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown when the current shim does not correspond to the specified type.
-        /// </exception>
-        public override T To<T>()
+        public override TargetType To<TargetType>()
         {
-            T result;
+            Precondition.IsOfType<TargetType, Block>(typeof(TargetType).ToString());
 
-            if (typeof(T) == typeof(Block))
-            {
-                result = (T)(ParquetParent)new Block(ID, Name, AddsToBiome, GatherTool, GatherEffect, ItemID,
-                                                     CollectibleID, IsFlammable, IsLiquid, MaxToughness);
-            }
-            else
-            {
-                throw new ArgumentException(nameof(T));
-            }
-
-            return result;
+            return (TargetType)(ParquetParent)new Block(ID, Name, AddsToBiome, GatherTool, GatherEffect, ItemID,
+                                               CollectibleID, IsFlammable, IsLiquid, MaxToughness);
         }
     }
 }

--- a/ParquetCSVImporter/Shims/CollectibleShim.cs
+++ b/ParquetCSVImporter/Shims/CollectibleShim.cs
@@ -1,7 +1,7 @@
-using System;
 using ParquetClassLibrary;
 using ParquetClassLibrary.Sandbox.IDs;
 using ParquetClassLibrary.Sandbox.Parquets;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetCSVImporter.Shims
 {
@@ -28,25 +28,13 @@ namespace ParquetCSVImporter.Shims
         /// <summary>
         /// Converts a shim into the class is corresponds to.
         /// </summary>
-        /// <typeparam name="T">The type to convert this shim to.</typeparam>
+        /// <typeparam name="TargetType">The type to convert this shim to.</typeparam>
         /// <returns>An instance of a child class of <see cref="ParquetParent"/>.</returns>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown when the current shim does not correspond to the specified type.
-        /// </exception>
-        public override T To<T>()
+        public override TargetType To<TargetType>()
         {
-            T result;
+            Precondition.IsOfType<TargetType, Collectible>(typeof(TargetType).ToString());
 
-            if (typeof(T) == typeof(Collectible))
-            {
-                result = (T)(ParquetParent)new Collectible(ID, Name, AddsToBiome, Effect, EffectAmount, ItemID);
-            }
-            else
-            {
-                throw new ArgumentException(nameof(T));
-            }
-
-            return result;
+            return (TargetType)(ParquetParent)new Collectible(ID, Name, AddsToBiome, Effect, EffectAmount, ItemID); ;
         }
     }
 }

--- a/ParquetCSVImporter/Shims/FloorShim.cs
+++ b/ParquetCSVImporter/Shims/FloorShim.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using ParquetClassLibrary.Items;
+﻿using ParquetClassLibrary.Items;
 using ParquetClassLibrary.Sandbox.Parquets;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetCSVImporter.Shims
 {
@@ -24,25 +24,13 @@ namespace ParquetCSVImporter.Shims
         /// <summary>
         /// Converts a shim into the class is corresponds to.
         /// </summary>
-        /// <typeparam name="T">The type to convert this shim to.</typeparam>
+        /// <typeparam name="TargetType">The type to convert this shim to.</typeparam>
         /// <returns>An instance of a child class of <see cref="ParquetParent"/>.</returns>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown when the current shim does not correspond to the specified type.
-        /// </exception>
-        public override T To<T>()
+        public override TargetType To<TargetType>()
         {
-            T result;
+            Precondition.IsOfType<TargetType, Floor>(typeof(TargetType).ToString());
 
-            if (typeof(T) == typeof(Floor))
-            {
-                result = (T)(ParquetParent)new Floor(ID, Name, AddsToBiome, ModTool, TrenchName, IsWalkable);
-            }
-            else
-            {
-                throw new ArgumentException(nameof(T));
-            }
-
-            return result;
+            return (TargetType)(ParquetParent)new Floor(ID, Name, AddsToBiome, ModTool, TrenchName, IsWalkable);
         }
     }
 }

--- a/ParquetCSVImporter/Shims/FurnishingShim.cs
+++ b/ParquetCSVImporter/Shims/FurnishingShim.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using ParquetClassLibrary;
+﻿using ParquetClassLibrary;
 using ParquetClassLibrary.Sandbox.Parquets;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetCSVImporter.Shims
 {
@@ -30,26 +30,14 @@ namespace ParquetCSVImporter.Shims
         /// <summary>
         /// Converts a shim into the class is corresponds to.
         /// </summary>
-        /// <typeparam name="T">The type to convert this shim to.</typeparam>
+        /// <typeparam name="TargetType">The type to convert this shim to.</typeparam>
         /// <returns>An instance of a child class of <see cref="ParquetParent"/>.</returns>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown when the current shim does not correspond to the specified type.
-        /// </exception>
-        public override T To<T>()
+        public override TargetType To<TargetType>()
         {
-            T result;
+            Precondition.IsOfType<TargetType, Floor>(typeof(TargetType).ToString());
 
-            if (typeof(T) == typeof(Furnishing))
-            {
-                result = (T)(ParquetParent)new Furnishing(ID, Name, AddsToBiome, IsWalkable,
-                                                          IsEntry, IsEnclosing, SwapID);
-            }
-            else
-            {
-                throw new ArgumentException(nameof(T));
-            }
-
-            return result;
+            return (TargetType)(ParquetParent)new Furnishing(ID, Name, AddsToBiome, IsWalkable,
+                                                             IsEntry, IsEnclosing, SwapID);
         }
     }
 }

--- a/ParquetClassLibrary/Characters/Being.cs
+++ b/ParquetClassLibrary/Characters/Being.cs
@@ -43,24 +43,9 @@ namespace ParquetClassLibrary.Characters
                         Behavior in_primaryBehavior, List<EntityID> in_avoids = null, List<EntityID> in_seeks = null)
             : base(in_bounds, in_id, in_name)
         {
-            if (!All.BeingIDs.ContainsRange(in_bounds))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_bounds));
-            }
-            foreach (var parquetID in in_avoids ?? Enumerable.Empty<EntityID>())
-            {
-                if (!parquetID.IsValidForRange(All.ParquetIDs))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(in_avoids));
-                }
-            }
-            foreach (var parquetID in in_seeks ?? Enumerable.Empty<EntityID>())
-            {
-                if (!parquetID.IsValidForRange(All.ParquetIDs))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(in_seeks));
-                }
-            }
+            Precondition.IsInRange(in_bounds, All.BeingIDs, nameof(in_bounds));
+            Precondition.AreInRange(in_avoids, All.ParquetIDs, nameof(in_avoids));
+            Precondition.AreInRange(in_seeks, All.ParquetIDs, nameof(in_seeks));
 
             NativeBiome = in_nativeBiome;
             PrimaryBehavior = in_primaryBehavior;

--- a/ParquetClassLibrary/Characters/Character.cs
+++ b/ParquetClassLibrary/Characters/Character.cs
@@ -56,26 +56,17 @@ namespace ParquetClassLibrary.Characters
                             string in_pronoun = DefaultPronoun)
             : base(in_bounds, in_id, in_name, in_nativeBiome, in_primaryBehavior, in_avoids, in_seeks)
         {
-            foreach (var questID in in_quests ?? Enumerable.Empty<EntityID>())
-            {
-                if (!questID.IsValidForRange(All.QuestIDs))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(in_quests));
-                }
-            }
-            foreach (var itemID in in_inventory ?? Enumerable.Empty<EntityID>())
-            {
-                if (!itemID.IsValidForRange(All.ItemIDs))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(in_inventory));
-                }
-            }
             var nonNullPronoun = string.IsNullOrEmpty(in_pronoun) ? DefaultPronoun : in_pronoun;
+            var nonNullQuests = in_quests ?? Enumerable.Empty<EntityID>();
+            var nonNullInventory = in_inventory ?? Enumerable.Empty<EntityID>();
+
+            Precondition.AreInRange(nonNullQuests, All.QuestIDs, nameof(in_quests));
+            Precondition.AreInRange(nonNullInventory, All.ItemIDs, nameof(in_inventory));
 
             Pronoun = nonNullPronoun;
-            Quests.AddRange(in_quests ?? Enumerable.Empty<EntityID>());
+            Quests.AddRange(nonNullQuests);
             Dialogue.AddRange(in_dialogue ?? Enumerable.Empty<string>());
-            Inventory.AddRange(in_inventory ?? Enumerable.Empty<EntityID>());
+            Inventory.AddRange(nonNullInventory);
         }
         #endregion
     }

--- a/ParquetClassLibrary/Characters/Critter.cs
+++ b/ParquetClassLibrary/Characters/Critter.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using ParquetClassLibrary.Sandbox.IDs;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Characters
 {
@@ -25,10 +25,7 @@ namespace ParquetClassLibrary.Characters
                        List<EntityID> in_avoids = null, List<EntityID> in_seeks = null)
             : base(All.CritterIDs, in_id, in_name, in_nativeBiome, in_primaryBehavior, in_avoids, in_seeks)
         {
-            if (!in_id.IsValidForRange(All.CritterIDs))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_id));
-            }
+            Precondition.IsInRange(in_id, All.CritterIDs, nameof(in_id));
         }
     }
 }

--- a/ParquetClassLibrary/Characters/NPC.cs
+++ b/ParquetClassLibrary/Characters/NPC.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using ParquetClassLibrary.Sandbox;
 using ParquetClassLibrary.Sandbox.IDs;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Characters
 {
@@ -33,10 +34,7 @@ namespace ParquetClassLibrary.Characters
             : base(All.NpcIDs, in_id, in_name, in_nativeBiome, in_currentBehavior,
                    in_avoids, in_seeks, in_quests, in_dialogue, in_inventory, in_pronoun)
         {
-            if (!in_id.IsValidForRange(All.NpcIDs))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_id));
-            }
+            Precondition.IsInRange(in_id, All.NpcIDs, nameof(in_id));
         }
     }
 }

--- a/ParquetClassLibrary/Crafting/CraftingElement.cs
+++ b/ParquetClassLibrary/Crafting/CraftingElement.cs
@@ -1,5 +1,6 @@
 using System;
 using ParquetClassLibrary.Items;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Crafting
 {
@@ -24,14 +25,8 @@ namespace ParquetClassLibrary.Crafting
         /// <param name="in_itemAmount">In amount of the <see cref="Item"/>.  Must be positive.</param>
         public CraftingElement(EntityID in_itemID, int in_itemAmount)
         {
-            if (!in_itemID.IsValidForRange(All.ItemIDs))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_itemID));
-            }
-            if (in_itemAmount < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_itemAmount));
-            }
+            Precondition.IsInRange(in_itemID, All.ItemIDs, nameof(in_itemID));
+            Precondition.MustBePositive(in_itemAmount, nameof(in_itemAmount));
 
             ItemID = in_itemID;
             ItemAmount = in_itemAmount;

--- a/ParquetClassLibrary/Crafting/CraftingRecipe.cs
+++ b/ParquetClassLibrary/Crafting/CraftingRecipe.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Crafting
 {
@@ -48,32 +49,17 @@ namespace ParquetClassLibrary.Crafting
                               List<CraftingElement> in_ingredients, StrikePanel[,] in_panelPattern)
             : base(All.CraftingRecipeIDs, in_id, in_name)
         {
-            if (null == in_products)
-            {
-                throw new ArgumentNullException(nameof(in_products));
-            }
-            if (in_products.Count < 1)
-            {
-                throw new IndexOutOfRangeException(nameof(in_products));
-            }
-            if (null == in_ingredients)
-            {
-                throw new ArgumentNullException(nameof(in_ingredients));
-            }
-            if (in_ingredients.Count < 1)
-            {
-                throw new IndexOutOfRangeException(nameof(in_ingredients));
-            }
-            if (null == in_panelPattern)
-            {
-                throw new ArgumentNullException(nameof(in_panelPattern));
-            }
+            Precondition.IsNotNull(in_products, nameof(in_products));
+            Precondition.IsNotEmpty(in_products, nameof(in_products));
+            Precondition.IsNotNull(in_ingredients, nameof(in_ingredients));
+            Precondition.IsNotEmpty(in_ingredients, nameof(in_ingredients));
+            Precondition.IsNotNull(in_panelPattern, nameof(in_panelPattern));
             if (in_panelPattern.GetLength(0) > All.Dimensions.PanelsPerPatternWidth
                 || in_panelPattern.GetLength(1) > All.Dimensions.PanelsPerPatternHeight
                 || in_panelPattern.GetLength(0) < 1
                 || in_panelPattern.GetLength(1) < 1)
             {
-                throw new IndexOutOfRangeException(nameof(in_panelPattern));
+                throw new IndexOutOfRangeException($"Dimension outside specification: {nameof(in_panelPattern)}");
             }
 
             Products = in_products;

--- a/ParquetClassLibrary/Crafting/CraftingRecipe.cs
+++ b/ParquetClassLibrary/Crafting/CraftingRecipe.cs
@@ -36,11 +36,6 @@ namespace ParquetClassLibrary.Crafting
         /// <param name="in_products">The types and quantities of <see cref="Items.Item"/>s created by following this recipe once.</param>
         /// <param name="in_ingredients">All items needed to follow this <see cref="CraftingRecipe"/> once.</param>
         /// <param name="in_panelPattern">The arrangment of panels encompassed by this <see cref="CraftingRecipe"/>.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="in_products"/> is null.</exception>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="in_ingredients"/> is null.</exception>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="in_panelPattern"/> is null.</exception>
-        /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="in_products"/> is empty.</exception>
-        /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="in_ingredients"/> is empty.</exception>
         /// <exception cref="IndexOutOfRangeException">
         /// Thrown when <paramref name="in_panelPattern"/> has zero-dimensions or dimensions larger than those given by
         /// <see cref="All.Dimensions.PanelsPerPatternWidth"/> and <see cref="All.Dimensions.PanelsPerPatternHeight"/>.

--- a/ParquetClassLibrary/Crafting/StrikePanel.cs
+++ b/ParquetClassLibrary/Crafting/StrikePanel.cs
@@ -43,10 +43,6 @@ namespace ParquetClassLibrary.Crafting
         /// The range of values this panel targets for a completed craft.
         /// The values must fall within the range of <c see="WorkingRange"/>.
         /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown when the either the <see cref="Range{T}.Maximum"/> or <see cref="Range{T}.Minimum"/> are beyond
-        /// the range specified in <c see="WorkingRange"/>.
-        /// </exception>
         public Range<int> IdealRange
         {
             get => _idealRange;

--- a/ParquetClassLibrary/Crafting/StrikePanel.cs
+++ b/ParquetClassLibrary/Crafting/StrikePanel.cs
@@ -52,9 +52,13 @@ namespace ParquetClassLibrary.Crafting
             get => _idealRange;
             set
             {
-                if (!WorkingRange.ContainsRange(value))
+                if (value.Maximum > WorkingRange.Maximum)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(IdealRange));
+                    value.Maximum = WorkingRange.Maximum;
+                }
+                if (value.Minimum < WorkingRange.Minimum)
+                {
+                    value.Minimum = WorkingRange.Minimum;
                 }
 
                 _idealRange = value;

--- a/ParquetClassLibrary/Entity.cs
+++ b/ParquetClassLibrary/Entity.cs
@@ -42,14 +42,8 @@ namespace ParquetClassLibrary
         [JsonConstructor]
         protected Entity(Range<EntityID> in_bounds, EntityID in_id, string in_name)
         {
-            if (!in_id.IsValidForRange(in_bounds))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_id));
-            }
-            if (string.IsNullOrEmpty(in_name))
-            {
-                throw new ArgumentNullException(nameof(in_name));
-            }
+            Precondition.IsInRange(in_id, in_bounds, nameof(in_id));
+            Precondition.IsNotEmpty(in_name, nameof(in_name));
 
             ID = in_id;
             Name = in_name;

--- a/ParquetClassLibrary/EntityCollection.cs
+++ b/ParquetClassLibrary/EntityCollection.cs
@@ -33,7 +33,7 @@ namespace ParquetClassLibrary
         {
             if (!in_bounds.IsValid())
             {
-                throw new ArgumentException(nameof(in_bounds));
+                throw new ArgumentException($"Invalid bounds given: {nameof(in_bounds)}");
             }
 
             Bounds = in_bounds;
@@ -49,14 +49,8 @@ namespace ParquetClassLibrary
         /// <returns><c>true</c> if the <see cref="Entity"/> was added successfully; <c>false</c> otherwise.</returns>
         public bool Add(Entity in_entity)
         {
-            if (null == in_entity)
-            {
-                throw new ArgumentNullException(nameof(in_entity));
-            }
-            if (!in_entity.ID.IsValidForRange(Bounds))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_entity.ID));
-            }
+            Precondition.IsNotNull(in_entity, nameof(in_entity));
+            Precondition.IsInRange(in_entity.ID, Bounds, nameof(in_entity));
 
             var isNew = !Entities.ContainsKey(in_entity.ID);
 
@@ -79,12 +73,9 @@ namespace ParquetClassLibrary
         /// <returns><c>true</c> if all of the <see cref="Entity"/>s were added successfully; <c>false</c> otherwise.</returns>
         public bool AddRange(IEnumerable<Entity> in_entities)
         {
-            var succeeded = true;
+            Precondition.IsNotNull(in_entities, nameof(in_entities));
 
-            if (null == in_entities)
-            {
-                throw new ArgumentNullException(nameof(in_entities));
-            }
+            var succeeded = true;
 
             foreach (var entity in in_entities)
             {
@@ -112,10 +103,7 @@ namespace ParquetClassLibrary
         /// <remarks>This method is equivalent to <see cref="Dictionary{EntityID, Entity}.ContainsKey"/>.</remarks>
         public bool Contains(EntityID in_id)
         {
-            if (!in_id.IsValidForRange(Bounds))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_id));
-            }
+            Precondition.IsInRange(in_id, Bounds, nameof(in_id));
 
             return Entities.ContainsKey(in_id);
         }
@@ -143,10 +131,7 @@ namespace ParquetClassLibrary
         /// </returns>
         public bool Remove(EntityID in_id)
         {
-            if (!in_id.IsValidForRange(Bounds))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_id));
-            }
+            Precondition.IsInRange(in_id, Bounds, nameof(in_id));
 
             return Entities.Remove(in_id);
         }
@@ -161,10 +146,7 @@ namespace ParquetClassLibrary
         /// <returns>The specified <typeparamref name="T"/>.</returns>
         public T Get<T>(EntityID in_id) where T : ParentType
         {
-            if (!in_id.IsValidForRange(Bounds))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_id));
-            }
+            Precondition.IsInRange(in_id, Bounds, nameof(in_id));
 
             return (T)Entities[in_id];
         }

--- a/ParquetClassLibrary/EntityCollection.cs
+++ b/ParquetClassLibrary/EntityCollection.cs
@@ -31,11 +31,6 @@ namespace ParquetClassLibrary
         /// <param name="in_bounds">The bounds within which the collected <see cref="EntityID"/>s are defined.</param>
         public EntityCollection(List<Range<EntityID>> in_bounds)
         {
-            if (!in_bounds.IsValid())
-            {
-                throw new ArgumentException($"Invalid bounds given: {nameof(in_bounds)}");
-            }
-
             Bounds = in_bounds;
             Entities = new Dictionary<EntityID, Entity> { { EntityID.None, null } };
         }

--- a/ParquetClassLibrary/EntityID.cs
+++ b/ParquetClassLibrary/EntityID.cs
@@ -114,7 +114,11 @@ namespace ParquetClassLibrary
 
             foreach (var idRange in in_ranges)
             {
-                result |= IsValidForRange(idRange);
+                if (IsValidForRange(idRange))
+                {
+                    result = true;
+                    break;
+                }
             }
 
             return result;

--- a/ParquetClassLibrary/Items/Item.cs
+++ b/ParquetClassLibrary/Items/Item.cs
@@ -70,10 +70,8 @@ namespace ParquetClassLibrary.Items
                     KeyItem in_asKeyItem, EntityID? in_recipeID = null) : base(All.ItemIDs, in_id, in_name)
         {
             Precondition.IsInRange(in_asParquet, All.ParquetIDs, nameof(in_asParquet));
-            if (in_stackMax < 1)
-            {
-                throw new ArgumentOutOfRangeException($"{nameof(in_stackMax)} cannot be 0 or less.");
-            }
+            Precondition.MustBePositive(in_stackMax, nameof(in_stackMax));
+
             // TODO Do we need to bounds-check in_effectWhileHeld?  If so, add a unit test.
             // TODO Do we need to bounds-check in_effectWhenUsed?  If so, add a unit test.
             /* TODO This check is a good idea but it is improper to get a specific entityfrom All

--- a/ParquetClassLibrary/Items/Item.cs
+++ b/ParquetClassLibrary/Items/Item.cs
@@ -1,6 +1,7 @@
 using System;
 using Newtonsoft.Json;
 using ParquetClassLibrary.Crafting;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Items
 {
@@ -68,18 +69,14 @@ namespace ParquetClassLibrary.Items
                     int in_stackMax, int in_effectWhileHeld, int in_effectWhenUsed, EntityID in_asParquet,
                     KeyItem in_asKeyItem, EntityID? in_recipeID = null) : base(All.ItemIDs, in_id, in_name)
         {
-            if (!in_asParquet.IsValidForRange(All.ParquetIDs))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_id));
-            }
+            Precondition.IsInRange(in_asParquet, All.ParquetIDs, nameof(in_asParquet));
             if (in_stackMax < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(in_stackMax));
+                throw new ArgumentOutOfRangeException($"{nameof(in_stackMax)} cannot be 0 or less.");
             }
             // TODO Do we need to bounds-check in_effectWhileHeld?  If so, add a unit test.
             // TODO Do we need to bounds-check in_effectWhenUsed?  If so, add a unit test.
-            var nonNullCraftingRecipeID = in_recipeID ?? CraftingRecipe.NotCraftable.ID;
-            /* TODO This check is a good idea but it is improper to call an All entity collection
+            /* TODO This check is a good idea but it is improper to get a specific entityfrom All
              * during initialization of an entity.  If we are to include this functionality another
              * means of implementing it must be found.
             if (nonNullCraftingRecipeID != CraftingRecipe.NotCraftable.ID)
@@ -100,6 +97,8 @@ namespace ParquetClassLibrary.Items
                 }
             }
             */
+
+            var nonNullCraftingRecipeID = in_recipeID ?? CraftingRecipe.NotCraftable.ID;
 
             Subtype = in_subtype;
             Price = in_price;

--- a/ParquetClassLibrary/Sandbox/Parquets/Block.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Block.cs
@@ -78,15 +78,10 @@ namespace ParquetClassLibrary.Sandbox.Parquets
                      : base(Bounds, in_id, in_name, in_addsToBiome)
         {
             var nonNullCollectibleID = in_collectibleID ?? EntityID.None;
-            if (!nonNullCollectibleID.IsValidForRange(All.CollectibleIDs))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_collectibleID));
-            }
             var nonNullItemID = in_itemID ?? EntityID.None;
-            if (!nonNullItemID.IsValidForRange(All.ItemIDs))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_itemID));
-            }
+
+            Precondition.IsInRange(nonNullCollectibleID, All.CollectibleIDs, nameof(in_collectibleID));
+            Precondition.IsInRange(nonNullItemID, All.ItemIDs, nameof(in_itemID));
 
             GatherTool = in_gatherTool;
             GatherEffect = in_gatherEffect;

--- a/ParquetClassLibrary/Sandbox/Parquets/Collectible.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Collectible.cs
@@ -55,10 +55,8 @@ namespace ParquetClassLibrary.Sandbox.Parquets
             : base(Bounds, in_id, in_name, in_addsToBiome)
         {
             var nonNullItemID = in_itemID ?? EntityID.None;
-            if (!nonNullItemID.IsValidForRange(All.ItemIDs))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_itemID));
-            }
+
+            Precondition.IsInRange(nonNullItemID, All.ItemIDs, nameof(in_itemID));
 
             Effect = in_effect;
             EffectAmount = in_effectAmount;

--- a/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
+++ b/ParquetClassLibrary/Sandbox/Parquets/Furnishing.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json;
 using ParquetClassLibrary.Sandbox.IDs;
 using ParquetClassLibrary.Utilities;
@@ -58,15 +57,10 @@ namespace ParquetClassLibrary.Sandbox.Parquets
             : base(Bounds, in_id, in_name, in_addsToBiome)
         {
             var nonNullItemID = in_itemID ?? EntityID.None;
-            if (!nonNullItemID.IsValidForRange(All.ItemIDs))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_itemID));
-            }
             var nonNullSwapID = in_swapID ?? EntityID.None;
-            if (!nonNullSwapID.IsValidForRange(Bounds))
-            {
-                throw new ArgumentOutOfRangeException(nameof(in_swapID));
-            }
+
+            Precondition.IsInRange(nonNullItemID, All.ItemIDs, nameof(in_itemID));
+            Precondition.IsInRange(nonNullSwapID, Bounds, nameof(in_swapID));
 
             IsWalkable = in_isWalkable;
             IsEntry = in_isEntry;

--- a/ParquetClassLibrary/Sandbox/Room.cs
+++ b/ParquetClassLibrary/Sandbox/Room.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ParquetClassLibrary.Sandbox.Parquets;
 using ParquetClassLibrary.Stubs;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Sandbox
 {
@@ -95,24 +96,21 @@ namespace ParquetClassLibrary.Sandbox
         /// </param>
         public Room(HashSet<Space> in_walkableArea, HashSet<Space> in_perimeter)
         {
-            if (null == in_walkableArea)
-            {
-                throw new ArgumentNullException(nameof(in_walkableArea));
-            }
+            Precondition.IsNotNull(in_walkableArea, nameof(in_walkableArea));
+            Precondition.IsNotNull(in_perimeter, nameof(in_perimeter));
+
             if (in_walkableArea.Count < All.Recipes.Rooms.MinWalkableSpaces
                 || in_walkableArea.Count > All.Recipes.Rooms.MaxWalkableSpaces)
             {
                 throw new IndexOutOfRangeException(nameof(in_walkableArea));
             }
-            if (null == in_perimeter)
-            {
-                throw new ArgumentNullException(nameof(in_perimeter));
-            }
+
             var minimumPossiblePerimeterLength = (2 * in_walkableArea.Count) + 2;
             if (in_perimeter.Count < minimumPossiblePerimeterLength)
             {
-                throw new IndexOutOfRangeException(nameof(in_perimeter));
+                throw new IndexOutOfRangeException($"{nameof(in_perimeter)} is too small to surround {nameof(in_walkableArea)}.");
             }
+
             if (!in_walkableArea.Concat(in_perimeter).Any(space
                 => null != space.Content.Furnishing
                 && space.Content.Furnishing.IsEntry))

--- a/ParquetClassLibrary/Sandbox/RoomRecipe.cs
+++ b/ParquetClassLibrary/Sandbox/RoomRecipe.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetClassLibrary.Sandbox
 {
@@ -54,39 +55,15 @@ namespace ParquetClassLibrary.Sandbox
                           List<EntityID> in_optionallyRequiredPerimeterBlocks = null)
             : base (All.RoomRecipeIDs, in_id, in_name)
         {
+            Precondition.AreInRange(in_optionallyRequiredWalkableFloors, All.FloorIDs, nameof(in_optionallyRequiredWalkableFloors));
+            Precondition.AreInRange(in_optionallyRequiredPerimeterBlocks, All.BlockIDs, nameof(in_optionallyRequiredPerimeterBlocks));
+            Precondition.IsNotNull(in_requiredFurnishings, nameof(in_requiredFurnishings));
+            Precondition.IsNotEmpty(in_requiredFurnishings, nameof(in_requiredFurnishings));
+            Precondition.AreInRange(in_requiredFurnishings.Keys, All.FurnishingIDs, nameof(in_requiredFurnishings));
             if (in_MinimumWalkableSpaces < All.Recipes.Rooms.MinWalkableSpaces
                 || in_MinimumWalkableSpaces > All.Recipes.Rooms.MaxWalkableSpaces)
             {
                 throw new ArgumentOutOfRangeException(nameof(in_MinimumWalkableSpaces));
-            }
-            foreach (var floorID in in_optionallyRequiredWalkableFloors ?? Enumerable.Empty<EntityID>())
-            {
-                if (!floorID.IsValidForRange(All.FloorIDs))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(in_optionallyRequiredWalkableFloors));
-                }
-            }
-            foreach (var wallID in in_optionallyRequiredPerimeterBlocks ?? Enumerable.Empty<EntityID>())
-            {
-                if (!wallID.IsValidForRange(All.BlockIDs))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(in_optionallyRequiredPerimeterBlocks));
-                }
-            }
-            if (null == in_requiredFurnishings)
-            {
-                throw new ArgumentNullException(nameof(in_requiredFurnishings));
-            }
-            if (in_requiredFurnishings.Count < 1)
-            {
-                throw new IndexOutOfRangeException(nameof(in_requiredFurnishings));
-            }
-            foreach (var furnishingID in in_requiredFurnishings.Keys)
-            {
-                if (!furnishingID.IsValidForRange(All.FurnishingIDs))
-                {
-                    throw new ArgumentOutOfRangeException(nameof(in_requiredFurnishings));
-                }
             }
 
             MinimumWalkableSpaces = in_MinimumWalkableSpaces;

--- a/ParquetClassLibrary/Utilities/Precondition.cs
+++ b/ParquetClassLibrary/Utilities/Precondition.cs
@@ -68,6 +68,19 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
+        internal static void AreInRange(IEnumerable<EntityID> in_enumerable, Range<EntityID> in_bounds,
+                                        string in_argumentName = DefaultArgumentName)
+        {
+            foreach (var id in in_enumerable ?? Enumerable.Empty<EntityID>())
+            {
+                if (!id.IsValidForRange(in_bounds))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        $"{in_argumentName}: {id} is not within {in_bounds}.");
+                }
+            }
+        }
+
         internal static void IsNotEmpty(string in_string, string in_argumentName = DefaultArgumentName)
         {
             if (string.IsNullOrEmpty(in_string))

--- a/ParquetClassLibrary/Utilities/Precondition.cs
+++ b/ParquetClassLibrary/Utilities/Precondition.cs
@@ -55,6 +55,18 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
+        /// <exception cref="System.InvalidOperationException">
+        /// Thrown when <typeparamref name="TypeToCheck"/> does not correspond to <typeparamref name="TargetType"/>.
+        /// </exception>
+        public static void IsOfType<TypeToCheck, TargetType>(string in_parameter = DefaultArgumentName)
+        {
+            if (typeof(TypeToCheck) != typeof(TargetType))
+            {
+                throw new InvalidOperationException(
+                    $"{in_parameter} is of type {typeof(TypeToCheck)} but must be of type {typeof(TargetType)}.");
+            }
+        }
+
         internal static void AreInRange(IEnumerable<EntityID> in_enumerable, List<Range<EntityID>> in_bounds,
                                         string in_argumentName = DefaultArgumentName)
         {
@@ -81,14 +93,24 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
+        internal static void MustBePositive(int in_number, string in_argumentName = DefaultArgumentName)
+        {
+            if (in_number < 1)
+            {
+                throw new ArgumentOutOfRangeException($"{in_argumentName} must be a positive number.");
+            }
+        }
+
+        /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="in_string"/> is null or empty.</exception>
         internal static void IsNotEmpty(string in_string, string in_argumentName = DefaultArgumentName)
         {
             if (string.IsNullOrEmpty(in_string))
             {
-                throw new ArgumentNullException($"{in_argumentName} is null or empty.");
+                throw new IndexOutOfRangeException($"{in_argumentName} is null or empty.");
             }
         }
 
+        /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="in_enumerable"/> is null or empty.</exception>
         internal static void IsNotEmpty<T>(IEnumerable<T> in_enumerable, string in_argumentName = DefaultArgumentName)
         {
             if (!in_enumerable?.Any() ?? false)
@@ -97,6 +119,7 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="in_reference"/> is null.</exception>
         internal static void IsNotNull(object in_reference, string in_argumentName = DefaultArgumentName)
         {
             if (null == in_reference)

--- a/ParquetClassLibrary/Utilities/Precondition.cs
+++ b/ParquetClassLibrary/Utilities/Precondition.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ParquetClassLibrary.Utilities
+{
+    /// <summary>
+    /// Provides constructors and initialization routines with concise arugment boilerplate.
+    /// </summary>
+    public static class Precondition
+    {
+        /// <summary>Text to use when no argument name is provided.</summary>
+        private const string DefaultArgumentName = "Argument";
+
+        // TODO: XML comment these methods.
+        // TODO: Ensure that this is the only file that documents what it throws.
+
+
+        internal static void IsInRange(EntityID in_id, Range<EntityID> in_bounds,
+                                       string in_argumentName = DefaultArgumentName)
+        {
+            if (!in_id.IsValidForRange(in_bounds))
+            {
+                throw new ArgumentOutOfRangeException($"{in_argumentName}: {in_id} is not within {in_bounds}.");
+            }
+        }
+
+        internal static void IsInRange(Range<EntityID> in_innerBounds, Range<EntityID> in_outerBounds,
+                                       string in_argumentName = DefaultArgumentName)
+        {
+            if (!in_outerBounds.ContainsRange(in_innerBounds))
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"{in_argumentName}: {in_innerBounds} is not within {in_outerBounds}.");
+            }
+        }
+
+        internal static void IsInRange(EntityID in_id, List<Range<EntityID>> in_boundsCollection,
+                                       string in_argumentName = DefaultArgumentName)
+        {
+            if (!in_id.IsValidForRange(in_boundsCollection))
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"{in_argumentName}: {in_id} is not within {in_boundsCollection}.");
+            }
+        }
+
+        internal static void IsInRange(Range<EntityID> in_innerBounds, List<Range<EntityID>> in_boundsCollection,
+                                       string in_argumentName = DefaultArgumentName)
+        {
+            if (!in_boundsCollection.ContainsRange(in_innerBounds))
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"{in_argumentName}: {in_innerBounds} is not within {in_boundsCollection}.");
+            }
+        }
+
+        internal static void AreInRange(IEnumerable<EntityID> in_enumerable, List<Range<EntityID>> in_bounds,
+                                        string in_argumentName = DefaultArgumentName)
+        {
+            foreach (var id in in_enumerable ?? Enumerable.Empty<EntityID>())
+            {
+                if (!id.IsValidForRange(in_bounds))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        $"{in_argumentName}: {id} is not within {in_bounds}.");
+                }
+            }
+        }
+
+        internal static void IsNotEmpty(string in_string, string in_argumentName = DefaultArgumentName)
+        {
+            if (string.IsNullOrEmpty(in_string))
+            {
+                throw new ArgumentNullException($"{in_argumentName} is null or empty.");
+            }
+        }
+
+        internal static void IsNotEmpty<T>(IEnumerable<T> in_enumerable, string in_argumentName = DefaultArgumentName)
+        {
+            if (!in_enumerable?.Any() ?? false)
+            {
+                throw new IndexOutOfRangeException($"{in_argumentName} is empty.");
+            }
+        }
+
+        internal static void IsNotNull(object in_reference, string in_argumentName = DefaultArgumentName)
+        {
+            if (null == in_reference)
+            {
+                throw new ArgumentNullException($"{in_argumentName} is null.");
+            }
+        }
+    }
+}

--- a/ParquetClassLibrary/Utilities/Precondition.cs
+++ b/ParquetClassLibrary/Utilities/Precondition.cs
@@ -9,15 +9,20 @@ namespace ParquetClassLibrary.Utilities
     /// </summary>
     public static class Precondition
     {
+        #region Class Defaults
         /// <summary>Text to use when no argument name is provided.</summary>
         private const string DefaultArgumentName = "Argument";
+        #endregion
 
-        // TODO: XML comment these methods.
-        // TODO: Ensure that this is the only file that documents what it throws.
-
-
-        internal static void IsInRange(EntityID in_id, Range<EntityID> in_bounds,
-                                       string in_argumentName = DefaultArgumentName)
+        /// <summary>
+        /// Checks if the given <see cref="EntityID"/> falls within the given <see cref="Range{T}"/>.
+        /// </summary>
+        /// <param name="in_id">The identifier to test.</param>
+        /// <param name="in_bounds">The range it must fall within.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <exception cref="ArgumentOutOfRangeException">When the identifier is not in range.</exception>
+        public static void IsInRange(EntityID in_id, Range<EntityID> in_bounds,
+                                     string in_argumentName = DefaultArgumentName)
         {
             if (!in_id.IsValidForRange(in_bounds))
             {
@@ -25,8 +30,15 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
-        internal static void IsInRange(Range<EntityID> in_innerBounds, Range<EntityID> in_outerBounds,
-                                       string in_argumentName = DefaultArgumentName)
+        /// <summary>
+        /// Checks if the first given <see cref="Range{T}"/> falls within the second given <see cref="Range{T}"/>.
+        /// </summary>
+        /// <param name="in_innerBounds">The range to test.</param>
+        /// <param name="in_outerBounds">The range it must fall within.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <exception cref="ArgumentOutOfRangeException">When the first range is not in the second range.</exception>
+        public static void IsInRange(Range<EntityID> in_innerBounds, Range<EntityID> in_outerBounds,
+                                     string in_argumentName = DefaultArgumentName)
         {
             if (!in_outerBounds.ContainsRange(in_innerBounds))
             {
@@ -35,8 +47,16 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
-        internal static void IsInRange(EntityID in_id, List<Range<EntityID>> in_boundsCollection,
-                                       string in_argumentName = DefaultArgumentName)
+        /// <summary>
+        /// Checks if the first given <see cref="EntityID"/> falls within at least one of the
+        /// given collection of <see cref="Range{T}"/>s.
+        /// </summary>
+        /// <param name="in_id">The identifier to test.</param>
+        /// <param name="in_boundsCollection">The collection of ranges it must fall within.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <exception cref="ArgumentOutOfRangeException">When the identifier is not in any of the ranges.</exception>
+        public static void IsInRange(EntityID in_id, List<Range<EntityID>> in_boundsCollection,
+                                     string in_argumentName = DefaultArgumentName)
         {
             if (!in_id.IsValidForRange(in_boundsCollection))
             {
@@ -45,8 +65,16 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
-        internal static void IsInRange(Range<EntityID> in_innerBounds, List<Range<EntityID>> in_boundsCollection,
-                                       string in_argumentName = DefaultArgumentName)
+        /// <summary>
+        /// Checks if the given <see cref="Range{T}"/> falls within at least one of the
+        /// given collection of <see cref="Range{T}"/>s.
+        /// </summary>
+        /// <param name="in_innerBounds">The range to test.</param>
+        /// <param name="in_boundsCollection">The collection of ranges it must fall within.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <exception cref="ArgumentOutOfRangeException">When the first range is not in the second range.</exception>
+        public static void IsInRange(Range<EntityID> in_innerBounds, List<Range<EntityID>> in_boundsCollection,
+                                     string in_argumentName = DefaultArgumentName)
         {
             if (!in_boundsCollection.ContainsRange(in_innerBounds))
             {
@@ -55,45 +83,71 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
+        /// <summary>
+        /// Verifies that the first given <see langword="type"/> is or is derived from
+        /// the second given <see langword="type"/>.
+        /// </summary>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <typeparam name="TypeToCheck">The type to check.</typeparam>
+        /// <typeparam name="TargetType">The type of which it must be a subtype.</typeparam>
         /// <exception cref="System.InvalidOperationException">
         /// Thrown when <typeparamref name="TypeToCheck"/> does not correspond to <typeparamref name="TargetType"/>.
         /// </exception>
-        public static void IsOfType<TypeToCheck, TargetType>(string in_parameter = DefaultArgumentName)
+        public static void IsOfType<TypeToCheck, TargetType>(string in_argumentName = DefaultArgumentName)
         {
             if (typeof(TypeToCheck) != typeof(TargetType))
             {
-                throw new InvalidOperationException(
-                    $"{in_parameter} is of type {typeof(TypeToCheck)} but must be of type {typeof(TargetType)}.");
+                throw new InvalidCastException(
+                    $"{in_argumentName} is of type {typeof(TypeToCheck)} but must be of type {typeof(TargetType)}.");
             }
         }
 
-        internal static void AreInRange(IEnumerable<EntityID> in_enumerable, List<Range<EntityID>> in_bounds,
-                                        string in_argumentName = DefaultArgumentName)
+        /// <summary>
+        /// Verifies that all of the given <see cref="EntityID"/>s fall within the given <see cref="Range{T}"/>.
+        /// </summary>
+        /// <param name="in_enumerable">The identifiers to test.</param>
+        /// <param name="in_bounds">The range they must fall within.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <exception cref="ArgumentOutOfRangeException">When the identifier is not in range.</exception>
+        public static void AreInRange(IEnumerable<EntityID> in_enumerable, Range<EntityID> in_bounds,
+                                      string in_argumentName = DefaultArgumentName)
         {
             foreach (var id in in_enumerable ?? Enumerable.Empty<EntityID>())
             {
                 if (!id.IsValidForRange(in_bounds))
                 {
-                    throw new ArgumentOutOfRangeException(
-                        $"{in_argumentName}: {id} is not within {in_bounds}.");
+                    throw new ArgumentOutOfRangeException($"{in_argumentName}: {id} is not within {in_bounds}.");
                 }
             }
         }
 
-        internal static void AreInRange(IEnumerable<EntityID> in_enumerable, Range<EntityID> in_bounds,
-                                        string in_argumentName = DefaultArgumentName)
+        /// <summary>
+        /// Verifies that all of the given <see cref="EntityID"/>s fall within the given 
+        /// collection of <see cref="Range{T}"/>s.
+        /// </summary>
+        /// <param name="in_enumerable">The identifiers to test.</param>
+        /// <param name="in_boundsCollection">The collection of ranges they must fall within.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <exception cref="ArgumentOutOfRangeException">When the identifier is not in range.</exception>
+        public static void AreInRange(IEnumerable<EntityID> in_enumerable, List<Range<EntityID>> in_boundsCollection,
+                                      string in_argumentName = DefaultArgumentName)
         {
             foreach (var id in in_enumerable ?? Enumerable.Empty<EntityID>())
             {
-                if (!id.IsValidForRange(in_bounds))
+                if (!id.IsValidForRange(in_boundsCollection))
                 {
-                    throw new ArgumentOutOfRangeException(
-                        $"{in_argumentName}: {id} is not within {in_bounds}.");
+                    throw new ArgumentOutOfRangeException($"{in_argumentName}: {id} is not within {in_boundsCollection}.");
                 }
             }
         }
 
-        internal static void MustBePositive(int in_number, string in_argumentName = DefaultArgumentName)
+        /// <summary>
+        /// Verifies that the given number is positive.
+        /// </summary>
+        /// <param name="in_number">The number to test.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <exception cref="ArgumentOutOfRangeException">When the number is zero or less.</exception>
+        public static void MustBePositive(int in_number, string in_argumentName = DefaultArgumentName)
         {
             if (in_number < 1)
             {
@@ -101,8 +155,13 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
-        /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="in_string"/> is null or empty.</exception>
-        internal static void IsNotEmpty(string in_string, string in_argumentName = DefaultArgumentName)
+        /// <summary>
+        /// Verifies that the given <see langword="string"/> is not empty.
+        /// </summary>
+        /// <param name="in_string">The string to test.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
+        /// <exception cref="IndexOutOfRangeException">When <paramref name="in_string"/> is null or empty.</exception>
+        public static void IsNotEmpty(string in_string, string in_argumentName = DefaultArgumentName)
         {
             if (string.IsNullOrEmpty(in_string))
             {
@@ -110,8 +169,13 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
+        /// <summary>
+        /// Verifies that the given <see cref="IEnumerable{T}"/> is not empty.
+        /// </summary>
+        /// <param name="in_enumerable">The collection to test.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
         /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="in_enumerable"/> is null or empty.</exception>
-        internal static void IsNotEmpty<T>(IEnumerable<T> in_enumerable, string in_argumentName = DefaultArgumentName)
+        public static void IsNotEmpty<T>(IEnumerable<T> in_enumerable, string in_argumentName = DefaultArgumentName)
         {
             if (!in_enumerable?.Any() ?? false)
             {
@@ -119,8 +183,13 @@ namespace ParquetClassLibrary.Utilities
             }
         }
 
+        /// <summary>
+        /// Verifies that the given reference is not <c>null</c>.
+        /// </summary>
+        /// <param name="in_reference">The reference to test.</param>
+        /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="in_reference"/> is null.</exception>
-        internal static void IsNotNull(object in_reference, string in_argumentName = DefaultArgumentName)
+        public static void IsNotNull(object in_reference, string in_argumentName = DefaultArgumentName)
         {
             if (null == in_reference)
             {

--- a/ParquetClassLibrary/Utilities/Precondition.cs
+++ b/ParquetClassLibrary/Utilities/Precondition.cs
@@ -84,8 +84,8 @@ namespace ParquetClassLibrary.Utilities
         }
 
         /// <summary>
-        /// Verifies that the first given <see langword="type"/> is or is derived from
-        /// the second given <see langword="type"/>.
+        /// Verifies that the first given <see langword="class"/> is or is derived from
+        /// the second given <see langword="class"/>.
         /// </summary>
         /// <param name="in_argumentName">The name of the argument to use in error reporting.</param>
         /// <typeparam name="TypeToCheck">The type to check.</typeparam>
@@ -95,7 +95,8 @@ namespace ParquetClassLibrary.Utilities
         /// </exception>
         public static void IsOfType<TypeToCheck, TargetType>(string in_argumentName = DefaultArgumentName)
         {
-            if (typeof(TypeToCheck) != typeof(TargetType))
+            if (!typeof(TypeToCheck).IsSubclassOf(typeof(TargetType))
+                && typeof(TypeToCheck) != typeof(TargetType))
             {
                 throw new InvalidCastException(
                     $"{in_argumentName} is of type {typeof(TypeToCheck)} but must be of type {typeof(TargetType)}.");

--- a/ParquetClassLibrary/Utilities/Range.cs
+++ b/ParquetClassLibrary/Utilities/Range.cs
@@ -30,7 +30,7 @@ namespace ParquetClassLibrary.Utilities
 
             if (!IsValid())
             {
-                throw new ArgumentException($"{nameof(in_minimum)} and {nameof(in_maximum)}");
+                throw new InvalidOperationException($"{nameof(in_minimum)} must be less than or equal to {nameof(in_maximum)}.");
             }
         }
 

--- a/ParquetRunner/RunnerProgram.cs
+++ b/ParquetRunner/RunnerProgram.cs
@@ -1,6 +1,7 @@
 using System;
 using ParquetClassLibrary;
 using ParquetClassLibrary.Sandbox;
+using ParquetClassLibrary.Utilities;
 
 namespace ParquetRunner
 {

--- a/ParquetRunner/RunnerProgram.cs
+++ b/ParquetRunner/RunnerProgram.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using ParquetClassLibrary;
 using ParquetClassLibrary.Sandbox;
 using ParquetClassLibrary.Utilities;

--- a/ParquetUnitTests/Utilities/PreconditionUnitTest.cs
+++ b/ParquetUnitTests/Utilities/PreconditionUnitTest.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using ParquetClassLibrary;
+using ParquetClassLibrary.Utilities;
+using Xunit;
+
+namespace ParquetUnitTests.Utilities
+{
+    public class PreconditionUnitTest
+    {
+        #region Test Values
+        public class BaseType { };
+        public class DerivedType : BaseType { };
+        #endregion
+
+        [Fact]
+        public void EntityIsInRangeTest()
+        {
+            var testID = (EntityID)6;
+            var testRange = new Range<EntityID>(0, 10);
+
+            var exception = Record.Exception(() => Precondition.IsInRange(testID, testRange));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void RangeIsInRangeTest()
+        {
+            var innerRange = new Range<EntityID>(1, 9);
+            var outterRange = new Range<EntityID>(0, 10);
+
+            var exception = Record.Exception(() => Precondition.IsInRange(innerRange, outterRange));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void EntityIsInRangeCollectionTest()
+        {
+            var testID = (EntityID)7;
+            var testCollection = new List<Range<EntityID>> { new Range<EntityID>(0, 5), new Range<EntityID>(6, 10) };
+
+            var exception = Record.Exception(() => Precondition.IsInRange(testID, testCollection));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void RangeIsInRangeCollectionTest()
+        {
+            var innerRange = new Range<EntityID>(1, 4);
+            var testCollection = new List<Range<EntityID>> { new Range<EntityID>(0, 5), new Range<EntityID>(6, 10) };
+
+            var exception = Record.Exception(() => Precondition.IsInRange(innerRange, testCollection));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void EntityIsInRangeThrowsOnOutOfRangeTest()
+        {
+            var testID = (EntityID)12;
+            var testRange = new Range<EntityID>(0, 10);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Precondition.IsInRange(testID, testRange); });
+        }
+
+        [Fact]
+        public void RangeIsInRangeThrowsOnOutOfRangeTest()
+        {
+            var innerRange = new Range<EntityID>(0, 10);
+            var outterRange = new Range<EntityID>(1, 9);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Precondition.IsInRange(innerRange, outterRange); });
+        }
+
+        [Fact]
+        public void EntityIsInRangeCollectionThrowsOnOutOfRangeTest()
+        {
+            var testID = (EntityID)12;
+            var testCollection = new List<Range<EntityID>> { new Range<EntityID>(0, 5), new Range<EntityID>(6, 10) };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Precondition.IsInRange(testID, testCollection); });
+        }
+
+        [Fact]
+        public void RangeIsInRangeCollectionThrowsOnOutOfRangeTest()
+        {
+            var innerRange = new Range<EntityID>(0, 10);
+            var testCollection = new List<Range<EntityID>> { new Range<EntityID>(1, 5), new Range<EntityID>(6, 9) };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Precondition.IsInRange(innerRange, testCollection); });
+        }
+
+        [Fact]
+        public void IsOfTypeTest()
+        {
+            var exception = Record.Exception(() => Precondition.IsOfType<DerivedType, BaseType>());
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void IsOfTypeThrowsOnNotSubtypeTest()
+        {
+            Assert.Throws<InvalidCastException>(() => Precondition.IsOfType<BaseType, DerivedType>());
+        }
+
+        [Fact]
+        public void IsOfTypeSystemTest()
+        {
+            var exception = Record.Exception(() => Precondition.IsOfType<string, object>());
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void IsOfTypeThrowsOnNotSubtypeSystemTest()
+        {
+            Assert.Throws<InvalidCastException>(() => Precondition.IsOfType<object, string>());
+        }
+
+        [Fact]
+        public void IsOfTypeThrowsOnNotSubtypeValueTypeTest()
+        {
+            Assert.Throws<InvalidCastException>(() => Precondition.IsOfType<float, int>());
+        }
+
+        [Fact]
+        public void AreInRangeTest()
+        {
+            var testIDCollection = new List<EntityID> { 0, 1, 5, 6, 9, 10 };
+            var testRange = new Range<EntityID>(0, 10);
+
+            var exception = Record.Exception(() => Precondition.AreInRange(testIDCollection, testRange));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void AreInRangeCollectionTest()
+        {
+            var testIDCollection = new List<EntityID> { 0, 1, 2, 7, 8, 10 };
+            var testCollection = new List<Range<EntityID>> { new Range<EntityID>(0, 5), new Range<EntityID>(6, 10) };
+
+            var exception = Record.Exception(() => Precondition.AreInRange(testIDCollection, testCollection));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void AreInRangeThrowsOnSingleOutOfRangeTest()
+        {
+            var testIDCollection = new List<EntityID> { 0, 1, 5, 9, 10, 20 };
+            var testRange = new Range<EntityID>(0, 10);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Precondition.AreInRange(testIDCollection, testRange));
+        }
+
+        [Fact]
+        public void AreInRangeThrowsOnSingleOutOfRangeCollectionTest()
+        {
+            var testIDCollection = new List<EntityID> { 0, 1, 3, 8, 10, 20 };
+            var testCollection = new List<Range<EntityID>> { new Range<EntityID>(0, 5), new Range<EntityID>(6, 10) };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Precondition.AreInRange(testIDCollection, testCollection));
+        }
+
+        [Fact]
+        public void MustBePositiveTest()
+        {
+            var testValue = 1;
+
+            var exception = Record.Exception(() => Precondition.MustBePositive(testValue));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void MustBePositiveThrowsOnZeroTest()
+        {
+            var testValue = 0;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Precondition.MustBePositive(testValue));
+        }
+
+        [Fact]
+        public void MustBePositiveThrowsOnNegativeTest()
+        {
+            var testValue = -1;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Precondition.MustBePositive(testValue));
+        }
+
+
+        [Fact]
+        public void IsNotEmptyTest()
+        {
+            var testValue = new List<EntityID> { 0, 1, 2 };
+
+            var exception = Record.Exception(() => Precondition.IsNotEmpty(testValue));
+
+            Assert.Null(exception);
+        }
+
+
+        [Fact]
+        public void IsNotEmptyStringTest()
+        {
+            var testValue = "will pass";
+
+            var exception = Record.Exception(() => Precondition.IsNotEmpty(testValue));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void IsNotEmptyThrowsOnEmptyTest()
+        {
+            var testValue = new List<EntityID>();
+
+            Assert.Throws<IndexOutOfRangeException>(() => Precondition.IsNotEmpty(testValue));
+        }
+
+        [Fact]
+        public void IsNotEmptyStringThrowsOnEmptyStringTest()
+        {
+            var testValue = "";
+
+            Assert.Throws<IndexOutOfRangeException>(() => Precondition.IsNotEmpty(testValue));
+        }
+
+        [Fact]
+        public void IsNullTest()
+        {
+            var testValue = "will pass";
+
+            var exception = Record.Exception(() => Precondition.IsNotNull(testValue));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void IsNullThrowsOnNullTest()
+        {
+            object testValue = null;
+
+            Assert.Throws<ArgumentNullException>(() => Precondition.IsNotNull(testValue));
+        }
+    }
+}

--- a/ParquetUnitTests/Utilities/RangeUnitTest.cs
+++ b/ParquetUnitTests/Utilities/RangeUnitTest.cs
@@ -15,7 +15,7 @@ namespace ParquetUnitTests.Utilities
         [Fact]
         public void RangeMustBeWillDefinedTest()
         {
-            Assert.Throws<ArgumentException>(() => { var _ = new Range<int>(upperBound, lowerBound); });
+            Assert.Throws<InvalidOperationException>(() => { var _ = new Range<int>(upperBound, lowerBound); });
         }
 
         [Fact]


### PR DESCRIPTION
Another PR where a lot of files were touched, but where all the important changes are in a few.  In this case, `Precondition.cs` and `PreconditionUnitTest.cs`.

I wrote a set of static helper methods to clean up and simplify various object init routines.  I think the biggest benefit can be felt in the Shim classes and in the Entities with many preconditions to check.

I would love any design input you may have on this in addition to any code checks.  Thanks!