### PR TITLE
Remove Parameter Prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 
+## [0.5.0] - 2021-??-??
+### Alpha
+- This update makes Parquet method calls more C# idiomatic.
+#### Adds
+- ...
+#### Removes
+- ...
+#### Changes
+- ...
+
 ## [0.4.0] - 2021-02-23
 ### Pre-Alpha 3 API Revision
 - This update changes the API in far-reaching ways in order to separate design-time and play-time concerns in map-related types.

--- a/ParquetClassLibrary/All.cs
+++ b/ParquetClassLibrary/All.cs
@@ -484,40 +484,40 @@ namespace Parquet
         /// <summary>
         /// Initializes the <see cref="ModelCollection{T}"/>s from the given collections.
         /// </summary>
-        /// <param name="inPronouns">The pronouns that the game knows by default.</param>
-        /// <param name="inCharacters">All characters to be used in the game.</param>
-        /// <param name="inCritters">All critters to be used in the game.</param>
-        /// <param name="inBiomes">All biomes to be used in the game.</param>
-        /// <param name="inCraftingRecipes">All crafting recipes to be used in the game.</param>
-        /// <param name="inGames">All games or episodes to be used in the game.</param>
-        /// <param name="inInteractions">All interactions to be used in the game.</param>
-        /// <param name="inRegions">All region metadata to be used in the game.</param>
-        /// <param name="inRegionStatuses">All maps that have already been generated in the game.</param>
-        /// <param name="inFloors">All floors to be used in the game.</param>
-        /// <param name="inBlocks">All blocks to be used in the game.</param>
-        /// <param name="inFurnishings">All furnishings to be used in the game.</param>
-        /// <param name="inCollectibles">All collectibles to be used in the game.</param>
-        /// <param name="inRoomRecipes">All room recipes to be used in the game.</param>
-        /// <param name="inScripts">All scripts to be used in the game.</param>
-        /// <param name="inItems">All items to be used in the game.</param>
+        /// <param name="pronouns">The pronouns that the game knows by default.</param>
+        /// <param name="characters">All characters to be used in the game.</param>
+        /// <param name="critters">All critters to be used in the game.</param>
+        /// <param name="biomes">All biomes to be used in the game.</param>
+        /// <param name="craftingRecipes">All crafting recipes to be used in the game.</param>
+        /// <param name="games">All games or episodes to be used in the game.</param>
+        /// <param name="interactions">All interactions to be used in the game.</param>
+        /// <param name="regions">All region metadata to be used in the game.</param>
+        /// <param name="regionStatuses">All maps that have already been generated in the game.</param>
+        /// <param name="floors">All floors to be used in the game.</param>
+        /// <param name="blocks">All blocks to be used in the game.</param>
+        /// <param name="furnishings">All furnishings to be used in the game.</param>
+        /// <param name="collectibles">All collectibles to be used in the game.</param>
+        /// <param name="roomRecipes">All room recipes to be used in the game.</param>
+        /// <param name="scripts">All scripts to be used in the game.</param>
+        /// <param name="items">All items to be used in the game.</param>
         /// <remarks>The collections of models must be separately cleared between calls to this initialization routine.</remarks>
         /// <seealso cref="Clear"/>
-        public static void InitializeCollections(IEnumerable<PronounGroup> inPronouns,
-                                                 IEnumerable<GameModel> inGames,
-                                                 IEnumerable<FloorModel> inFloors,
-                                                 IEnumerable<BlockModel> inBlocks,
-                                                 IEnumerable<FurnishingModel> inFurnishings,
-                                                 IEnumerable<CollectibleModel> inCollectibles,
-                                                 IEnumerable<CritterModel> inCritters,
-                                                 IEnumerable<CharacterModel> inCharacters,
-                                                 IEnumerable<BiomeRecipe> inBiomes,
-                                                 IEnumerable<CraftingRecipe> inCraftingRecipes,
-                                                 IEnumerable<RoomRecipe> inRoomRecipes,
-                                                 IEnumerable<RegionModel> inRegions,
-                                                 IEnumerable<KeyValuePair<ModelID, RegionStatus>> inRegionStatuses,
-                                                 IEnumerable<ScriptModel> inScripts,
-                                                 IEnumerable<InteractionModel> inInteractions,
-                                                 IEnumerable<ItemModel> inItems)
+        public static void InitializeCollections(IEnumerable<PronounGroup> pronouns,
+                                                 IEnumerable<GameModel> games,
+                                                 IEnumerable<FloorModel> floors,
+                                                 IEnumerable<BlockModel> blocks,
+                                                 IEnumerable<FurnishingModel> furnishings,
+                                                 IEnumerable<CollectibleModel> collectibles,
+                                                 IEnumerable<CritterModel> critters,
+                                                 IEnumerable<CharacterModel> characters,
+                                                 IEnumerable<BiomeRecipe> biomes,
+                                                 IEnumerable<CraftingRecipe> craftingRecipes,
+                                                 IEnumerable<RoomRecipe> roomRecipes,
+                                                 IEnumerable<RegionModel> regions,
+                                                 IEnumerable<KeyValuePair<ModelID, RegionStatus>> regionStatuses,
+                                                 IEnumerable<ScriptModel> scripts,
+                                                 IEnumerable<InteractionModel> interactions,
+                                                 IEnumerable<ItemModel> items)
         {
             if (CollectionsHaveBeenInitialized)
             {
@@ -525,45 +525,45 @@ namespace Parquet
                                                            nameof(All), "initialization"));
                 return;
             }
-            Precondition.IsNotNull(inPronouns, nameof(inPronouns));
-            Precondition.IsNotNull(inGames, nameof(inGames));
-            Precondition.IsNotNull(inFloors, nameof(inFloors));
-            Precondition.IsNotNull(inBlocks, nameof(inBlocks));
-            Precondition.IsNotNull(inFurnishings, nameof(inFurnishings));
-            Precondition.IsNotNull(inCollectibles, nameof(inCollectibles));
-            Precondition.IsNotNull(inCritters, nameof(inCritters));
-            Precondition.IsNotNull(inCharacters, nameof(inCharacters));
-            Precondition.IsNotNull(inBiomes, nameof(inBiomes));
-            Precondition.IsNotNull(inCraftingRecipes, nameof(inCraftingRecipes));
-            Precondition.IsNotNull(inRoomRecipes, nameof(inRoomRecipes));
-            Precondition.IsNotNull(inRegions, nameof(inRegions));
-            Precondition.IsNotNull(inScripts, nameof(inScripts));
-            Precondition.IsNotNull(inInteractions, nameof(inInteractions));
-            Precondition.IsNotNull(inItems, nameof(inItems));
+            Precondition.IsNotNull(pronouns, nameof(pronouns));
+            Precondition.IsNotNull(games, nameof(games));
+            Precondition.IsNotNull(floors, nameof(floors));
+            Precondition.IsNotNull(blocks, nameof(blocks));
+            Precondition.IsNotNull(furnishings, nameof(furnishings));
+            Precondition.IsNotNull(collectibles, nameof(collectibles));
+            Precondition.IsNotNull(critters, nameof(critters));
+            Precondition.IsNotNull(characters, nameof(characters));
+            Precondition.IsNotNull(biomes, nameof(biomes));
+            Precondition.IsNotNull(craftingRecipes, nameof(craftingRecipes));
+            Precondition.IsNotNull(roomRecipes, nameof(roomRecipes));
+            Precondition.IsNotNull(regions, nameof(regions));
+            Precondition.IsNotNull(scripts, nameof(scripts));
+            Precondition.IsNotNull(interactions, nameof(interactions));
+            Precondition.IsNotNull(items, nameof(items));
 
-            Games = new ModelCollection<GameModel>(GameIDs, inGames);
-            Floors = new ModelCollection<FloorModel>(FloorIDs, inFloors);
-            Blocks = new ModelCollection<BlockModel>(BlockIDs, inBlocks);
-            Furnishings = new ModelCollection<FurnishingModel>(FurnishingIDs, inFurnishings);
-            Collectibles = new ModelCollection<CollectibleModel>(CollectibleIDs, inCollectibles);
+            Games = new ModelCollection<GameModel>(GameIDs, games);
+            Floors = new ModelCollection<FloorModel>(FloorIDs, floors);
+            Blocks = new ModelCollection<BlockModel>(BlockIDs, blocks);
+            Furnishings = new ModelCollection<FurnishingModel>(FurnishingIDs, furnishings);
+            Collectibles = new ModelCollection<CollectibleModel>(CollectibleIDs, collectibles);
             Parquets = new ModelCollection<ParquetModel>(ParquetIDs, ((IEnumerable<ParquetModel>)Floors)
                 .Concat(Blocks)
                 .Concat(Furnishings)
                 .Concat(Collectibles));
-            Critters = new ModelCollection<CritterModel>(CritterIDs, inCritters);
-            Characters = new ModelCollection<CharacterModel>(CharacterIDs, inCharacters);
+            Critters = new ModelCollection<CritterModel>(CritterIDs, critters);
+            Characters = new ModelCollection<CharacterModel>(CharacterIDs, characters);
             Beings = new ModelCollection<BeingModel>(BeingIDs, ((IEnumerable<BeingModel>)Characters)
                 .Concat(Critters));
-            BiomeRecipes = new ModelCollection<BiomeRecipe>(BiomeRecipeIDs, inBiomes);
-            CraftingRecipes = new ModelCollection<CraftingRecipe>(CraftingRecipeIDs, inCraftingRecipes);
-            RoomRecipes = new ModelCollection<RoomRecipe>(RoomRecipeIDs, inRoomRecipes);
-            Regions = new ModelCollection<RegionModel>(RegionIDs, inRegions);
-            Scripts = new ModelCollection<ScriptModel>(ScriptIDs, inScripts);
-            Interactions = new ModelCollection<InteractionModel>(InteractionIDs, inInteractions);
-            Items = new ModelCollection<ItemModel>(ItemIDs, inItems);
+            BiomeRecipes = new ModelCollection<BiomeRecipe>(BiomeRecipeIDs, biomes);
+            CraftingRecipes = new ModelCollection<CraftingRecipe>(CraftingRecipeIDs, craftingRecipes);
+            RoomRecipes = new ModelCollection<RoomRecipe>(RoomRecipeIDs, roomRecipes);
+            Regions = new ModelCollection<RegionModel>(RegionIDs, regions);
+            Scripts = new ModelCollection<ScriptModel>(ScriptIDs, scripts);
+            Interactions = new ModelCollection<InteractionModel>(InteractionIDs, interactions);
+            Items = new ModelCollection<ItemModel>(ItemIDs, items);
 
-            PronounGroups = new HashSet<PronounGroup>(inPronouns);
-            RegionStatuses = new Dictionary<ModelID, RegionStatus>(inRegionStatuses);
+            PronounGroups = new HashSet<PronounGroup>(pronouns);
+            RegionStatuses = new Dictionary<ModelID, RegionStatus>(regionStatuses);
 
             CollectionsHaveBeenInitialized = true;
         }
@@ -706,27 +706,27 @@ namespace Parquet
         /// <summary>
         /// Given a <see cref="ModelID"/>, return the <see cref="Range{ModelID}"/> within which it is defined.
         /// </summary>
-        /// <param name="inID">The ID whose <see cref="Range{ModelID}"/> is sought.</param>
+        /// <param name="id">The ID whose <see cref="Range{ModelID}"/> is sought.</param>
         /// <returns>
         /// The range within which this <see cref="ModelID"/> is defined, or <see cref="Range{ModelID}.None"/> if there is none.
         /// </returns>
-        public static Range<ModelID> GetIDRangeForType(ModelID inID)
-            => inID == ModelID.None
+        public static Range<ModelID> GetIDRangeForType(ModelID id)
+            => id == ModelID.None
                 ? Range<ModelID>.None
-                : AllDefinedIDs.Where(range => range.ContainsValue(inID)).DefaultIfEmpty(Range<ModelID>.None).First();
+                : AllDefinedIDs.Where(range => range.ContainsValue(id)).DefaultIfEmpty(Range<ModelID>.None).First();
 
         /// <summary>
         /// Given an instance of <see cref="Model"/>, return the appropriate <see cref="Range{ModelID}"/>.
         /// </summary>
-        /// <param name="inModel">The model whose <see cref="Range{ModelID}"/> is sought.</param>
+        /// <param name="model">The model whose <see cref="Range{ModelID}"/> is sought.</param>
         /// <returns>
         /// The range within which this model's <see cref="ModelID"/> is defined, or <see cref="Range{ModelID}.None"/> if there is none.
         /// </returns>
-        public static Range<ModelID> GetIDRangeForType(Model inModel)
-            => inModel is null
-            || inModel.ID == ModelID.None
+        public static Range<ModelID> GetIDRangeForType(Model model)
+            => model is null
+            || model.ID == ModelID.None
                 ? Range<ModelID>.None
-                : inModel switch
+                : model switch
                 {
                     GameModel _ => GameIDs,
                     FloorModel _ => FloorIDs,
@@ -748,26 +748,26 @@ namespace Parquet
         /// <summary>
         /// Given a <see cref="Type"/> derived from a <see cref="Model"/>, return the appropriate <see cref="Range{ModelID}"/>.
         /// </summary>
-        /// <param name="inModelType">The model type whose ID range is sought.</param>
+        /// <param name="modelType">The model type whose ID range is sought.</param>
         /// <returns>
         /// The range within which this model type's <see cref="ModelID"/> would be defined,
         /// or <see cref="Range{ModelID}.None"/> if none exists.
         /// </returns>
-        public static Range<ModelID> GetIDRangeForType(Type inModelType)
-            => inModelType == typeof(GameModel) ? GameIDs
-            : inModelType == typeof(BlockModel) ? BlockIDs
-            : inModelType == typeof(FloorModel) ? FloorIDs
-            : inModelType == typeof(FurnishingModel) ? FurnishingIDs
-            : inModelType == typeof(CollectibleModel) ? CollectibleIDs
-            : inModelType == typeof(CritterModel) ? CritterIDs
-            : inModelType == typeof(CharacterModel) ? CharacterIDs
-            : inModelType == typeof(BiomeRecipe) ? BiomeRecipeIDs
-            : inModelType == typeof(CraftingRecipe) ? CraftingRecipeIDs
-            : inModelType == typeof(RoomRecipe) ? RoomRecipeIDs
-            : inModelType == typeof(RegionModel) ? RegionIDs
-            : inModelType == typeof(ScriptModel) ? ScriptIDs
-            : inModelType == typeof(InteractionModel) ? InteractionIDs
-            : inModelType == typeof(ItemModel) ? ItemIDs
+        public static Range<ModelID> GetIDRangeForType(Type modelType)
+            => modelType == typeof(GameModel) ? GameIDs
+            : modelType == typeof(BlockModel) ? BlockIDs
+            : modelType == typeof(FloorModel) ? FloorIDs
+            : modelType == typeof(FurnishingModel) ? FurnishingIDs
+            : modelType == typeof(CollectibleModel) ? CollectibleIDs
+            : modelType == typeof(CritterModel) ? CritterIDs
+            : modelType == typeof(CharacterModel) ? CharacterIDs
+            : modelType == typeof(BiomeRecipe) ? BiomeRecipeIDs
+            : modelType == typeof(CraftingRecipe) ? CraftingRecipeIDs
+            : modelType == typeof(RoomRecipe) ? RoomRecipeIDs
+            : modelType == typeof(RegionModel) ? RegionIDs
+            : modelType == typeof(ScriptModel) ? ScriptIDs
+            : modelType == typeof(InteractionModel) ? InteractionIDs
+            : modelType == typeof(ItemModel) ? ItemIDs
             : Range<ModelID>.None;
         #endregion
     }

--- a/ParquetClassLibrary/Beings/BeingModel.cs
+++ b/ParquetClassLibrary/Beings/BeingModel.cs
@@ -33,35 +33,35 @@ namespace Parquet.Beings
         /// <summary>
         /// Used by <see cref="BeingModel"/> subtypes.
         /// </summary>
-        /// <param name="inBounds">
+        /// <param name="bounds">
         /// The bounds within which the being's <see cref="ModelID"/> is defined.
         /// Must be one of <see cref="All.BeingIDs"/>.
         /// </param>
-        /// <param name="inID">Unique identifier for the being.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the being.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the being.</param>
-        /// <param name="inComment">Comment of, on, or by the being.</param>
-        /// <param name="inTags">Any additional functionality this being has, e.g. contributing to a <see cref="Biomes.BiomeRecipe"/>.</param>
-        /// <param name="inNativeBiomeID">The <see cref="ModelID"/> for the <see cref="Biomes.BiomeRecipe"/> in which this being is most comfortable.</param>
-        /// <param name="inPrimaryBehaviorID">The rules that govern how this being acts.  Cannot be null.</param>
-        /// <param name="inAvoidsIDs">Any parquets this being avoids.</param>
-        /// <param name="inSeeksIDs">Any parquets this being seeks.</param>
-        protected BeingModel(Range<ModelID> inBounds, ModelID inID, string inName, string inDescription,
-                             string inComment, IEnumerable<ModelTag> inTags = null, ModelID? inNativeBiomeID = null,
-                             ModelID? inPrimaryBehaviorID = null, IEnumerable<ModelID> inAvoidsIDs = null,
-                             IEnumerable<ModelID> inSeeksIDs = null)
-            : base(inBounds, inID, inName, inDescription, inComment, inTags)
+        /// <param name="id">Unique identifier for the being.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the being.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the being.</param>
+        /// <param name="comment">Comment of, on, or by the being.</param>
+        /// <param name="tags">Any additional functionality this being has, e.g. contributing to a <see cref="Biomes.BiomeRecipe"/>.</param>
+        /// <param name="nativeBiomeID">The <see cref="ModelID"/> for the <see cref="Biomes.BiomeRecipe"/> in which this being is most comfortable.</param>
+        /// <param name="primaryBehaviorID">The rules that govern how this being acts.  Cannot be null.</param>
+        /// <param name="avoidsIDs">Any parquets this being avoids.</param>
+        /// <param name="seeksIDs">Any parquets this being seeks.</param>
+        protected BeingModel(Range<ModelID> bounds, ModelID id, string name, string description,
+                             string comment, IEnumerable<ModelTag> tags = null, ModelID? nativeBiomeID = null,
+                             ModelID? primaryBehaviorID = null, IEnumerable<ModelID> avoidsIDs = null,
+                             IEnumerable<ModelID> seeksIDs = null)
+            : base(bounds, id, name, description, comment, tags)
         {
-            var nonNullNativeBiomeID = inNativeBiomeID ?? ModelID.None;
-            var nonNullPrimaryBehaviorID = inPrimaryBehaviorID ?? ModelID.None;
-            var nonNullAvoidsIDs = (inAvoidsIDs ?? Enumerable.Empty<ModelID>()).ToList();
-            var nonNullSeeksIDs = (inSeeksIDs ?? Enumerable.Empty<ModelID>()).ToList();
+            var nonNullNativeBiomeID = nativeBiomeID ?? ModelID.None;
+            var nonNullPrimaryBehaviorID = primaryBehaviorID ?? ModelID.None;
+            var nonNullAvoidsIDs = (avoidsIDs ?? Enumerable.Empty<ModelID>()).ToList();
+            var nonNullSeeksIDs = (seeksIDs ?? Enumerable.Empty<ModelID>()).ToList();
 
-            Precondition.IsInRange(inBounds, All.BeingIDs, nameof(inBounds));
-            Precondition.IsInRange(nonNullNativeBiomeID, All.BiomeRecipeIDs, nameof(inNativeBiomeID));
-            Precondition.IsInRange(nonNullPrimaryBehaviorID, All.ScriptIDs, nameof(inPrimaryBehaviorID));
-            Precondition.AreInRange(nonNullAvoidsIDs, All.ParquetIDs, nameof(inAvoidsIDs));
-            Precondition.AreInRange(nonNullSeeksIDs, All.ParquetIDs, nameof(inSeeksIDs));
+            Precondition.IsInRange(bounds, All.BeingIDs, nameof(bounds));
+            Precondition.IsInRange(nonNullNativeBiomeID, All.BiomeRecipeIDs, nameof(nativeBiomeID));
+            Precondition.IsInRange(nonNullPrimaryBehaviorID, All.ScriptIDs, nameof(primaryBehaviorID));
+            Precondition.AreInRange(nonNullAvoidsIDs, All.ParquetIDs, nameof(avoidsIDs));
+            Precondition.AreInRange(nonNullSeeksIDs, All.ParquetIDs, nameof(seeksIDs));
 
             NativeBiomeID = nonNullNativeBiomeID;
             PrimaryBehaviorID = nonNullPrimaryBehaviorID;

--- a/ParquetClassLibrary/Beings/CharacterModel.cs
+++ b/ParquetClassLibrary/Beings/CharacterModel.cs
@@ -85,41 +85,41 @@ namespace Parquet.Beings
         /// <summary>
         /// Initializes a new instance of the <see cref="CharacterModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="CharacterModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Personal and family names of the <see cref="CharacterModel"/>, separated by a space.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="CharacterModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="CharacterModel"/>.</param>
-        /// <param name="inTags">Any additional information about the <see cref="CharacterModel"/>.</param>
-        /// <param name="inNativeBiomeID">The <see cref="ModelID"/> for the <see cref="Biomes.BiomeRecipe"/> in which this <see cref="CharacterModel"/> is most comfortable.</param>
-        /// <param name="inPrimaryBehaviorID">The rules that govern how this <see cref="CharacterModel"/> acts.  Cannot be null.</param>
-        /// <param name="inAvoidsIDs">Any parquets this <see cref="CharacterModel"/> avoids.</param>
-        /// <param name="inSeeksIDs">Any parquets this <see cref="CharacterModel"/> seeks.</param>
-        /// <param name="inPronounKey">How to refer to this <see cref="CharacterModel"/>.</param>
-        /// <param name="inStoryCharacterID">A means of identifying this <see cref="CharacterModel"/> across multiple shipped game titles.</param>
-        /// <param name="inStartingLocation">The <see cref="Location"/> where this <see cref="CharacterModel"/> begins.</param>
-        /// <param name="inStartingQuestIDs">Any quests this <see cref="CharacterModel"/> has to offer or has undertaken.</param>
-        /// <param name="inStartingDialogueID">All dialogue this <see cref="CharacterModel"/> may say.</param>
-        /// <param name="inStartingInventory">Any items this <see cref="CharacterModel"/> possesses at the outset.</param>
-        public CharacterModel(ModelID inID, string inName, string inDescription, string inComment,
-                              IEnumerable<ModelTag> inTags = null, ModelID? inNativeBiomeID = null,
-                              ModelID? inPrimaryBehaviorID = null, IEnumerable<ModelID> inAvoidsIDs = null,
-                              IEnumerable<ModelID> inSeeksIDs = null, string inPronounKey = PronounGroup.DefaultKey,
-                              string inStoryCharacterID = "", Location? inStartingLocation = null,
-                              IEnumerable<ModelID> inStartingQuestIDs = null, ModelID? inStartingDialogueID = null,
-                              InventoryCollection inStartingInventory = null)
-            : base(All.CharacterIDs, inID, inName, inDescription, inComment, inTags,
-                   inNativeBiomeID, inPrimaryBehaviorID, inAvoidsIDs, inSeeksIDs)
+        /// <param name="id">Unique identifier for the <see cref="CharacterModel"/>.  Cannot be null.</param>
+        /// <param name="name">Personal and family names of the <see cref="CharacterModel"/>, separated by a space.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="CharacterModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="CharacterModel"/>.</param>
+        /// <param name="tags">Any additional information about the <see cref="CharacterModel"/>.</param>
+        /// <param name="nativeBiomeID">The <see cref="ModelID"/> for the <see cref="Biomes.BiomeRecipe"/> in which this <see cref="CharacterModel"/> is most comfortable.</param>
+        /// <param name="primaryBehaviorID">The rules that govern how this <see cref="CharacterModel"/> acts.  Cannot be null.</param>
+        /// <param name="avoidsIDs">Any parquets this <see cref="CharacterModel"/> avoids.</param>
+        /// <param name="seeksIDs">Any parquets this <see cref="CharacterModel"/> seeks.</param>
+        /// <param name="pronounKey">How to refer to this <see cref="CharacterModel"/>.</param>
+        /// <param name="storyCharacterID">A means of identifying this <see cref="CharacterModel"/> across multiple shipped game titles.</param>
+        /// <param name="startingLocation">The <see cref="Location"/> where this <see cref="CharacterModel"/> begins.</param>
+        /// <param name="startingQuestIDs">Any quests this <see cref="CharacterModel"/> has to offer or has undertaken.</param>
+        /// <param name="startingDialogueID">All dialogue this <see cref="CharacterModel"/> may say.</param>
+        /// <param name="startingInventory">Any items this <see cref="CharacterModel"/> possesses at the outset.</param>
+        public CharacterModel(ModelID id, string name, string description, string comment,
+                              IEnumerable<ModelTag> tags = null, ModelID? nativeBiomeID = null,
+                              ModelID? primaryBehaviorID = null, IEnumerable<ModelID> avoidsIDs = null,
+                              IEnumerable<ModelID> seeksIDs = null, string pronounKey = PronounGroup.DefaultKey,
+                              string storyCharacterID = "", Location? startingLocation = null,
+                              IEnumerable<ModelID> startingQuestIDs = null, ModelID? startingDialogueID = null,
+                              InventoryCollection startingInventory = null)
+            : base(All.CharacterIDs, id, name, description, comment, tags,
+                   nativeBiomeID, primaryBehaviorID, avoidsIDs, seeksIDs)
         {
-            var nonNullStartingLocation = inStartingLocation ?? Location.Nowhere;
-            var nonNullQuestIDs = inStartingQuestIDs ?? Enumerable.Empty<ModelID>();
-            var nonNullDialogueID = inStartingDialogueID ?? ModelID.None;
-            var nonNullInventory = inStartingInventory ?? InventoryCollection.Empty;
+            var nonNullStartingLocation = startingLocation ?? Location.Nowhere;
+            var nonNullQuestIDs = startingQuestIDs ?? Enumerable.Empty<ModelID>();
+            var nonNullDialogueID = startingDialogueID ?? ModelID.None;
+            var nonNullInventory = startingInventory ?? InventoryCollection.Empty;
 
-            Precondition.AreInRange(nonNullQuestIDs, All.InteractionIDs, nameof(inStartingQuestIDs));
-            Precondition.IsInRange(nonNullDialogueID, All.InteractionIDs, nameof(inStartingDialogueID));
+            Precondition.AreInRange(nonNullQuestIDs, All.InteractionIDs, nameof(startingQuestIDs));
+            Precondition.IsInRange(nonNullDialogueID, All.InteractionIDs, nameof(startingDialogueID));
 
-            PronounKey = inPronounKey;
-            StoryCharacterID = inStoryCharacterID;
+            PronounKey = pronounKey;
+            StoryCharacterID = storyCharacterID;
             StartingLocation = nonNullStartingLocation;
             StartingQuestIDs = nonNullQuestIDs.ToList();
             StartingDialogueID = nonNullDialogueID;

--- a/ParquetClassLibrary/Beings/CharacterStatus.cs
+++ b/ParquetClassLibrary/Beings/CharacterStatus.cs
@@ -64,45 +64,45 @@ namespace Parquet.Beings
         /// <summary>
         /// Initializes a new instance of the <see cref="CharacterStatus"/> class.
         /// </summary>
-        /// <param name="inPosition">The <see cref="Location"/> the tracked <see cref="CharacterModel"/> occupies.</param>
-        /// <param name="inSpawnAt">The <see cref="Location"/> the tracked <see cref="CharacterModel"/> will next spawn at.</param>
-        /// <param name="inRoomAssignment">The <see cref="Location"/> of the <see cref="Rooms.Room"/> to which the tracked <see cref="CharacterModel"/> is assigned.</param>
-        /// <param name="inCurrentBehavior">The behavior currently governing the tracked <see cref="CharacterModel"/>.</param>
-        /// <param name="inBiomeTimeRemaining">How long [TODO in what units?] before the <see cref="CharacterModel"/> must leave the <see cref="Biomes.BiomeRecipe"/>.</param>
-        /// <param name="inKnownBeings">The <see cref="CritterModel"/>s that this <see cref="CharacterModel"/> has encountered.</param>
-        /// <param name="inKnownParquets">The parquets that this <see cref="CharacterModel"/> has encountered.</param>
-        /// <param name="inKnownRoomRecipes">The <see cref="Rooms.RoomRecipe"/>s that this <see cref="CharacterModel"/> knows.</param>
-        /// <param name="inKnownCraftingRecipes">The <see cref="Crafts.CraftingRecipe"/>s that this <see cref="CharacterModel"/> knows.</param>
-        /// <param name="inQuests">The <see cref="Scripts.InteractionModel"/>s that this <see cref="CharacterModel"/> offers or has undertaken.</param>
-        /// <param name="inInventory">This <see cref="CharacterModel"/>'s set of belongings.</param>
-        public CharacterStatus(Location? inPosition = null, Location? inSpawnAt = null, Location? inRoomAssignment = null,
-                               ModelID? inCurrentBehavior = null, int inBiomeTimeRemaining = int.MaxValue,
-                               ICollection<ModelID> inKnownBeings = null, ICollection<ModelID> inKnownParquets = null,
-                               ICollection<ModelID> inKnownRoomRecipes = null, ICollection<ModelID> inKnownCraftingRecipes = null,
-                               ICollection<ModelID> inQuests = null, InventoryCollection inInventory = null)
+        /// <param name="position">The <see cref="Location"/> the tracked <see cref="CharacterModel"/> occupies.</param>
+        /// <param name="spawnAt">The <see cref="Location"/> the tracked <see cref="CharacterModel"/> will next spawn at.</param>
+        /// <param name="roomAssignment">The <see cref="Location"/> of the <see cref="Rooms.Room"/> to which the tracked <see cref="CharacterModel"/> is assigned.</param>
+        /// <param name="currentBehavior">The behavior currently governing the tracked <see cref="CharacterModel"/>.</param>
+        /// <param name="biomeTimeRemaining">How long [TODO in what units?] before the <see cref="CharacterModel"/> must leave the <see cref="Biomes.BiomeRecipe"/>.</param>
+        /// <param name="knownBeings">The <see cref="CritterModel"/>s that this <see cref="CharacterModel"/> has encountered.</param>
+        /// <param name="knownParquets">The parquets that this <see cref="CharacterModel"/> has encountered.</param>
+        /// <param name="knownRoomRecipes">The <see cref="Rooms.RoomRecipe"/>s that this <see cref="CharacterModel"/> knows.</param>
+        /// <param name="knownCraftingRecipes">The <see cref="Crafts.CraftingRecipe"/>s that this <see cref="CharacterModel"/> knows.</param>
+        /// <param name="quests">The <see cref="Scripts.InteractionModel"/>s that this <see cref="CharacterModel"/> offers or has undertaken.</param>
+        /// <param name="inventory">This <see cref="CharacterModel"/>'s set of belongings.</param>
+        public CharacterStatus(Location? position = null, Location? spawnAt = null, Location? roomAssignment = null,
+                               ModelID? currentBehavior = null, int biomeTimeRemaining = int.MaxValue,
+                               ICollection<ModelID> knownBeings = null, ICollection<ModelID> knownParquets = null,
+                               ICollection<ModelID> knownRoomRecipes = null, ICollection<ModelID> knownCraftingRecipes = null,
+                               ICollection<ModelID> quests = null, InventoryCollection inventory = null)
         {
-            var nonNullPosition = inPosition ?? Location.Nowhere;
-            var nonNullSpawnAt = inSpawnAt ?? Location.Nowhere;
-            var nonNullRoomAssignment = inRoomAssignment ?? Location.Nowhere;
-            var nonNullCurrentBehavior = inCurrentBehavior ?? ModelID.None;
-            Precondition.IsInRange(nonNullCurrentBehavior, All.ScriptIDs, nameof(inCurrentBehavior));
-            var nonNullBeings = inKnownBeings ?? Enumerable.Empty<ModelID>().ToList();
-            var nonNullParquets = inKnownParquets ?? Enumerable.Empty<ModelID>().ToList();
-            var nonNullRoomRecipes = inKnownRoomRecipes ?? Enumerable.Empty<ModelID>().ToList();
-            var nonNullCraftingRecipes = inKnownCraftingRecipes ?? Enumerable.Empty<ModelID>().ToList();
-            var nonNullQuests = inQuests ?? Enumerable.Empty<ModelID>().ToList();
-            var nonNullInventory = inInventory ?? InventoryCollection.Empty;
-            Precondition.AreInRange(nonNullBeings, All.CritterIDs, nameof(inKnownBeings));
-            Precondition.AreInRange(nonNullParquets, All.ParquetIDs, nameof(inKnownParquets));
-            Precondition.AreInRange(nonNullRoomRecipes, All.RoomRecipeIDs, nameof(inKnownRoomRecipes));
-            Precondition.AreInRange(nonNullCraftingRecipes, All.CraftingRecipeIDs, nameof(inKnownCraftingRecipes));
-            Precondition.AreInRange(nonNullQuests, All.InteractionIDs, nameof(inQuests));
+            var nonNullPosition = position ?? Location.Nowhere;
+            var nonNullSpawnAt = spawnAt ?? Location.Nowhere;
+            var nonNullRoomAssignment = roomAssignment ?? Location.Nowhere;
+            var nonNullCurrentBehavior = currentBehavior ?? ModelID.None;
+            Precondition.IsInRange(nonNullCurrentBehavior, All.ScriptIDs, nameof(currentBehavior));
+            var nonNullBeings = knownBeings ?? Enumerable.Empty<ModelID>().ToList();
+            var nonNullParquets = knownParquets ?? Enumerable.Empty<ModelID>().ToList();
+            var nonNullRoomRecipes = knownRoomRecipes ?? Enumerable.Empty<ModelID>().ToList();
+            var nonNullCraftingRecipes = knownCraftingRecipes ?? Enumerable.Empty<ModelID>().ToList();
+            var nonNullQuests = quests ?? Enumerable.Empty<ModelID>().ToList();
+            var nonNullInventory = inventory ?? InventoryCollection.Empty;
+            Precondition.AreInRange(nonNullBeings, All.CritterIDs, nameof(knownBeings));
+            Precondition.AreInRange(nonNullParquets, All.ParquetIDs, nameof(knownParquets));
+            Precondition.AreInRange(nonNullRoomRecipes, All.RoomRecipeIDs, nameof(knownRoomRecipes));
+            Precondition.AreInRange(nonNullCraftingRecipes, All.CraftingRecipeIDs, nameof(knownCraftingRecipes));
+            Precondition.AreInRange(nonNullQuests, All.InteractionIDs, nameof(quests));
 
             Position = nonNullPosition;
             SpawnAt = nonNullSpawnAt;
             RoomAssignment = nonNullRoomAssignment;
             CurrentBehaviorID = nonNullCurrentBehavior;
-            BiomeTimeRemaining = inBiomeTimeRemaining;
+            BiomeTimeRemaining = biomeTimeRemaining;
             KnownBeings = nonNullBeings;
             KnownParquets = nonNullParquets;
             KnownRoomRecipes = nonNullRoomRecipes;
@@ -116,11 +116,11 @@ namespace Parquet.Beings
         /// Initializes an instance of the <see cref="CharacterStatus"/> class
         /// based on a given <see cref="CharacterModel"/> instance.
         /// </summary>
-        /// <param name="inCharacterModel">The definitions being tracked.</param>
-        public CharacterStatus(CharacterModel inCharacterModel)
+        /// <param name="characterModel">The definitions being tracked.</param>
+        public CharacterStatus(CharacterModel characterModel)
         {
-            Precondition.IsNotNull(inCharacterModel);
-            var nonNullCharacterModel = inCharacterModel ?? CharacterModel.Unused;
+            Precondition.IsNotNull(characterModel);
+            var nonNullCharacterModel = characterModel ?? CharacterModel.Unused;
 
             Position = Location.Nowhere;
             SpawnAt = nonNullCharacterModel.StartingLocation;
@@ -159,10 +159,10 @@ namespace Parquet.Beings
         /// <summary>
         /// Determines whether the specified <see cref="CharacterStatus"/> is equal to the current <see cref="CharacterStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="CharacterStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="CharacterStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is CharacterStatus characterStatus
+        public override bool Equals<T>(T status)
+            => status is CharacterStatus characterStatus
             && CurrentBehaviorID == characterStatus.CurrentBehaviorID
             && Position == characterStatus.Position
             && SpawnAt == characterStatus.SpawnAt
@@ -187,20 +187,20 @@ namespace Parquet.Beings
         /// <summary>
         /// Determines whether a specified instance of <see cref="CharacterStatus"/> is equal to another specified instance of <see cref="CharacterStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="CharacterStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="CharacterStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="CharacterStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="CharacterStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(CharacterStatus inStatus1, CharacterStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(CharacterStatus status1, CharacterStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="CharacterStatus"/> is not equal to another specified instance of <see cref="CharacterStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="CharacterStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="CharacterStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="CharacterStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="CharacterStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(CharacterStatus inStatus1, CharacterStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(CharacterStatus status1, CharacterStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -210,72 +210,72 @@ namespace Parquet.Beings
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is CharacterStatus status
-                ? $"{status.CurrentBehaviorID.ConvertToString(status.CurrentBehaviorID, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{status.Position.ConvertToString(status.Position, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{status.SpawnAt.ConvertToString(status.SpawnAt, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{status.RoomAssignment.ConvertToString(status.RoomAssignment, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is CharacterStatus status
+                ? $"{status.CurrentBehaviorID.ConvertToString(status.CurrentBehaviorID, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{status.Position.ConvertToString(status.Position, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{status.SpawnAt.ConvertToString(status.SpawnAt, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{status.RoomAssignment.ConvertToString(status.RoomAssignment, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
                   $"{status.BiomeTimeRemaining}{Delimiters.SecondaryDelimiter}" +
-                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.KnownBeings, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.KnownParquets, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.KnownRoomRecipes, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.KnownCraftingRecipes, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.Quests, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.Inventory, inRow, inMemberMapData)}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(CharacterStatus), nameof(Unused));
+                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.KnownBeings, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.KnownParquets, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.KnownRoomRecipes, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.KnownCraftingRecipes, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.Quests, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertToString(status.Inventory, row, memberMapData)}"
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(CharacterStatus), nameof(Unused));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Unused), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Unused), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
-                return Logger.DefaultWithConvertLog(inText, nameof(CharacterStatus), Unused);
+                return Logger.DefaultWithConvertLog(text, nameof(CharacterStatus), Unused);
             }
 
-            var parameterText = inText.Split(Delimiters.SecondaryDelimiter);
+            var parameterText = text.Split(Delimiters.SecondaryDelimiter);
 
             var parsedPosition = (Location)Location.ConverterFactory.ConvertFromString(parameterText[0],
-                                                                                       inRow, inMemberMapData);
+                                                                                       row, memberMapData);
             var parsedSpawnAt = (Location)Location.ConverterFactory.ConvertFromString(parameterText[1],
-                                                                                      inRow, inMemberMapData);
+                                                                                      row, memberMapData);
             var parsedRoomAssignment = (Location)Location.ConverterFactory.ConvertFromString(parameterText[2],
-                                                                                             inRow, inMemberMapData);
+                                                                                             row, memberMapData);
             var parsedCurrentBehaviorID = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[3],
-                                                                                              inRow, inMemberMapData);
+                                                                                              row, memberMapData);
             var parsedBiomeTimeRemaining = int.TryParse(parameterText[4], All.SerializedNumberStyle,
                                                         CultureInfo.InvariantCulture, out var temp4)
                 ? temp4
                 : Logger.DefaultWithParseLog(parameterText[4], nameof(BiomeTimeRemaining), int.MaxValue);
             var parsedKnownBeings = (ICollection<ModelID>)
-                SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertFromString(parameterText[9], inRow,
-                                                                                           inMemberMapData);
+                SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertFromString(parameterText[9], row,
+                                                                                           memberMapData);
             var parsedKnownParquets = (ICollection<ModelID>)
                 SeriesConverter<ModelID, List<ModelID>>.ConverterFactory
-                                                       .ConvertFromString(parameterText[10], inRow, inMemberMapData);
+                                                       .ConvertFromString(parameterText[10], row, memberMapData);
             var parsedKnownRoomRecipes = (ICollection<ModelID>)
-                SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertFromString(parameterText[11], inRow,
-                                                                                           inMemberMapData);
+                SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertFromString(parameterText[11], row,
+                                                                                           memberMapData);
             var parsedKnownCraftingRecipes = (ICollection<ModelID>)
-                SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertFromString(parameterText[12], inRow,
-                                                                                           inMemberMapData);
+                SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertFromString(parameterText[12], row,
+                                                                                           memberMapData);
             var parsedQuests = (ICollection<ModelID>)
-                SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertFromString(parameterText[13], inRow,
-                                                                                           inMemberMapData);
+                SeriesConverter<ModelID, List<ModelID>>.ConverterFactory.ConvertFromString(parameterText[13], row,
+                                                                                           memberMapData);
             var parsedInventory = (InventoryCollection)
-                SeriesConverter<InventorySlot, InventoryCollection>.ConverterFactory.ConvertFromString(parameterText[14], inRow,
-                                                                                             inMemberMapData);
+                SeriesConverter<InventorySlot, InventoryCollection>.ConverterFactory.ConvertFromString(parameterText[14], row,
+                                                                                             memberMapData);
 
             return new CharacterStatus(parsedPosition,
                                        parsedSpawnAt,

--- a/ParquetClassLibrary/Beings/CritterModel.cs
+++ b/ParquetClassLibrary/Beings/CritterModel.cs
@@ -16,25 +16,25 @@ namespace Parquet.Beings
         /// <summary>
         /// Initializes a new instance of the <see cref="CritterModel"/> class.
         /// </summary>
-        /// <param name="inID">
+        /// <param name="id">
         /// Unique identifier for the <see cref="CritterModel"/>.  Cannot be null.
         /// Must be a <see cref="All.CritterIDs"/>.
         /// </param>
-        /// <param name="inName">Player-friendly name of the <see cref="CritterModel"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="CritterModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="CritterModel"/>.</param>
-        /// <param name="inTags">Any additional information about the <see cref="CritterModel"/>.</param>
-        /// <param name="inNativeBiomeID">The <see cref="Biomes.BiomeRecipe"/> in which this <see cref="CritterModel"/> is most comfortable.</param>
-        /// <param name="inPrimaryBehaviorID">The rules that govern how this <see cref="CritterModel"/> acts.  Cannot be null.</param>
-        /// <param name="inAvoidsIDs">Any parquets this <see cref="CritterModel"/> avoids.</param>
-        /// <param name="inSeeksIDs">Any parquets this <see cref="CritterModel"/> seeks.</param>
-        public CritterModel(ModelID inID, string inName, string inDescription, string inComment,
-                            IEnumerable<ModelTag> inTags = null, ModelID? inNativeBiomeID = null,
-                            ModelID? inPrimaryBehaviorID = null, IEnumerable<ModelID> inAvoidsIDs = null,
-                            IEnumerable<ModelID> inSeeksIDs = null)
-            : base(All.CritterIDs, inID, inName, inDescription, inComment, inTags,
-                   inNativeBiomeID, inPrimaryBehaviorID, inAvoidsIDs, inSeeksIDs)
-            => Precondition.IsInRange(inID, All.CritterIDs, nameof(inID));
+        /// <param name="name">Player-friendly name of the <see cref="CritterModel"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="CritterModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="CritterModel"/>.</param>
+        /// <param name="tags">Any additional information about the <see cref="CritterModel"/>.</param>
+        /// <param name="nativeBiomeID">The <see cref="Biomes.BiomeRecipe"/> in which this <see cref="CritterModel"/> is most comfortable.</param>
+        /// <param name="primaryBehaviorID">The rules that govern how this <see cref="CritterModel"/> acts.  Cannot be null.</param>
+        /// <param name="avoidsIDs">Any parquets this <see cref="CritterModel"/> avoids.</param>
+        /// <param name="seeksIDs">Any parquets this <see cref="CritterModel"/> seeks.</param>
+        public CritterModel(ModelID id, string name, string description, string comment,
+                            IEnumerable<ModelTag> tags = null, ModelID? nativeBiomeID = null,
+                            ModelID? primaryBehaviorID = null, IEnumerable<ModelID> avoidsIDs = null,
+                            IEnumerable<ModelID> seeksIDs = null)
+            : base(All.CritterIDs, id, name, description, comment, tags,
+                   nativeBiomeID, primaryBehaviorID, avoidsIDs, seeksIDs)
+            => Precondition.IsInRange(id, All.CritterIDs, nameof(id));
         #endregion
 
         #region IMutableCritterModel Implementation

--- a/ParquetClassLibrary/Beings/CritterStatus.cs
+++ b/ParquetClassLibrary/Beings/CritterStatus.cs
@@ -27,13 +27,13 @@ namespace Parquet.Beings
         /// <summary>
         /// Initializes a new instance of the <see cref="CritterStatus"/> class.
         /// </summary>
-        /// <param name="inPosition">The <see cref="Location"/> the tracked <see cref="CritterModel"/> occupies.</param>
-        /// <param name="inCurrentBehavior">The behavior currently governing the tracked <see cref="CritterModel"/>.</param>
-        public CritterStatus(Location? inPosition = null, ModelID? inCurrentBehavior = null)
+        /// <param name="position">The <see cref="Location"/> the tracked <see cref="CritterModel"/> occupies.</param>
+        /// <param name="currentBehavior">The behavior currently governing the tracked <see cref="CritterModel"/>.</param>
+        public CritterStatus(Location? position = null, ModelID? currentBehavior = null)
         {
-            var nonNullPosition = inPosition ?? Location.Nowhere;
-            var nonNullCurrentBehavior = inCurrentBehavior ?? ModelID.None;
-            Precondition.IsInRange(nonNullCurrentBehavior, All.ScriptIDs, nameof(inCurrentBehavior));
+            var nonNullPosition = position ?? Location.Nowhere;
+            var nonNullCurrentBehavior = currentBehavior ?? ModelID.None;
+            Precondition.IsInRange(nonNullCurrentBehavior, All.ScriptIDs, nameof(currentBehavior));
 
             Position = nonNullPosition;
             CurrentBehaviorID = nonNullCurrentBehavior;
@@ -44,11 +44,11 @@ namespace Parquet.Beings
         /// Initializes an instance of the <see cref="CritterStatus"/> class
         /// based on a given <see cref="CritterModel"/> instance.
         /// </summary>
-        /// <param name="inCritterModel">The definitions being tracked.</param>
-        public CritterStatus(CritterModel inCritterModel)
+        /// <param name="critterModel">The definitions being tracked.</param>
+        public CritterStatus(CritterModel critterModel)
         {
-            Precondition.IsNotNull(inCritterModel);
-            var nonNullCritterModel = inCritterModel ?? CritterModel.Unused;
+            Precondition.IsNotNull(critterModel);
+            var nonNullCritterModel = critterModel ?? CritterModel.Unused;
 
             Position = Location.Nowhere;
             CurrentBehaviorID = nonNullCritterModel.PrimaryBehaviorID;
@@ -68,10 +68,10 @@ namespace Parquet.Beings
         /// <summary>
         /// Determines whether the specified <see cref="CritterStatus"/> is equal to the current <see cref="CritterStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="CritterStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="CritterStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is CritterStatus critterStatus
+        public override bool Equals<T>(T status)
+            => status is CritterStatus critterStatus
             && Position == critterStatus.Position
             && CurrentBehaviorID == critterStatus.CurrentBehaviorID;
 
@@ -87,20 +87,20 @@ namespace Parquet.Beings
         /// <summary>
         /// Determines whether a specified instance of <see cref="CritterStatus"/> is equal to another specified instance of <see cref="CritterStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="CritterStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="CritterStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="CritterStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="CritterStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(CritterStatus inStatus1, CritterStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(CritterStatus status1, CritterStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="CritterStatus"/> is not equal to another specified instance of <see cref="CritterStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="CritterStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="CritterStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="CritterStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="CritterStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(CritterStatus inStatus1, CritterStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(CritterStatus status1, CritterStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -110,37 +110,37 @@ namespace Parquet.Beings
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is CritterStatus status
-                ? $"{status.Position.ConvertToString(status.Position, inRow, inMemberMapData)}{Delimiters.SecondaryDelimiter}" +
-                  $"{status.CurrentBehaviorID.ConvertToString(status.CurrentBehaviorID, inRow, inMemberMapData)}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(CritterStatus), nameof(Unused));
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is CritterStatus status
+                ? $"{status.Position.ConvertToString(status.Position, row, memberMapData)}{Delimiters.SecondaryDelimiter}" +
+                  $"{status.CurrentBehaviorID.ConvertToString(status.CurrentBehaviorID, row, memberMapData)}"
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(CritterStatus), nameof(Unused));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Unused), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Unused), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
-                return Logger.DefaultWithConvertLog(inText, nameof(CritterStatus), Unused);
+                return Logger.DefaultWithConvertLog(text, nameof(CritterStatus), Unused);
             }
 
-            var parameterText = inText.Split(Delimiters.SecondaryDelimiter);
+            var parameterText = text.Split(Delimiters.SecondaryDelimiter);
 
             var parsedPosition = (Location)Location.ConverterFactory.ConvertFromString(parameterText[0],
-                                                                                       inRow, inMemberMapData);
+                                                                                       row, memberMapData);
             var parsedCurrentBehaviorID = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[3],
-                                                                                              inRow, inMemberMapData);
+                                                                                              row, memberMapData);
 
             return new CritterStatus(parsedPosition, parsedCurrentBehaviorID);
         }

--- a/ParquetClassLibrary/Beings/PronounGroup.cs
+++ b/ParquetClassLibrary/Beings/PronounGroup.cs
@@ -70,25 +70,25 @@ namespace Parquet.Beings
         /// <summary>
         /// Initializes a new instance of the <see cref="PronounGroup"/> class.
         /// </summary>
-        /// <param name="inSubjective">Personal pronoun used as the subject of a verb.  Cannot be null or empty.</param>
-        /// <param name="inObjective">Personal pronoun used as the indirect object of a preposition or verb.  Cannot be null or empty.</param>
-        /// <param name="inDeterminer">Personal pronoun used to modify a noun attributing possession.  Cannot be null or empty.</param>
-        /// <param name="inPossessive">Personal pronoun used to indicate a relationship in a broad sense.  Cannot be null or empty.</param>
-        /// <param name="inReflexive">Personal pronoun used as a coreferential to indicate the user.  Cannot be null or empty.</param>
-        public PronounGroup(string inSubjective, string inObjective, string inDeterminer,
-                            string inPossessive, string inReflexive)
+        /// <param name="subjective">Personal pronoun used as the subject of a verb.  Cannot be null or empty.</param>
+        /// <param name="objective">Personal pronoun used as the indirect object of a preposition or verb.  Cannot be null or empty.</param>
+        /// <param name="determiner">Personal pronoun used to modify a noun attributing possession.  Cannot be null or empty.</param>
+        /// <param name="possessive">Personal pronoun used to indicate a relationship in a broad sense.  Cannot be null or empty.</param>
+        /// <param name="reflexive">Personal pronoun used as a coreferential to indicate the user.  Cannot be null or empty.</param>
+        public PronounGroup(string subjective, string objective, string determiner,
+                            string possessive, string reflexive)
         {
-            Precondition.IsNotNullOrEmpty(inSubjective, nameof(inSubjective));
-            Precondition.IsNotNullOrEmpty(inSubjective, nameof(inSubjective));
-            Precondition.IsNotNullOrEmpty(inSubjective, nameof(inSubjective));
-            Precondition.IsNotNullOrEmpty(inSubjective, nameof(inSubjective));
-            Precondition.IsNotNullOrEmpty(inSubjective, nameof(inSubjective));
+            Precondition.IsNotNullOrEmpty(subjective, nameof(subjective));
+            Precondition.IsNotNullOrEmpty(subjective, nameof(subjective));
+            Precondition.IsNotNullOrEmpty(subjective, nameof(subjective));
+            Precondition.IsNotNullOrEmpty(subjective, nameof(subjective));
+            Precondition.IsNotNullOrEmpty(subjective, nameof(subjective));
 
-            Subjective = inSubjective;
-            Objective = inObjective;
-            Determiner = inDeterminer;
-            Possessive = inPossessive;
-            Reflexive = inReflexive;
+            Subjective = subjective;
+            Objective = objective;
+            Determiner = determiner;
+            Possessive = possessive;
+            Reflexive = reflexive;
         }
         #endregion
 
@@ -170,9 +170,9 @@ namespace Parquet.Beings
         /// <summary>
         /// Writes the given <see cref="PronounGroup"/> records to the appropriate file.
         /// </summary>
-        public static void PutRecords(IEnumerable<PronounGroup> inGroups)
+        public static void PutRecords(IEnumerable<PronounGroup> groups)
         {
-            Precondition.IsNotNull(inGroups);
+            Precondition.IsNotNull(groups);
 
             using var writer = new StreamWriter(FilePath, false, new UTF8Encoding(true, true));
             using var csv = new CsvWriter(writer, CultureInfo.InvariantCulture);
@@ -185,7 +185,7 @@ namespace Parquet.Beings
 
             csv.WriteHeader<PronounGroup>();
             csv.NextRecord();
-            csv.WriteRecords(inGroups);
+            csv.WriteRecords(groups);
         }
         #endregion
 
@@ -200,10 +200,10 @@ namespace Parquet.Beings
         /// <summary>
         /// Replaces pronoun tags with the appropriate pronoun from the given <see cref="PronounGroup"/>.
         /// </summary>
-        /// <param name="inText">The text to transform.</param>
+        /// <param name="text">The text to transform.</param>
         /// <returns>The updated text.</returns>
-        public StringBuilder FillInPronouns(StringBuilder inText)
-            => inText?
+        public StringBuilder FillInPronouns(StringBuilder text)
+            => text?
                 .Replace(SubjectiveTag, Subjective)
                 .Replace(ObjectiveTag, Objective)
                 .Replace(DeterminerTag, Determiner)
@@ -213,10 +213,10 @@ namespace Parquet.Beings
         /// <summary>
         /// Replaces pronoun tags with the appropriate pronoun from the given <see cref="PronounGroup"/>.
         /// </summary>
-        /// <param name="inText">The text to transform.</param>
+        /// <param name="text">The text to transform.</param>
         /// <returns>The updated text.</returns>
-        public StringBuilder FillInPronouns(string inText)
-            => new StringBuilder(inText)
+        public StringBuilder FillInPronouns(string text)
+            => new StringBuilder(text)
                 .Replace(SubjectiveTag, Subjective)
                 .Replace(ObjectiveTag, Objective)
                 .Replace(DeterminerTag, Determiner)

--- a/ParquetClassLibrary/Beings/PronounGroup.cs
+++ b/ParquetClassLibrary/Beings/PronounGroup.cs
@@ -154,11 +154,7 @@ namespace Parquet.Beings
             using var reader = new StreamReader(FilePath);
             using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
             csv.Configuration.TypeConverterOptionsCache.AddOptions(typeof(ModelID), All.IdentifierOptions);
-            csv.Configuration.PrepareHeaderForMatch =
-                (string header, int index)
-                    => header.StartsWith("in", StringComparison.InvariantCulture)
-                        ? header[2..].ToUpperInvariant()
-                        : header.ToUpperInvariant();
+            csv.Configuration.PrepareHeaderForMatch = (string header, int index) => header.ToUpperInvariant();
             foreach (var kvp in All.ConversionConverters)
             {
                 csv.Configuration.TypeConverterCache.AddConverter(kvp.Key, kvp.Value);

--- a/ParquetClassLibrary/Biomes/BiomeRecipe.cs
+++ b/ParquetClassLibrary/Biomes/BiomeRecipe.cs
@@ -53,29 +53,29 @@ namespace Parquet.Biomes
         /// <summary>
         /// Initializes a new instance of the <see cref="BiomeRecipe"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="BiomeRecipe"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="BiomeRecipe"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="BiomeRecipe"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="BiomeRecipe"/>.</param>
-        /// <param name="inTags">Any additional functionality this <see cref="BiomeRecipe"/> has.</param>
-        /// <param name="inTier">A rating indicating where in the progression this <see cref="BiomeRecipe"/> falls.</param>
-        /// <param name="inIsRoomBased">Determines whether or not this <see cref="BiomeRecipe"/> is defined in terms of <see cref="Rooms.Room"/>s.</param>
-        /// <param name="inIsLiquidBased">Determines whether or not this <see cref="BiomeRecipe"/> is defined in terms of liquid parquets.</param>
-        /// <param name="inParquetCriteria">Describes the parquets that make up this <see cref="BiomeRecipe"/>.</param>
-        /// <param name="inEntryRequirements">Describes the <see cref="ItemModel"/>s needed to access this <see cref="BiomeRecipe"/>.</param>
-        public BiomeRecipe(ModelID inID, string inName, string inDescription, string inComment,
-                           IEnumerable<ModelTag> inTags = null, int inTier = 0, bool inIsRoomBased = false,
-                           bool inIsLiquidBased = false, ModelTag inParquetCriteria = null,
-                           IEnumerable<ModelTag> inEntryRequirements = null)
-            : base(All.BiomeRecipeIDs, inID, inName, inDescription, inComment, inTags)
+        /// <param name="id">Unique identifier for the <see cref="BiomeRecipe"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="BiomeRecipe"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="BiomeRecipe"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="BiomeRecipe"/>.</param>
+        /// <param name="tags">Any additional functionality this <see cref="BiomeRecipe"/> has.</param>
+        /// <param name="tier">A rating indicating where in the progression this <see cref="BiomeRecipe"/> falls.</param>
+        /// <param name="isRoomBased">Determines whether or not this <see cref="BiomeRecipe"/> is defined in terms of <see cref="Rooms.Room"/>s.</param>
+        /// <param name="isLiquidBased">Determines whether or not this <see cref="BiomeRecipe"/> is defined in terms of liquid parquets.</param>
+        /// <param name="parquetCriteria">Describes the parquets that make up this <see cref="BiomeRecipe"/>.</param>
+        /// <param name="entryRequirements">Describes the <see cref="ItemModel"/>s needed to access this <see cref="BiomeRecipe"/>.</param>
+        public BiomeRecipe(ModelID id, string name, string description, string comment,
+                           IEnumerable<ModelTag> tags = null, int tier = 0, bool isRoomBased = false,
+                           bool isLiquidBased = false, ModelTag parquetCriteria = null,
+                           IEnumerable<ModelTag> entryRequirements = null)
+            : base(All.BiomeRecipeIDs, id, name, description, comment, tags)
         {
-            Precondition.MustBeNonNegative(inTier, nameof(inTier));
+            Precondition.MustBeNonNegative(tier, nameof(tier));
 
-            Tier = inTier;
-            IsRoomBased = inIsRoomBased;
-            IsLiquidBased = inIsLiquidBased;
-            ParquetCriteria = inParquetCriteria ?? ModelTag.None;
-            EntryRequirements = (inEntryRequirements ?? Enumerable.Empty<ModelTag>()).ToList();
+            Tier = tier;
+            IsRoomBased = isRoomBased;
+            IsLiquidBased = isLiquidBased;
+            ParquetCriteria = parquetCriteria ?? ModelTag.None;
+            EntryRequirements = (entryRequirements ?? Enumerable.Empty<ModelTag>()).ToList();
         }
         #endregion
 

--- a/ParquetClassLibrary/Crafts/CraftingRecipe.cs
+++ b/ParquetClassLibrary/Crafts/CraftingRecipe.cs
@@ -47,26 +47,26 @@ namespace Parquet.Crafts
         /// <summary>
         /// Initializes a new instance of the <see cref="CraftingRecipe"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="CraftingRecipe"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="CraftingRecipe"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="CraftingRecipe"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="CraftingRecipe"/>.</param>
-        /// <param name="inTags">Any additional functionality this <see cref="CraftingRecipe"/> has.</param>
-        /// <param name="inProducts">The types and quantities of <see cref="Items.ItemModel"/>s created by following this recipe once.</param>
-        /// <param name="inIngredients">All items needed to follow this <see cref="CraftingRecipe"/> once.</param>
-        /// <param name="inPanelPattern">The arrangement of panels encompassed by this <see cref="CraftingRecipe"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="CraftingRecipe"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="CraftingRecipe"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="CraftingRecipe"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="CraftingRecipe"/>.</param>
+        /// <param name="tags">Any additional functionality this <see cref="CraftingRecipe"/> has.</param>
+        /// <param name="products">The types and quantities of <see cref="Items.ItemModel"/>s created by following this recipe once.</param>
+        /// <param name="ingredients">All items needed to follow this <see cref="CraftingRecipe"/> once.</param>
+        /// <param name="panelPattern">The arrangement of panels encompassed by this <see cref="CraftingRecipe"/>.</param>
         /// <remarks>
-        /// <paramref name="inPanelPattern"/> must have dimensions between <c>1</c> and those given by
+        /// <paramref name="panelPattern"/> must have dimensions between <c>1</c> and those given by
         /// <see cref="StrikePanelGrid.PanelsPerPatternWidth"/> and <see cref="StrikePanelGrid.PanelsPerPatternHeight"/>.
         /// </remarks>
-        public CraftingRecipe(ModelID inID, string inName, string inDescription, string inComment,
-                              IEnumerable<ModelTag> inTags = null, IEnumerable<RecipeElement> inProducts = null,
-                              IEnumerable<RecipeElement> inIngredients = null, IReadOnlyGrid<StrikePanel> inPanelPattern = null)
-            : base(All.CraftingRecipeIDs, inID, inName, inDescription, inComment, inTags)
+        public CraftingRecipe(ModelID id, string name, string description, string comment,
+                              IEnumerable<ModelTag> tags = null, IEnumerable<RecipeElement> products = null,
+                              IEnumerable<RecipeElement> ingredients = null, IReadOnlyGrid<StrikePanel> panelPattern = null)
+            : base(All.CraftingRecipeIDs, id, name, description, comment, tags)
         {
-            var nonNullProducts = inProducts ?? Enumerable.Empty<RecipeElement>();
-            var nonNullIngredients = inIngredients ?? Enumerable.Empty<RecipeElement>();
-            var nonNullPanelPattern = inPanelPattern ?? StrikePanelGrid.Empty;
+            var nonNullProducts = products ?? Enumerable.Empty<RecipeElement>();
+            var nonNullIngredients = ingredients ?? Enumerable.Empty<RecipeElement>();
+            var nonNullPanelPattern = panelPattern ?? StrikePanelGrid.Empty;
 
             // NOTE that these two checks should not be made from within editing tools.
             if (LibraryState.IsPlayMode)
@@ -75,14 +75,14 @@ namespace Parquet.Crafts
                 if (!CraftConfiguration.ProductCount.ContainsValue(count))
                 {
                     Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                               $"{nameof(inProducts)}.Count", count,
+                                                               $"{nameof(products)}.Count", count,
                                                                CraftConfiguration.ProductCount));
                 }
                 count = nonNullIngredients.Count();
                 if (!CraftConfiguration.IngredientCount.ContainsValue(count))
                 {
                     Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                               $"{nameof(inIngredients)}.Count", count,
+                                                               $"{nameof(ingredients)}.Count", count,
                                                                CraftConfiguration.IngredientCount));
                 }
             }
@@ -92,7 +92,7 @@ namespace Parquet.Crafts
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture,
                                                            Resources.ErrorUnsupportedDimension,
-                                                           nameof(inPanelPattern)));
+                                                           nameof(panelPattern)));
             }
 
             Products = nonNullProducts.ToList();
@@ -133,11 +133,11 @@ namespace Parquet.Crafts
         IGrid<StrikePanel> IMutableCraftingRecipe.PanelPattern => (IGrid<StrikePanel>)PanelPattern;
 
         /// <summary>Replaces the content of <see cref="PanelPattern"/> with the given pattern.</summary>
-        /// <param name="inReplacement">The new pattern to use.</param>
-        public void PanelPatternReplace(IGrid<StrikePanel> inReplacement)
+        /// <param name="replacement">The new pattern to use.</param>
+        public void PanelPatternReplace(IGrid<StrikePanel> replacement)
             => PanelPattern = LibraryState.IsPlayMode
                 ? Logger.DefaultWithImmutableInPlayLog(nameof(PanelPattern), PanelPattern)
-                : inReplacement as StrikePanelGrid ?? StrikePanelGrid.Empty;
+                : replacement as StrikePanelGrid ?? StrikePanelGrid.Empty;
         #endregion
     }
 }

--- a/ParquetClassLibrary/Crafts/IMutableCraftingRecipe.cs
+++ b/ParquetClassLibrary/Crafts/IMutableCraftingRecipe.cs
@@ -21,7 +21,7 @@ namespace Parquet.Crafts
         public IGrid<StrikePanel> PanelPattern { get; }
 
         /// <summary>Replaces the content of <see cref="PanelPattern"/> with the given pattern.</summary>
-        /// <param name="inReplacement">The new pattern to use.</param>
-        public void PanelPatternReplace(IGrid<StrikePanel> inReplacement);
+        /// <param name="replacement">The new pattern to use.</param>
+        public void PanelPatternReplace(IGrid<StrikePanel> replacement);
     }
 }

--- a/ParquetClassLibrary/Crafts/StrikePanel.cs
+++ b/ParquetClassLibrary/Crafts/StrikePanel.cs
@@ -233,14 +233,14 @@ namespace Parquet.Crafts
         /// <summary>
         /// Determines if the given position corresponds to a point within the current array.
         /// </summary>
-        /// <param name="inStrikePanels">The <see cref="StrikePanel"/> to check against.</param>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="strikePanels">The <see cref="StrikePanel"/> to check against.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public static bool IsValidPosition(this StrikePanel[,] inStrikePanels, Point2D inPosition)
-            => inStrikePanels is not null
-                && inPosition.X > -1
-                && inPosition.Y > -1
-                && inPosition.X < inStrikePanels.GetLength(1)
-                && inPosition.Y < inStrikePanels.GetLength(0);
+        public static bool IsValidPosition(this StrikePanel[,] strikePanels, Point2D position)
+            => strikePanels is not null
+                && position.X > -1
+                && position.Y > -1
+                && position.X < strikePanels.GetLength(1)
+                && position.Y < strikePanels.GetLength(0);
     }
 }

--- a/ParquetClassLibrary/Crafts/StrikePanel.cs
+++ b/ParquetClassLibrary/Crafts/StrikePanel.cs
@@ -94,13 +94,13 @@ namespace Parquet.Crafts
         /// <summary>
         /// Initializes a new instance of the <see cref="StrikePanel"/> class.
         /// </summary>
-        /// <param name="inWorkingRange">The range of values this panel can take on while being worked.</param>
-        /// <param name="inIdealRange">The range of values this panel targets for a completed craft.</param>
-        public StrikePanel(Range<int> inWorkingRange, Range<int> inIdealRange)
+        /// <param name="workingRange">The range of values this panel can take on while being worked.</param>
+        /// <param name="idealRange">The range of values this panel targets for a completed craft.</param>
+        public StrikePanel(Range<int> workingRange, Range<int> idealRange)
         {
             // NOTE the use of the backing struct to avoid preinitialized range-checking.
-            workingRangeBackingStruct = inWorkingRange;
-            IdealRange = inIdealRange;
+            workingRangeBackingStruct = workingRange;
+            IdealRange = idealRange;
         }
         #endregion
 
@@ -126,11 +126,11 @@ namespace Parquet.Crafts
         /// <summary>
         /// Determines whether the specified <see cref="StrikePanel"/> is equal to the current <see cref="StrikePanel"/>.
         /// </summary>
-        /// <param name="inStrikePanel">The <see cref="StrikePanel"/> to compare with the current.</param>
+        /// <param name="strikePanel">The <see cref="StrikePanel"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(StrikePanel inStrikePanel)
-            => workingRangeBackingStruct == inStrikePanel?.workingRangeBackingStruct
-            && idealRangeBackingStruct == inStrikePanel.idealRangeBackingStruct;
+        public bool Equals(StrikePanel strikePanel)
+            => workingRangeBackingStruct == strikePanel?.workingRangeBackingStruct
+            && idealRangeBackingStruct == strikePanel.idealRangeBackingStruct;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="StrikePanel"/>.
@@ -144,20 +144,20 @@ namespace Parquet.Crafts
         /// <summary>
         /// Determines whether a specified instance of <see cref="StrikePanel"/> is equal to another specified instance of <see cref="StrikePanel"/>.
         /// </summary>
-        /// <param name="inStrikePanel1">The first <see cref="StrikePanel"/> to compare.</param>
-        /// <param name="inStrikePanel2">The second <see cref="StrikePanel"/> to compare.</param>
+        /// <param name="strikePanel1">The first <see cref="StrikePanel"/> to compare.</param>
+        /// <param name="strikePanel2">The second <see cref="StrikePanel"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(StrikePanel inStrikePanel1, StrikePanel inStrikePanel2)
-            => inStrikePanel1?.Equals(inStrikePanel2) ?? inStrikePanel2?.Equals(inStrikePanel1) ?? true;
+        public static bool operator ==(StrikePanel strikePanel1, StrikePanel strikePanel2)
+            => strikePanel1?.Equals(strikePanel2) ?? strikePanel2?.Equals(strikePanel1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="StrikePanel"/> is not equal to another specified instance of <see cref="StrikePanel"/>.
         /// </summary>
-        /// <param name="inStrikePanel1">The first <see cref="StrikePanel"/> to compare.</param>
-        /// <param name="inStrikePanel2">The second <see cref="StrikePanel"/> to compare.</param>
+        /// <param name="strikePanel1">The first <see cref="StrikePanel"/> to compare.</param>
+        /// <param name="strikePanel2">The second <see cref="StrikePanel"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(StrikePanel inStrikePanel1, StrikePanel inStrikePanel2)
-            => !(inStrikePanel1 == inStrikePanel2);
+        public static bool operator !=(StrikePanel strikePanel1, StrikePanel strikePanel2)
+            => !(strikePanel1 == strikePanel2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -167,21 +167,21 @@ namespace Parquet.Crafts
         /// <summary>
         /// Converts the given <see cref="string"/> to a <see cref="StrikePanel"/>.
         /// </summary>
-        /// <param name="inText">The <see cref="string"/> to convert to an object.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The <see cref="string"/> to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <returns>The <see cref="StrikePanel"/> created from the <see cref="string"/>.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Unused), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Unused), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Unused;
             }
 
-            var panelSplitText = inText.Split(Delimiters.InternalDelimiter);
-            var workingRangeDeserialized = (Range<int>)Range<int>.ConverterFactory.ConvertFromString(panelSplitText[0], inRow, inMemberMapData);
-            var idealRangeDeserialized = (Range<int>)Range<int>.ConverterFactory.ConvertFromString(panelSplitText[1], inRow, inMemberMapData);
+            var panelSplitText = text.Split(Delimiters.InternalDelimiter);
+            var workingRangeDeserialized = (Range<int>)Range<int>.ConverterFactory.ConvertFromString(panelSplitText[0], row, memberMapData);
+            var idealRangeDeserialized = (Range<int>)Range<int>.ConverterFactory.ConvertFromString(panelSplitText[1], row, memberMapData);
 
             return new StrikePanel(workingRangeDeserialized, idealRangeDeserialized);
         }
@@ -189,19 +189,19 @@ namespace Parquet.Crafts
         /// <summary>
         /// Converts the given <see cref="StrikePanel"/> to a record column.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
         /// <returns>The <see cref="StrikePanel"/> as a CSV record.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is StrikePanel panel
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is StrikePanel panel
                 ? Unused == panel
                     ? nameof(Unused)
                     : $"{panel.WorkingRange.Minimum}{Delimiters.ElementDelimiter}" +
                       $"{panel.WorkingRange.Maximum}{Delimiters.InternalDelimiter}" +
                       $"{panel.IdealRange.Minimum}{Delimiters.ElementDelimiter}" +
                       $"{panel.IdealRange.Maximum}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(StrikePanel), nameof(Unused));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(StrikePanel), nameof(Unused));
         #endregion
 
         #region IDeeplyCloneable Implementation

--- a/ParquetClassLibrary/Crafts/StrikePanelGrid.cs
+++ b/ParquetClassLibrary/Crafts/StrikePanelGrid.cs
@@ -43,15 +43,15 @@ namespace Parquet.Crafts
         /// <summary>
         /// Initializes a new <see cref="StrikePanelGrid"/>.
         /// </summary>
-        /// <param name="inRowCount">The length of the Y dimension of the collection.</param>
-        /// <param name="inColumnCount">The length of the X dimension of the collection.</param>
+        /// <param name="rowCount">The length of the Y dimension of the collection.</param>
+        /// <param name="columnCount">The length of the X dimension of the collection.</param>
         /// <remarks>This constructor supports instance creation via reflection from the <see cref="GridConverter{TElement, TGrid}"/> class.</remarks>
-        public StrikePanelGrid(int inRowCount, int inColumnCount)
+        public StrikePanelGrid(int rowCount, int columnCount)
         {
-            StrikePanels = new StrikePanel[inRowCount, inColumnCount];
-            for (var y = 0; y < inRowCount; y++)
+            StrikePanels = new StrikePanel[rowCount, columnCount];
+            for (var y = 0; y < rowCount; y++)
             {
-                for (var x = 0; x < inColumnCount; x++)
+                for (var x = 0; x < columnCount; x++)
                 {
                     StrikePanels[y, x] = StrikePanel.Unused.DeepClone();
                 }
@@ -61,22 +61,22 @@ namespace Parquet.Crafts
         /// <summary>
         /// Initializes a new <see cref="StrikePanelGrid"/> similar to the one provided but with the given dimensions.
         /// </summary>
-        /// <param name="inContent">An existing <see cref="StrikePanelGrid"/>.</param>
-        /// <param name="inRowCount">The length of the Y dimension of the collection.</param>
-        /// <param name="inColumnCount">The length of the X dimension of the collection.</param>
+        /// <param name="content">An existing <see cref="StrikePanelGrid"/>.</param>
+        /// <param name="rowCount">The length of the Y dimension of the collection.</param>
+        /// <param name="columnCount">The length of the X dimension of the collection.</param>
         /// <remarks>This constructor supports instance creation via reflection from the <see cref="GridConverter{TElement, TGrid}"/> class.</remarks>
-        public StrikePanelGrid(IGrid<StrikePanel> inContent, int inRowCount, int inColumnCount)
+        public StrikePanelGrid(IGrid<StrikePanel> content, int rowCount, int columnCount)
         {
-            StrikePanels = new StrikePanel[inRowCount, inColumnCount];
-            if (inContent is not null)
+            StrikePanels = new StrikePanel[rowCount, columnCount];
+            if (content is not null)
             {
-                for (var y = 0; y < inRowCount; y++)
+                for (var y = 0; y < rowCount; y++)
                 {
-                    for (var x = 0; x < inColumnCount; x++)
+                    for (var x = 0; x < columnCount; x++)
                     {
-                        StrikePanels[y, x] = x < inContent.Columns
-                                           && y < inContent.Rows
-                            ? inContent[y, x].DeepClone()
+                        StrikePanels[y, x] = x < content.Columns
+                                           && y < content.Rows
+                            ? content[y, x].DeepClone()
                             : StrikePanel.Unused.DeepClone();
                     }
                 }
@@ -156,10 +156,10 @@ namespace Parquet.Crafts
         /// <summary>
         /// Determines if the given position corresponds to a point within the collection.
         /// </summary>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public bool IsValidPosition(Point2D inPosition)
-            => StrikePanels.IsValidPosition(inPosition);
+        public bool IsValidPosition(Point2D position)
+            => StrikePanels.IsValidPosition(position);
         #endregion
     }
 }

--- a/ParquetClassLibrary/EmptyTolerantEnumConverter.cs
+++ b/ParquetClassLibrary/EmptyTolerantEnumConverter.cs
@@ -19,41 +19,41 @@ namespace Parquet
         /// <summary>
         /// Creates a new <see cref="EmptyTolerantEnumConverter"/> for the given <see cref="Enum"/> <see cref="Type"/>.
         /// </summary>
-        /// <param name="inType">The type of the enumeration.</param>
-        public EmptyTolerantEnumConverter(Type inType)
-            : base(inType)
-            => EnumType = (inType?.IsEnum ?? false)
-                ? inType
-                : DefaultWithCastLog(nameof(inType), inType?.Name ?? "null", nameof(Enum), default(Type));
+        /// <param name="type">The type of the enumeration.</param>
+        public EmptyTolerantEnumConverter(Type type)
+            : base(type)
+            => EnumType = (type?.IsEnum ?? false)
+                ? type
+                : DefaultWithCastLog(nameof(type), type?.Name ?? "null", nameof(Enum), default(Type));
 
         /// <summary>
         /// Convenience method that logs a casting error and returns the given default value.
         /// This is a fatal error as the library will be unable to handle a default type in place of an enumeration.
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
-        /// <param name="inValue">The value that could not be case.</param>
-        /// <param name="inActualTypeName">The name of type received.</param>
-        /// <param name="inExpectedTypeName">The name of type expected.</param>
-        /// <param name="inDefaultValue">The default value to return.</param>
+        /// <param name="value">The value that could not be case.</param>
+        /// <param name="actualTypeName">The name of type received.</param>
+        /// <param name="expectedTypeName">The name of type expected.</param>
+        /// <param name="defaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        private static T DefaultWithCastLog<T>(string inValue, string inActualTypeName, string inExpectedTypeName, T inDefaultValue)
+        private static T DefaultWithCastLog<T>(string value, string actualTypeName, string expectedTypeName, T defaultValue)
         {
             Logger.Log(LogLevel.Fatal, string.Format(CultureInfo.CurrentCulture, Resources.ErrorInvalidCast,
-                                                     inValue, inActualTypeName, inExpectedTypeName), null);
+                                                     value, actualTypeName, expectedTypeName), null);
 
-            return inDefaultValue;
+            return defaultValue;
         }
 
         /// <summary>
         /// Converts the <c>string</c> to an <c>object</c>.
         /// </summary>
-        /// <param name="inText">The string to convert.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The string to convert.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <returns>The object created from the string.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
-            => string.IsNullOrEmpty(inText)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+            => string.IsNullOrEmpty(text)
                 ? Activator.CreateInstance(EnumType)
-                : base.ConvertFromString(inText, inRow, inMemberMapData);
+                : base.ConvertFromString(text, row, memberMapData);
     }
 }

--- a/ParquetClassLibrary/Games/GameModel.cs
+++ b/ParquetClassLibrary/Games/GameModel.cs
@@ -43,30 +43,30 @@ namespace Parquet.Games
         /// Models a full game or an episode in a serial game.
         /// Contains metadata and starting conditions.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="GameModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-facing title of the <see cref="GameModel"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-facing description of the <see cref="GameModel"/>.</param>
-        /// <param name="inComment">A private comment on the nature of the game or episode.</param>
-        /// <param name="inTags">Any additional information about this <see cref="GameModel"/>.</param>
-        /// <param name="inIsEpisode">If <c>true</c> this game is part of a longer sequence of games.</param>
-        /// <param name="inEpisodeTitle">Title of this episode, if any.</param>
-        /// <param name="inEpisodeNumber">Number of this episode in its sequence, if any.</param>
-        /// <param name="inPlayerCharacterID">The <see cref="ModelID"/> of the <see cref="Beings.CharacterModel"/> that the player controls at the outset.</param>
-        /// <param name="inFirstScriptID">The <see cref="ModelID"/> of the <see cref="Scripts.ScriptModel"/> to run when play begins.</param>
-        public GameModel(ModelID inID, string inName, string inDescription, string inComment,
-                         IEnumerable<ModelTag> inTags = null, bool inIsEpisode = false, string inEpisodeTitle = "",
-                         int inEpisodeNumber = 0, ModelID? inPlayerCharacterID = null, ModelID? inFirstScriptID = null)
-            : base(All.GameIDs, inID, inName, inDescription, inComment, inTags)
+        /// <param name="id">Unique identifier for the <see cref="GameModel"/>.  Cannot be null.</param>
+        /// <param name="name">Player-facing title of the <see cref="GameModel"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-facing description of the <see cref="GameModel"/>.</param>
+        /// <param name="comment">A private comment on the nature of the game or episode.</param>
+        /// <param name="tags">Any additional information about this <see cref="GameModel"/>.</param>
+        /// <param name="isEpisode">If <c>true</c> this game is part of a longer sequence of games.</param>
+        /// <param name="episodeTitle">Title of this episode, if any.</param>
+        /// <param name="episodeNumber">Number of this episode in its sequence, if any.</param>
+        /// <param name="playerCharacterID">The <see cref="ModelID"/> of the <see cref="Beings.CharacterModel"/> that the player controls at the outset.</param>
+        /// <param name="firstScriptID">The <see cref="ModelID"/> of the <see cref="Scripts.ScriptModel"/> to run when play begins.</param>
+        public GameModel(ModelID id, string name, string description, string comment,
+                         IEnumerable<ModelTag> tags = null, bool isEpisode = false, string episodeTitle = "",
+                         int episodeNumber = 0, ModelID? playerCharacterID = null, ModelID? firstScriptID = null)
+            : base(All.GameIDs, id, name, description, comment, tags)
         {
-            var nonNullPlayerCharacterID = inPlayerCharacterID ?? ModelID.None;
-            var nonNullFirstScriptID = inFirstScriptID ?? ModelID.None;
+            var nonNullPlayerCharacterID = playerCharacterID ?? ModelID.None;
+            var nonNullFirstScriptID = firstScriptID ?? ModelID.None;
 
-            Precondition.IsInRange(nonNullPlayerCharacterID, All.CharacterIDs, nameof(inPlayerCharacterID));
-            Precondition.IsInRange(nonNullFirstScriptID, All.ScriptIDs, nameof(inFirstScriptID));
+            Precondition.IsInRange(nonNullPlayerCharacterID, All.CharacterIDs, nameof(playerCharacterID));
+            Precondition.IsInRange(nonNullFirstScriptID, All.ScriptIDs, nameof(firstScriptID));
 
-            IsEpisode = inIsEpisode;
-            EpisodeTitle = IsEpisode ? inEpisodeTitle : "";
-            EpisodeNumber = IsEpisode ? inEpisodeNumber : 0;
+            IsEpisode = isEpisode;
+            EpisodeTitle = IsEpisode ? episodeTitle : "";
+            EpisodeNumber = IsEpisode ? episodeNumber : 0;
             PlayerCharacterID = nonNullPlayerCharacterID;
             FirstScriptID = nonNullFirstScriptID;
         }

--- a/ParquetClassLibrary/Games/GameStatus.cs
+++ b/ParquetClassLibrary/Games/GameStatus.cs
@@ -35,25 +35,25 @@ namespace Parquet.Games
         /// <summary>
         /// Initializes a new instance of the <see cref="GameStatus"/> class.
         /// </summary>
-        /// <param name="inPlayerCharacterID">The <see cref="ModelID"/> of the <see cref="Beings.CharacterModel"/> that the player controls at the outset.</param>
-        /// <param name="inCurrentScriptID">The <see cref="ModelID"/> of the <see cref="Scripts.ScriptModel"/> to run when play begins.</param>
-        public GameStatus(ModelID? inPlayerCharacterID, ModelID? inCurrentScriptID)
+        /// <param name="playerCharacterID">The <see cref="ModelID"/> of the <see cref="Beings.CharacterModel"/> that the player controls at the outset.</param>
+        /// <param name="currentScriptID">The <see cref="ModelID"/> of the <see cref="Scripts.ScriptModel"/> to run when play begins.</param>
+        public GameStatus(ModelID? playerCharacterID, ModelID? currentScriptID)
         {
-            PlayerCharacterID = inPlayerCharacterID ?? ModelID.None;
-            CurrentScriptID = inCurrentScriptID ?? ModelID.None;
+            PlayerCharacterID = playerCharacterID ?? ModelID.None;
+            CurrentScriptID = currentScriptID ?? ModelID.None;
         }
 
         /// <summary>
         /// Initializes an instance of the <see cref="GameStatus"/> class
         /// based on a given <see cref="GameModel"/> instance.
         /// </summary>
-        /// <param name="inGameModel">The definitions being tracked.</param>
-        public GameStatus(GameModel inGameModel)
+        /// <param name="gameModel">The definitions being tracked.</param>
+        public GameStatus(GameModel gameModel)
         {
-            Precondition.IsNotNull(inGameModel);
-            var nonNullGameModel = inGameModel is null
+            Precondition.IsNotNull(gameModel);
+            var nonNullGameModel = gameModel is null
                 ? GameModel.Empty
-                : inGameModel;
+                : gameModel;
 
             PlayerCharacterID = nonNullGameModel.PlayerCharacterID;
             CurrentScriptID = nonNullGameModel.FirstScriptID;
@@ -71,12 +71,12 @@ namespace Parquet.Games
         /// <summary>
         /// Determines whether the specified <see cref="GameStatus"/> is equal to the current <see cref="GameStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="GameStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="GameStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is GameStatus status
-            && PlayerCharacterID == status.PlayerCharacterID
-            && CurrentScriptID == status.CurrentScriptID;
+        public override bool Equals<T>(T status)
+            => status is GameStatus gameStatus
+            && PlayerCharacterID == gameStatus.PlayerCharacterID
+            && CurrentScriptID == gameStatus.CurrentScriptID;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="GameStatus"/>.
@@ -90,20 +90,20 @@ namespace Parquet.Games
         /// <summary>
         /// Determines whether a specified instance of <see cref="GameStatus"/> is equal to another specified instance of <see cref="GameStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="GameStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="GameStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="GameStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="GameStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(GameStatus inStatus1, GameStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(GameStatus status1, GameStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="GameStatus"/> is not equal to another specified instance of <see cref="GameStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="GameStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="GameStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="GameStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="GameStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(GameStatus inStatus1, GameStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(GameStatus status1, GameStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -113,35 +113,35 @@ namespace Parquet.Games
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is GameStatus status
-                ? $"{ModelID.ConverterFactory.ConvertToString(status.PlayerCharacterID, inRow, inMemberMapData)}{Delimiters.InternalDelimiter}" +
-                  $"{ModelID.ConverterFactory.ConvertToString(status.CurrentScriptID, inRow, inMemberMapData)}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(GameStatus), nameof(Default));
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is GameStatus status
+                ? $"{ModelID.ConverterFactory.ConvertToString(status.PlayerCharacterID, row, memberMapData)}{Delimiters.InternalDelimiter}" +
+                  $"{ModelID.ConverterFactory.ConvertToString(status.CurrentScriptID, row, memberMapData)}"
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(GameStatus), nameof(Default));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Default), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Default), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Default.DeepClone();
             }
 
-            var parameterText = inText.Split(Delimiters.InternalDelimiter);
+            var parameterText = text.Split(Delimiters.InternalDelimiter);
 
-            var parsedPlayerCharacterID = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[0], inRow, inMemberMapData);
-            var parsedCurrentScriptID = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[1], inRow, inMemberMapData);
+            var parsedPlayerCharacterID = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[0], row, memberMapData);
+            var parsedCurrentScriptID = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[1], row, memberMapData);
 
             return new GameStatus(parsedPlayerCharacterID, parsedCurrentScriptID);
         }

--- a/ParquetClassLibrary/GlobalSuppressions.cs
+++ b/ParquetClassLibrary/GlobalSuppressions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
                            Justification = "Parquet logs errors and returns results; it does not throw exceptions.",
                            Scope = "namespaceanddescendants", Target = "~N:Parquet")]
 
+// TODO: Try removing this after refactoring for in prefix.
 [assembly: SuppressMessage("Naming", "CA1725:Parameter names should match base declaration",
                            Justification = "This rule inhibits clarity as it prefers general terms to specific terms.  (For example, calling a Model an Object.)",
                            Scope = "namespaceanddescendants", Target = "~N:Parquet")]

--- a/ParquetClassLibrary/GlobalSuppressions.cs
+++ b/ParquetClassLibrary/GlobalSuppressions.cs
@@ -6,9 +6,8 @@ using System.Diagnostics.CodeAnalysis;
                            Justification = "Parquet logs errors and returns results; it does not throw exceptions.",
                            Scope = "namespaceanddescendants", Target = "~N:Parquet")]
 
-// TODO: Try removing this after refactoring for in prefix.
 [assembly: SuppressMessage("Naming", "CA1725:Parameter names should match base declaration",
-                           Justification = "This rule inhibits clarity as it prefers general terms to specific terms.  (For example, calling a Model an Object.)",
+                           Justification = "This rule inhibits clarity as it prefers general terms to specific terms.  Also, it creates confusion by forcing non-ItemModels to be called 'item' (for example, when implementing IEnumerableConverter).",
                            Scope = "namespaceanddescendants", Target = "~N:Parquet")]
 
 [assembly: SuppressMessage("Performance", "CA1814:Prefer jagged arrays over multidimensional",

--- a/ParquetClassLibrary/GridConverter.cs
+++ b/ParquetClassLibrary/GridConverter.cs
@@ -28,15 +28,15 @@ namespace Parquet
         /// <summary>
         /// Converts the given 2D collection into a record column.
         /// </summary>
-        /// <param name="inValue">The collection to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The collection to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given collection serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
         {
-            if (inValue is not IGrid<TElement> grid)
+            if (value is not IGrid<TElement> grid)
             {
-                return Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(IGrid<TElement>), "");
+                return Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(IGrid<TElement>), "");
             }
 
             if (grid.Count < 1
@@ -56,7 +56,7 @@ namespace Parquet
             {
                 for (var x = 0; x < grid.Columns; x++)
                 {
-                    result.Append(grid[y, x].ConvertToString(grid[y, x], inRow, inMemberMapData));
+                    result.Append(grid[y, x].ConvertToString(grid[y, x], row, memberMapData));
                     result.Append(gridDelimiter[0]);
                 }
             }
@@ -68,20 +68,20 @@ namespace Parquet
         /// <summary>
         /// Converts the given record column to a 2D collection.
         /// </summary>
-        /// <param name="inText">The record column to convert to an object.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The record column to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <returns>The <see cref="IGrid{TElement}"/> created from the record column.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(ModelID.None), inText, StringComparison.OrdinalIgnoreCase) == 0
-                || string.Compare(nameof(Enumerable.Empty), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(ModelID.None), text, StringComparison.OrdinalIgnoreCase) == 0
+                || string.Compare(nameof(Enumerable.Empty), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new TGrid();
             }
 
-            var headerAndGridTexts = inText.Split(Delimiters.DimensionalTerminator);
+            var headerAndGridTexts = text.Split(Delimiters.DimensionalTerminator);
             var header = headerAndGridTexts[0].Split(Delimiters.DimensionalDelimiter);
             var rowCount = int.TryParse(header[0], All.SerializedNumberStyle, CultureInfo.InvariantCulture, out var temp1)
                 ? temp1
@@ -103,7 +103,7 @@ namespace Parquet
                     }
 
                     var currentText = (string)gridTextEnumerator.Current;
-                    grid[y, x] = (TElement)ElementFactory.ConvertFromString(currentText, inRow, inMemberMapData);
+                    grid[y, x] = (TElement)ElementFactory.ConvertFromString(currentText, row, memberMapData);
                 }
             }
             return grid;

--- a/ParquetClassLibrary/ILogger.cs
+++ b/ParquetClassLibrary/ILogger.cs
@@ -14,9 +14,9 @@ namespace Parquet
         /// <summary>
         /// Writes a log entry.
         /// </summary>
-        /// <param name="inLogLevel">The severity of the event being logged.</param>
-        /// <param name="inMessage">A message summarizing the event being logged.</param>
-        /// <param name="inException">The exception related to this event, if any.</param>
-        void Log(LogLevel inLogLevel, string inMessage, Exception inException);
+        /// <param name="logLevel">The severity of the event being logged.</param>
+        /// <param name="message">A message summarizing the event being logged.</param>
+        /// <param name="exception">The exception related to this event, if any.</param>
+        void Log(LogLevel logLevel, string message, Exception exception);
     }
 }

--- a/ParquetClassLibrary/IMutableModelCollection.cs
+++ b/ParquetClassLibrary/IMutableModelCollection.cs
@@ -13,14 +13,14 @@ namespace Parquet
         /// <summary>
         /// Removes the <typeparamref name="TModel"/> associated with the given <see cref="ModelID"/> from the collection.
         /// </summary>
-        /// <param name="inID">The ID for a valid, defined <typeparamref name="TModel"/> contained in this collection.</param>
-        public bool Remove(ModelID inID);
+        /// <param name="id">The ID for a valid, defined <typeparamref name="TModel"/> contained in this collection.</param>
+        public bool Remove(ModelID id);
 
         /// <summary>
         /// Replaces a contained <typeparamref name="TModel"/> with the given <typeparamref name="TModel"/> whose
         /// <see cref="ModelID"/> is identical to that of the model being replaced.
         /// </summary>
-        /// <param name="inModel">A valid, defined <typeparamref name="TModel"/> contained in this collection.</param>
-        public void Replace(TModel inModel);
+        /// <param name="model">A valid, defined <typeparamref name="TModel"/> contained in this collection.</param>
+        public void Replace(TModel model);
     }
 }

--- a/ParquetClassLibrary/IReadOnlyCollectionOfTagsExtensions.cs
+++ b/ParquetClassLibrary/IReadOnlyCollectionOfTagsExtensions.cs
@@ -4,29 +4,29 @@ using System.Linq;
 namespace Parquet
 {
     /// <summary>
-    /// Extensions to the <see cref="IReadOnlyList{T}"/> interface for working with <see cref="ModelTag"/>s.
+    /// Extensions to the <see cref="IReadOnlyCollection{T}"/> interface for working with <see cref="ModelTag"/>s.
     /// </summary>
-    public static class IReadOnlyListOfTagsExtensions
+    public static class IReadOnlyCollectionOfTagsExtensions
     {
         /// <summary>
-        /// Determines whether this <see cref="IReadOnlyList{ModelTag}"/> contains a <see cref="ModelTag"/>
+        /// Determines whether this <see cref="IReadOnlyCollection{ModelTag}"/> contains a <see cref="ModelTag"/>
         /// beginning with the given prefix.
         /// </summary>
-        /// <param name="collection">The <see cref="IReadOnlyList{ModelTag}"/> to search.</param>
+        /// <param name="collection">The <see cref="IReadOnlyCollection{ModelTag}"/> to search.</param>
         /// <param name="prefix">The <see cref="ModelTag"/> prefix to search for.</param>
         /// <returns><c>true</c> if this and the given instance are identical, ignoring case; otherwise, <c>false</c>.</returns>
         /// <remarks>This is a convenience for client code and not used by the library itself.</remarks>
-        public static bool ContainsPrefixOrdinalIgnoreCase(this IReadOnlyList<ModelTag> collection, ModelTag prefix)
+        public static bool ContainsPrefixOrdinalIgnoreCase(this IReadOnlyCollection<ModelTag> collection, ModelTag prefix)
             => collection.Any(tag => tag.StartsWithOrdinalIgnoreCase(prefix));
 
         /// <summary>
-        /// Determines whether this <see cref="IReadOnlyList{ModelTag}"/> contains the given <see cref="ModelTag"/>.
+        /// Determines whether this <see cref="IReadOnlyCollection{ModelTag}"/> contains the given <see cref="ModelTag"/>.
         /// </summary>
-        /// <param name="collection">The <see cref="IReadOnlyList{ModelTag}"/> to search.</param>
+        /// <param name="collection">The <see cref="IReadOnlyCollection{ModelTag}"/> to search.</param>
         /// <param name="tag">The <see cref="ModelTag"/> to search for.</param>
         /// <returns><c>true</c> if this and the given instance are identical, ignoring case; otherwise, <c>false</c>.</returns>
         /// <remarks>This is a convenience for client code and not used by the library itself.</remarks>
-        public static bool ContainsOrdinalIgnoreCase(this IReadOnlyList<ModelTag> collection, ModelTag tag)
+        public static bool ContainsOrdinalIgnoreCase(this IReadOnlyCollection<ModelTag> collection, ModelTag tag)
             => collection.Any(tag => tag.EqualsOrdinalIgnoreCase(tag));
     }
 }

--- a/ParquetClassLibrary/IReadOnlyCollectionOfTagsExtensions.cs
+++ b/ParquetClassLibrary/IReadOnlyCollectionOfTagsExtensions.cs
@@ -27,6 +27,6 @@ namespace Parquet
         /// <returns><c>true</c> if this and the given instance are identical, ignoring case; otherwise, <c>false</c>.</returns>
         /// <remarks>This is a convenience for client code and not used by the library itself.</remarks>
         public static bool ContainsOrdinalIgnoreCase(this IReadOnlyCollection<ModelTag> collection, ModelTag tag)
-            => collection.Any(tag => tag.EqualsOrdinalIgnoreCase(tag));
+            => collection.Any(aTag => aTag.EqualsOrdinalIgnoreCase(tag));
     }
 }

--- a/ParquetClassLibrary/IReadOnlyListOfTagsExtensions.cs
+++ b/ParquetClassLibrary/IReadOnlyListOfTagsExtensions.cs
@@ -23,10 +23,10 @@ namespace Parquet
         /// Determines whether this <see cref="IReadOnlyCollection{ModelTag}"/> contains the given <see cref="ModelTag"/>.
         /// </summary>
         /// <param name="inList">The <see cref="IReadOnlyCollection{ModelTag}"/> to search.</param>
-        /// <param name="inTag">The <see cref="ModelTag"/> to search for.</param>
+        /// <param name="tag">The <see cref="ModelTag"/> to search for.</param>
         /// <returns><c>true</c> if this and the given instance are identical, ignoring case; otherwise, <c>false</c>.</returns>
         /// <remarks>This is a convenience for client code and not used by the library itself.</remarks>
-        public static bool ContainsOrdinalIgnoreCase(this IReadOnlyList<ModelTag> inList, ModelTag inTag)
-            => inList.Any(tag => tag.EqualsOrdinalIgnoreCase(inTag));
+        public static bool ContainsOrdinalIgnoreCase(this IReadOnlyList<ModelTag> inList, ModelTag tag)
+            => inList.Any(aTag => aTag.EqualsOrdinalIgnoreCase(tag));
     }
 }

--- a/ParquetClassLibrary/IReadOnlyListOfTagsExtensions.cs
+++ b/ParquetClassLibrary/IReadOnlyListOfTagsExtensions.cs
@@ -27,6 +27,6 @@ namespace Parquet
         /// <returns><c>true</c> if this and the given instance are identical, ignoring case; otherwise, <c>false</c>.</returns>
         /// <remarks>This is a convenience for client code and not used by the library itself.</remarks>
         public static bool ContainsOrdinalIgnoreCase(this IReadOnlyList<ModelTag> collection, ModelTag tag)
-            => collection.Any(tag => tag.EqualsOrdinalIgnoreCase(tag));
+            => collection.Any(aTag => aTag.EqualsOrdinalIgnoreCase(tag));
     }
 }

--- a/ParquetClassLibrary/IVisibleData.cs
+++ b/ParquetClassLibrary/IVisibleData.cs
@@ -5,12 +5,12 @@ namespace Parquet
     /// <summary>
     /// Indicates an external view onto associated data should be updated.
     /// </summary>
-    /// <param name="inSender">The instance that raised the event.</param>
-    /// <param name="inEventData">Additional event data.</param>
+    /// <param name="sender">The instance that raised the event.</param>
+    /// <param name="eventData">Additional event data.</param>
     /// <returns><c>true</c> if the operation succeeded; otherwise, <c>false</c>.</returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix",
         Justification = "False positive.")]
-    public delegate bool DataChangedEventHandler(object inSender, EventArgs inEventData);
+    public delegate bool DataChangedEventHandler(object sender, EventArgs eventData);
 
     /// <summary>
     /// Raises events when an external view onto associated data should be updated.

--- a/ParquetClassLibrary/IntExtensions.cs
+++ b/ParquetClassLibrary/IntExtensions.cs
@@ -6,22 +6,22 @@ namespace Parquet
     internal static class IntExtensions
     {
         /// <summary>Ensures an integer falls within the given range.</summary>
-        /// <param name="inInt">Integer to normalize.</param>
-        /// <param name="inLowerBound">The lowest valid value for the integer.</param>
-        /// <param name="inUpperBound">The highest valid value for the integer.</param>
+        /// <param name="value">Integer to normalize.</param>
+        /// <param name="lowerBound">The lowest valid value for the integer.</param>
+        /// <param name="upperBound">The highest valid value for the integer.</param>
         /// <returns>The integer, normalized.</returns>
-        public static int Normalize(this int inInt, int inLowerBound, int inUpperBound)
+        public static int Normalize(this int value, int lowerBound, int upperBound)
         {
-            if (inInt < inLowerBound)
+            if (value < lowerBound)
             {
-                inInt = inLowerBound;
+                value = lowerBound;
             }
-            else if (inInt > inUpperBound)
+            else if (value > upperBound)
             {
-                inInt = inUpperBound;
+                value = upperBound;
             }
 
-            return inInt;
+            return value;
         }
     }
 }

--- a/ParquetClassLibrary/Items/InventoryCollection.cs
+++ b/ParquetClassLibrary/Items/InventoryCollection.cs
@@ -160,46 +160,46 @@ namespace Parquet.Items
         /// <summary>
         /// Stores the given <see cref="InventorySlot"/> if possible.
         /// </summary>
-        /// <param name="inSlot">The slot to give.</param>
+        /// <param name="slot">The slot to give.</param>
         /// <returns>
         /// If everything was stored successfully, <c>0</c>;
         /// otherwise, the number of items that could not be stored because the <see cref="InventoryCollection"/> is full.
         /// </returns>
-        public int Give(InventorySlot inSlot)
-            => Give(inSlot?.ItemID ?? ModelID.None, inSlot?.Count ?? 0);
+        public int Give(InventorySlot slot)
+            => Give(slot?.ItemID ?? ModelID.None, slot?.Count ?? 0);
 
         /// <summary>
         /// Stores the given number of the given item, if possible.
         /// </summary>
-        /// <param name="inItemID">What kind of item to give.</param>
-        /// <param name="inHowMany">How many of the item to give.  Must be positive.</param>
+        /// <param name="itemID">What kind of item to give.</param>
+        /// <param name="howMany">How many of the item to give.  Must be positive.</param>
         /// <returns>
         /// If everything was stored successfully, <c>0</c>;
         /// otherwise, the number of items that could not be stored because the <see cref="InventoryCollection"/> is full.
         /// </returns>
-        public int Give(ModelID inItemID, int inHowMany)
+        public int Give(ModelID itemID, int howMany)
         {
             // In testing we want to alert the developer if they try to give "nothing",
             // but in production this should probably just silently succeed.
-            Debug.Assert(inItemID != ModelID.None,
+            Debug.Assert(itemID != ModelID.None,
                          string.Format(CultureInfo.CurrentCulture, Resources.WarningTriedToGiveNothing,
                          nameof(ModelID.None),
                          nameof(InventoryCollection)));
-            if (inItemID == ModelID.None)
+            if (itemID == ModelID.None)
             {
                 return 0;
             }
-            Precondition.MustBePositive(inHowMany, nameof(inHowMany));
+            Precondition.MustBePositive(howMany, nameof(howMany));
 
-            var remainder = inHowMany;
+            var remainder = howMany;
             // If this is happening during deserialization, assume the stack max was respected during serialization.
             var stackMax = All.CollectionsHaveBeenInitialized
-                ? All.Items?.GetOrNull<ItemModel>(inItemID)?.StackMax ?? ItemModel.DefaultStackMax
+                ? All.Items?.GetOrNull<ItemModel>(itemID)?.StackMax ?? ItemModel.DefaultStackMax
                 : ItemModel.DefaultStackMax;
 
             while (remainder > 0)
             {
-                var slotToAddTo = Slots.Find(slot => slot.ItemID == inItemID
+                var slotToAddTo = Slots.Find(slot => slot.ItemID == itemID
                                                   && slot.Count < stackMax);
                 if (slotToAddTo is null)
                 {
@@ -207,7 +207,7 @@ namespace Parquet.Items
                     if (Slots.Count < Capacity)
                     {
                         // If there is room for another slot, make one and add it.
-                        slotToAddTo = new InventorySlot(inItemID, 1);
+                        slotToAddTo = new InventorySlot(itemID, 1);
                         Slots.Add(slotToAddTo);
                         remainder--;
                     }
@@ -229,32 +229,32 @@ namespace Parquet.Items
         /// <summary>
         /// Removes the given <see cref="InventorySlot"/>, if possible.
         /// </summary>
-        /// <param name="inSlot">The slot to take.</param>
+        /// <param name="slot">The slot to take.</param>
         /// <returns>
         /// If everything was removed successfully, <c>0</c>;
         /// otherwise, the number of items that could not be removed because the <see cref="InventoryCollection"/> did not have any more.
         /// </returns>
-        public int Take(InventorySlot inSlot)
-            => Take(inSlot?.ItemID ?? ModelID.None, inSlot?.Count ?? 0);
+        public int Take(InventorySlot slot)
+            => Take(slot?.ItemID ?? ModelID.None, slot?.Count ?? 0);
 
         /// <summary>
         /// Removes the given number of the given item, if possible.
         /// </summary>
-        /// <param name="inItemID">What kind of item to take.</param>
-        /// <param name="inHowMany">How many of the item to take.  Must be positive.</param>
+        /// <param name="itemID">What kind of item to take.</param>
+        /// <param name="howMany">How many of the item to take.  Must be positive.</param>
         /// <returns>
         /// If everything was removed successfully, <c>0</c>;
         /// otherwise, the number of items that could not be removed because the <see cref="InventoryCollection"/> did not have any more.
         /// </returns>
-        public int Take(ModelID inItemID, int inHowMany)
+        public int Take(ModelID itemID, int howMany)
         {
-            Precondition.MustBePositive(inHowMany, nameof(inHowMany));
+            Precondition.MustBePositive(howMany, nameof(howMany));
 
-            var remainder = inHowMany;
+            var remainder = howMany;
 
             while (remainder > 0)
             {
-                var slotToTakeFrom = Slots.Find(slot => slot.ItemID == inItemID);
+                var slotToTakeFrom = Slots.Find(slot => slot.ItemID == itemID);
                 if (slotToTakeFrom is not null)
                 {
                     remainder = slotToTakeFrom.Take(remainder);
@@ -295,10 +295,10 @@ namespace Parquet.Items
         /// Adds the given <see cref="InventorySlot"/> to the <see cref="InventoryCollection"/>.
         /// </summary>
         /// <remarks>This method should only be used by <see cref="SeriesConverter{TElement, TCollection}"/>.</remarks>
-        /// <param name="inSlot">The slot to add.</param>
+        /// <param name="slot">The slot to add.</param>
         [Obsolete("Use InventoryCollection.Give() instead.")]
-        public void Add(InventorySlot inSlot)
-            => Give(inSlot);
+        public void Add(InventorySlot slot)
+            => Give(slot);
 
         /// <summary>
         /// Removes all <see cref="InventorySlot"/>s from the <see cref="InventoryCollection"/>.
@@ -310,19 +310,19 @@ namespace Parquet.Items
         /// <summary>
         /// Copies the elements of the <see cref="InventoryCollection"/> to an <see cref="System.Array"/>, starting at the given index.
         /// </summary>
-        /// <param name="inArray">The array to copy to.</param>
-        /// <param name="inArrayIndex">The index at which to begin copying.</param>
-        public void CopyTo(InventorySlot[] inArray, int inArrayIndex)
-            => Slots.CopyTo(inArray, inArrayIndex);
+        /// <param name="array">The array to copy to.</param>
+        /// <param name="arrayIndex">The index at which to begin copying.</param>
+        public void CopyTo(InventorySlot[] array, int arrayIndex)
+            => Slots.CopyTo(array, arrayIndex);
 
         /// <summary>
         /// Removes the first occurrence of the given <see cref="InventorySlot"/> from the <see cref="InventoryCollection"/>.
         /// </summary>
-        /// <param name="inSlot">The slot to remove.</param>
+        /// <param name="slot">The slot to remove.</param>
         /// <returns><c>False</c> if slot was found but could not be removed; otherwise, <c>true</c>.</returns>
         [Obsolete("Use InventoryCollection.Take() instead.", true)]
-        public bool Remove(InventorySlot inSlot)
-            => Take(inSlot) == 0;
+        public bool Remove(InventorySlot slot)
+            => Take(slot) == 0;
 
         /// <summary>
         /// Exposes an <see cref="IEnumerator"/> to support simple iteration.

--- a/ParquetClassLibrary/Items/InventoryCollection.cs
+++ b/ParquetClassLibrary/Items/InventoryCollection.cs
@@ -285,11 +285,11 @@ namespace Parquet.Items
         /// <summary>
         /// Determines whether the <see cref="InventoryCollection"/> contains the given <see cref="InventorySlot"/>.
         /// </summary>
-        /// <param name="slot">The slot to search for.</param>
+        /// <param name="other">The slot to search for.</param>
         /// <returns><c>true</c> if the slot is found; otherwise, <c>false</c>.</returns>
         [Obsolete("Use InventoryCollection.Has() instead.", true)]
-        public bool Contains(InventorySlot slot)
-            => Has(slot);
+        public bool Contains(InventorySlot other)
+            => Has(other);
 
         /// <summary>
         /// Adds the given <see cref="InventorySlot"/> to the <see cref="InventoryCollection"/>.

--- a/ParquetClassLibrary/Items/InventoryCollection.cs
+++ b/ParquetClassLibrary/Items/InventoryCollection.cs
@@ -63,28 +63,28 @@ namespace Parquet.Items
         /// <summary>
         /// Initializes a new empty instance of the <see cref="InventoryCollection"/> class.
         /// </summary>
-        /// <param name="inCapacity">How many inventory slots exist.  Must be positive</param>
-        public InventoryCollection(int inCapacity)
+        /// <param name="capacity">How many inventory slots exist.  Must be positive</param>
+        public InventoryCollection(int capacity)
         {
-            Precondition.MustBePositive(inCapacity, nameof(inCapacity));
+            Precondition.MustBePositive(capacity, nameof(capacity));
 
-            Capacity = inCapacity;
+            Capacity = capacity;
             Slots = new List<InventorySlot>();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InventoryCollection"/> class from a collection of <see cref="InventorySlot"/>s.
         /// </summary>
-        /// <param name="inSlots">The <see cref="InventorySlot"/>s to collect.  Cannot be null.</param>
-        /// <param name="inCapacity">How many inventory slots exist.  Must be positive</param>
-        public InventoryCollection(IEnumerable<InventorySlot> inSlots, int inCapacity)
+        /// <param name="slots">The <see cref="InventorySlot"/>s to collect.  Cannot be null.</param>
+        /// <param name="capacity">How many inventory slots exist.  Must be positive</param>
+        public InventoryCollection(IEnumerable<InventorySlot> slots, int capacity)
         {
-            Precondition.IsNotNull(inSlots, nameof(inSlots));
-            Precondition.MustBePositive(inCapacity, nameof(inCapacity));
+            Precondition.IsNotNull(slots, nameof(slots));
+            Precondition.MustBePositive(capacity, nameof(capacity));
 
-            Capacity = inCapacity;
+            Capacity = capacity;
             Slots = new List<InventorySlot>();
-            foreach (var slot in inSlots ?? Enumerable.Empty<InventorySlot>())
+            foreach (var slot in slots ?? Enumerable.Empty<InventorySlot>())
             {
                 Give(slot.ItemID, slot.Count);
             }
@@ -95,23 +95,23 @@ namespace Parquet.Items
         /// <summary>
         /// Determines how many of given type of item is contained in the <see cref="InventoryCollection"/>.
         /// </summary>
-        /// <param name="inItemID">The item type to check for.  Cannot be <see cref="ModelID.None"/>.</param>
+        /// <param name="itemID">The item type to check for.  Cannot be <see cref="ModelID.None"/>.</param>
         /// <returns>The number of items of the given type contained.</returns>
-        public int Contains(ModelID inItemID)
-            => Slots.Where(slot => slot.ItemID == inItemID)
+        public int Contains(ModelID itemID)
+            => Slots.Where(slot => slot.ItemID == itemID)
                     .Sum(slot => slot.Count);
 
         /// <summary>
         /// Determines if the <see cref="InventoryCollection"/> contains the given items in the given quantities.
         /// </summary>
-        /// <param name="inItems">The items to check for.  Cannot be null or empty.</param>
+        /// <param name="items">The items to check for.  Cannot be null or empty.</param>
         /// <returns><c>true</c> if everything was found; otherwise, <c>false</c>.</returns>
-        public bool Has(IEnumerable<(ModelID, int)> inItems)
+        public bool Has(IEnumerable<(ModelID, int)> items)
         {
-            Precondition.IsNotNullOrEmpty(inItems, nameof(inItems));
+            Precondition.IsNotNullOrEmpty(items, nameof(items));
 
             var result = true;
-            foreach (var slot in inItems ?? Enumerable.Empty<(ModelID, int)>())
+            foreach (var slot in items ?? Enumerable.Empty<(ModelID, int)>())
             {
                 result &= Has(slot.Item1, slot.Item2);
             }
@@ -121,14 +121,14 @@ namespace Parquet.Items
         /// <summary>
         /// Determines if the <see cref="InventoryCollection"/> contains the given <see cref="InventorySlot"/>s.
         /// </summary>
-        /// <param name="inSlots">The slots to check for.  Cannot be null or empty.</param>
+        /// <param name="slots">The slots to check for.  Cannot be null or empty.</param>
         /// <returns><c>true</c> if everything was found; otherwise, <c>false</c>.</returns>
-        public bool Has(IEnumerable<InventorySlot> inSlots)
+        public bool Has(IEnumerable<InventorySlot> slots)
         {
-            Precondition.IsNotNullOrEmpty(inSlots, nameof(inSlots));
+            Precondition.IsNotNullOrEmpty(slots, nameof(slots));
 
             var result = true;
-            foreach (var slot in inSlots ?? Enumerable.Empty<InventorySlot>())
+            foreach (var slot in slots ?? Enumerable.Empty<InventorySlot>())
             {
                 result &= Has(slot.ItemID, slot.Count);
             }
@@ -138,23 +138,23 @@ namespace Parquet.Items
         /// <summary>
         /// Determines if the <see cref="InventoryCollection"/> contains the given <see cref="InventorySlot"/>.
         /// </summary>
-        /// <param name="inSlot">The slot to check for.</param>
+        /// <param name="slot">The slot to check for.</param>
         /// <returns><c>true</c> if everything was found; otherwise, <c>false</c>.</returns>
         /// <remarks>A <c>null</c> slot is never found and will result in a return value of <c>false</c>.</remarks>
-        public bool Has(InventorySlot inSlot)
-            => inSlot is not null
-            && Has(inSlot.ItemID, inSlot.Count);
+        public bool Has(InventorySlot slot)
+            => slot is not null
+            && Has(slot.ItemID, slot.Count);
 
         /// <summary>
         /// Determines if the <see cref="InventoryCollection"/> contains the given number of the given item.
         /// </summary>
-        /// <param name="inItemID">What kind of item to check for.</param>
-        /// <param name="inHowMany">How many of the item to check for.  Must be positive.</param>
+        /// <param name="itemID">What kind of item to check for.</param>
+        /// <param name="howMany">How many of the item to check for.  Must be positive.</param>
         /// <returns><c>true</c> if everything was found; otherwise, <c>false</c>.</returns>
-        public bool Has(ModelID inItemID, int inHowMany = 1)
+        public bool Has(ModelID itemID, int howMany = 1)
         {
-            Precondition.MustBePositive(inHowMany, nameof(inHowMany));
-            return Contains(inItemID) >= inHowMany;
+            Precondition.MustBePositive(howMany, nameof(howMany));
+            return Contains(itemID) >= howMany;
         }
 
         /// <summary>
@@ -285,11 +285,11 @@ namespace Parquet.Items
         /// <summary>
         /// Determines whether the <see cref="InventoryCollection"/> contains the given <see cref="InventorySlot"/>.
         /// </summary>
-        /// <param name="inSlot">The slot to search for.</param>
+        /// <param name="slot">The slot to search for.</param>
         /// <returns><c>true</c> if the slot is found; otherwise, <c>false</c>.</returns>
         [Obsolete("Use InventoryCollection.Has() instead.", true)]
-        public bool Contains(InventorySlot inSlot)
-            => Has(inSlot);
+        public bool Contains(InventorySlot slot)
+            => Has(slot);
 
         /// <summary>
         /// Adds the given <see cref="InventorySlot"/> to the <see cref="InventoryCollection"/>.

--- a/ParquetClassLibrary/Items/InventoryConfiguration.cs
+++ b/ParquetClassLibrary/Items/InventoryConfiguration.cs
@@ -10,12 +10,12 @@ namespace Parquet.Items
     {
         #region Class Defaults
         /// <summary>The capacity to use for an <see cref="InventoryCollection"/> when the configuration cannot be read.</summary>
-        private const int DefaultDefaultCapacity = 16;
+        private const int FallbackCapacity = 16;
         #endregion
 
         #region Characteristics
         /// <summary>The capacity to use for an <see cref="InventoryCollection"/> when none is specified.</summary>
-        public static int DefaultCapacity { get; set; } = DefaultDefaultCapacity;
+        public static int DefaultCapacity { get; set; } = FallbackCapacity;
         #endregion
 
         #region Self Serialization
@@ -36,7 +36,7 @@ namespace Parquet.Items
             // Parse.
             DefaultCapacity = int.TryParse(value, out var outInt)
                 ? outInt
-                : Logger.DefaultWithParseLog(value, nameof(DefaultCapacity), DefaultDefaultCapacity);
+                : Logger.DefaultWithParseLog(value, nameof(DefaultCapacity), FallbackCapacity);
         }
 
         /// <summary>

--- a/ParquetClassLibrary/Items/InventoryConfiguration.cs
+++ b/ParquetClassLibrary/Items/InventoryConfiguration.cs
@@ -34,8 +34,8 @@ namespace Parquet.Items
             var value = reader.ReadLine();
 
             // Parse.
-            DefaultCapacity = int.TryParse(value, out var outInt)
-                ? outInt
+            DefaultCapacity = int.TryParse(value, out var parsedCapacity)
+                ? parsedCapacity
                 : Logger.DefaultWithParseLog(value, nameof(DefaultCapacity), FallbackCapacity);
         }
 

--- a/ParquetClassLibrary/Items/InventorySlot.cs
+++ b/ParquetClassLibrary/Items/InventorySlot.cs
@@ -45,22 +45,22 @@ namespace Parquet.Items
         /// <summary>
         /// Creates a new slot to store the given item type.
         /// </summary>
-        /// <param name="inItemToStore">
+        /// <param name="itemToStore">
         /// The <see cref="ModelID"/> corresponding to the item being stored here.
         /// Must be in-range and not <see cref="ModelID.None"/>.
         /// </param>
-        /// <param name="inHowMany">How many of the item to store initially.  Must be positive.</param>
-        public InventorySlot(ModelID inItemToStore, int inHowMany = 1)
+        /// <param name="howMany">How many of the item to store initially.  Must be positive.</param>
+        public InventorySlot(ModelID itemToStore, int howMany = 1)
         {
-            Precondition.IsNotNone(inItemToStore, nameof(inItemToStore));
-            Precondition.IsInRange(inItemToStore, All.ItemIDs, nameof(inItemToStore));
-            Precondition.MustBePositive(inHowMany, nameof(inHowMany));
-            Debug.Assert(inItemToStore != ModelID.None, string.Format(CultureInfo.CurrentCulture, Resources.WarningTriedToStoreNothing,
-                                                                      nameof(inItemToStore), nameof(InventorySlot)));
+            Precondition.IsNotNone(itemToStore, nameof(itemToStore));
+            Precondition.IsInRange(itemToStore, All.ItemIDs, nameof(itemToStore));
+            Precondition.MustBePositive(howMany, nameof(howMany));
+            Debug.Assert(itemToStore != ModelID.None, string.Format(CultureInfo.CurrentCulture, Resources.WarningTriedToStoreNothing,
+                                                                      nameof(itemToStore), nameof(InventorySlot)));
 
 
-            ItemID = inItemToStore;
-            Count = inHowMany;
+            ItemID = itemToStore;
+            Count = howMany;
         }
         #endregion
 
@@ -68,14 +68,14 @@ namespace Parquet.Items
         /// <summary>
         /// Increases the number of items stored by the given amount.
         /// </summary>
-        /// <param name="inHowMany">How many of the item to give.  Must be positive.</param>
+        /// <param name="howMany">How many of the item to give.  Must be positive.</param>
         /// <returns>The number of items still needing to be stored if this stack is full.</returns>
-        public int Give(int inHowMany = 1)
+        public int Give(int howMany = 1)
         {
-            Precondition.MustBePositive(inHowMany, nameof(inHowMany));
+            Precondition.MustBePositive(howMany, nameof(howMany));
 
             var remainder = 0;
-            var total = Count + inHowMany;
+            var total = Count + howMany;
             if (total > StackMax)
             {
                 Count = StackMax;
@@ -83,7 +83,7 @@ namespace Parquet.Items
             }
             else
             {
-                Count += inHowMany;
+                Count += howMany;
             }
 
             return remainder;
@@ -92,17 +92,17 @@ namespace Parquet.Items
         /// <summary>
         /// Decreases the number of items stored by the given amount.
         /// </summary>
-        /// <param name="inHowMany">How many of the item to take.  Must be positive.</param>
+        /// <param name="howMany">How many of the item to take.  Must be positive.</param>
         /// <returns>
         /// The number of items still needing to be removed from another
         /// <see cref="InventorySlot"/> once this one is emptied.
         /// </returns>
-        public int Take(int inHowMany = 1)
+        public int Take(int howMany = 1)
         {
-            Precondition.MustBePositive(inHowMany, nameof(inHowMany));
+            Precondition.MustBePositive(howMany, nameof(howMany));
 
             var remainder = 0;
-            var needed = Count - inHowMany;
+            var needed = Count - howMany;
             if (needed < 0)
             {
                 Count = 0;
@@ -111,7 +111,7 @@ namespace Parquet.Items
             }
             else
             {
-                Count -= inHowMany;
+                Count -= howMany;
             }
 
             return remainder;
@@ -131,10 +131,10 @@ namespace Parquet.Items
         /// <summary>
         /// Determines whether the specified status is equal to the current status.
         /// </summary>
-        /// <param name="inStatus">The status to compare with the current.</param>
+        /// <param name="status">The status to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is InventorySlot slot
+        public override bool Equals<T>(T status)
+            => status is InventorySlot slot
             && ItemID == slot.ItemID
             && Count == slot.Count;
 
@@ -150,20 +150,20 @@ namespace Parquet.Items
         /// <summary>
         /// Determines whether a specified instance of <see cref="InventorySlot"/> is equal to another specified instance of <see cref="InventorySlot"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="InventorySlot"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="InventorySlot"/> to compare.</param>
+        /// <param name="status1">The first <see cref="InventorySlot"/> to compare.</param>
+        /// <param name="status2">The second <see cref="InventorySlot"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(InventorySlot inStatus1, InventorySlot inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(InventorySlot status1, InventorySlot status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="InventorySlot"/> is not equal to another specified instance of <see cref="InventorySlot"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="InventorySlot"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="InventorySlot"/> to compare.</param>
+        /// <param name="status1">The first <see cref="InventorySlot"/> to compare.</param>
+        /// <param name="status2">The second <see cref="InventorySlot"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(InventorySlot inStatus1, InventorySlot inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(InventorySlot status1, InventorySlot status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -173,35 +173,35 @@ namespace Parquet.Items
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is InventorySlot slot
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is InventorySlot slot
                 ? $"{slot.ItemID}{Delimiters.InternalDelimiter}" +
                   $"{slot.Count}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(InventorySlot), nameof(Empty));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(InventorySlot), nameof(Empty));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Empty), inText, StringComparison.OrdinalIgnoreCase) == 0
-                || string.Compare(nameof(ModelID.None), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Empty), text, StringComparison.OrdinalIgnoreCase) == 0
+                || string.Compare(nameof(ModelID.None), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
-                return Logger.DefaultWithConvertLog(inText, nameof(InventorySlot), Empty);
+                return Logger.DefaultWithConvertLog(text, nameof(InventorySlot), Empty);
             }
 
-            var parameterText = inText.Split(Delimiters.InternalDelimiter);
+            var parameterText = text.Split(Delimiters.InternalDelimiter);
 
-            var id = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[0], inRow, inMemberMapData);
+            var id = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[0], row, memberMapData);
             var count = int.TryParse(parameterText[1], All.SerializedNumberStyle, CultureInfo.InvariantCulture, out var temp)
                 ? temp
                 : Logger.DefaultWithParseLog(parameterText[1], nameof(InventorySlot), 1);

--- a/ParquetClassLibrary/Items/ItemModel.cs
+++ b/ParquetClassLibrary/Items/ItemModel.cs
@@ -57,38 +57,38 @@ namespace Parquet.Items
         /// <summary>
         /// Initializes a new instance of the <see cref="ItemModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="ItemModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="ItemModel"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="ItemModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="ItemModel"/>.</param>
-        /// <param name="inTags">Any additional functionality this <see cref="ItemModel"/> has, e.g. contributing to a <see cref="Biomes.BiomeRecipe"/>.</param>
-        /// <param name="inSubtype">The type of <see cref="ItemModel"/>.</param>
-        /// <param name="inWorth"><see cref="ItemModel"/> cost.</param>
-        /// <param name="inRarity"><see cref="ItemModel"/> rarity.</param>
-        /// <param name="inStackMax">How many such items may be stacked together in the <see cref="InventoryCollection"/>.  Must be positive.</param>
-        /// <param name="inEffectWhileHeldID"><see cref="ItemModel"/>'s passive effect.</param>
-        /// <param name="inEffectWhenUsedID"><see cref="ItemModel"/>'s active effect.</param>
-        /// <param name="inParquetID">The parquet represented by this <see cref="ItemModel"/>, if any.</param>
-        public ItemModel(ModelID inID, string inName, string inDescription, string inComment,
-                         IEnumerable<ModelTag> inTags = null, ItemType inSubtype = ItemType.Other,
-                         int inWorth = 0, int inRarity = 0, int inStackMax = DefaultStackMax,
-                         ModelID? inEffectWhileHeldID = null, ModelID? inEffectWhenUsedID = null,
-                         ModelID? inParquetID = null)
-            : base(All.ItemIDs, inID, inName, inDescription, inComment, inTags)
+        /// <param name="id">Unique identifier for the <see cref="ItemModel"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="ItemModel"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="ItemModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="ItemModel"/>.</param>
+        /// <param name="tags">Any additional functionality this <see cref="ItemModel"/> has, e.g. contributing to a <see cref="Biomes.BiomeRecipe"/>.</param>
+        /// <param name="subtype">The type of <see cref="ItemModel"/>.</param>
+        /// <param name="worth"><see cref="ItemModel"/> cost.</param>
+        /// <param name="rarity"><see cref="ItemModel"/> rarity.</param>
+        /// <param name="stackMax">How many such items may be stacked together in the <see cref="InventoryCollection"/>.  Must be positive.</param>
+        /// <param name="effectWhileHeldID"><see cref="ItemModel"/>'s passive effect.</param>
+        /// <param name="effectWhenUsedID"><see cref="ItemModel"/>'s active effect.</param>
+        /// <param name="parquetID">The parquet represented by this <see cref="ItemModel"/>, if any.</param>
+        public ItemModel(ModelID id, string name, string description, string comment,
+                         IEnumerable<ModelTag> tags = null, ItemType subtype = ItemType.Other,
+                         int worth = 0, int rarity = 0, int stackMax = DefaultStackMax,
+                         ModelID? effectWhileHeldID = null, ModelID? effectWhenUsedID = null,
+                         ModelID? parquetID = null)
+            : base(All.ItemIDs, id, name, description, comment, tags)
         {
-            var nonNullEffectWhileHeldID = inEffectWhileHeldID ?? ModelID.None;
-            var nonNullEffectWhenUsedID = inEffectWhenUsedID ?? ModelID.None;
-            var nonNullParquetID = inParquetID ?? ModelID.None;
+            var nonNullEffectWhileHeldID = effectWhileHeldID ?? ModelID.None;
+            var nonNullEffectWhenUsedID = effectWhenUsedID ?? ModelID.None;
+            var nonNullParquetID = parquetID ?? ModelID.None;
 
-            Precondition.IsInRange(nonNullEffectWhileHeldID, All.ScriptIDs, nameof(inEffectWhileHeldID));
-            Precondition.IsInRange(nonNullEffectWhenUsedID, All.ScriptIDs, nameof(inEffectWhenUsedID));
-            Precondition.IsInRange(nonNullParquetID, All.ParquetIDs, nameof(inParquetID));
-            Precondition.MustBePositive(inStackMax, nameof(inStackMax));
+            Precondition.IsInRange(nonNullEffectWhileHeldID, All.ScriptIDs, nameof(effectWhileHeldID));
+            Precondition.IsInRange(nonNullEffectWhenUsedID, All.ScriptIDs, nameof(effectWhenUsedID));
+            Precondition.IsInRange(nonNullParquetID, All.ParquetIDs, nameof(parquetID));
+            Precondition.MustBePositive(stackMax, nameof(stackMax));
 
-            Subtype = inSubtype;
-            Worth = inWorth;
-            Rarity = inRarity;
-            StackMax = inStackMax;
+            Subtype = subtype;
+            Worth = worth;
+            Rarity = rarity;
+            StackMax = stackMax;
             EffectWhileHeldID = nonNullEffectWhileHeldID;
             EffectWhenUsedID = nonNullEffectWhenUsedID;
             ParquetID = nonNullParquetID;

--- a/ParquetClassLibrary/Location.cs
+++ b/ParquetClassLibrary/Location.cs
@@ -91,35 +91,35 @@ namespace Parquet
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is Location location
-                ? $"{location.RegionID.ConvertToString(location.RegionID, inRow, inMemberMapData)}{Delimiters.InternalDelimiter}" +
-                  $"{location.Position.ConvertToString(location.Position, inRow, inMemberMapData)}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(Location), nameof(Nowhere));
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is Location location
+                ? $"{location.RegionID.ConvertToString(location.RegionID, row, memberMapData)}{Delimiters.InternalDelimiter}" +
+                  $"{location.Position.ConvertToString(location.Position, row, memberMapData)}"
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(Location), nameof(Nowhere));
 
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Nowhere), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Nowhere), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Nowhere;
             }
 
-            var parameterText = inText.Split(Delimiters.InternalDelimiter);
+            var parameterText = text.Split(Delimiters.InternalDelimiter);
 
-            var parsedRegionID = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[0], inRow, inMemberMapData);
-            var parsedPosition = (Point2D)Point2D.ConverterFactory.ConvertFromString(parameterText[1], inRow, inMemberMapData);
+            var parsedRegionID = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[0], row, memberMapData);
+            var parsedPosition = (Point2D)Point2D.ConverterFactory.ConvertFromString(parameterText[1], row, memberMapData);
 
             return new Location(parsedRegionID, parsedPosition);
         }

--- a/ParquetClassLibrary/Location.cs
+++ b/ParquetClassLibrary/Location.cs
@@ -28,12 +28,12 @@ namespace Parquet
         /// <summary>
         /// Initializes a new instance of the <see cref="Location"/> class.
         /// </summary>
-        /// <param name="inRegionID">The identifier for the <see cref="Regions.RegionModel"/> in which the tracked <see cref="Model"/> is located.</param>
-        /// <param name="inPosition">The position within the current <see cref="Regions.RegionModel"/> of the tracked <see cref="Model"/>.</param>
-        public Location(ModelID? inRegionID = null, Point2D? inPosition = null)
+        /// <param name="regionID">The identifier for the <see cref="Regions.RegionModel"/> in which the tracked <see cref="Model"/> is located.</param>
+        /// <param name="position">The position within the current <see cref="Regions.RegionModel"/> of the tracked <see cref="Model"/>.</param>
+        public Location(ModelID? regionID = null, Point2D? position = null)
         {
-            RegionID = inRegionID ?? ModelID.None;
-            Position = inPosition ?? Point2D.Origin;
+            RegionID = regionID ?? ModelID.None;
+            Position = position ?? Point2D.Origin;
         }
         #endregion
 
@@ -50,11 +50,11 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Location"/> is equal to the current <see cref="Location"/>.
         /// </summary>
-        /// <param name="inLocation">The <see cref="Location"/> to compare with the current.</param>
+        /// <param name="location">The <see cref="Location"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Location inLocation)
-            => RegionID == inLocation.RegionID
-            && Position == inLocation.Position;
+        public bool Equals(Location location)
+            => RegionID == location.RegionID
+            && Position == location.Position;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Location"/>.
@@ -68,20 +68,20 @@ namespace Parquet
         /// <summary>
         /// Determines whether a specified instance of <see cref="Location"/> is equal to another specified instance of <see cref="Location"/>.
         /// </summary>
-        /// <param name="inLocation1">The first <see cref="Location"/> to compare.</param>
-        /// <param name="inLocation2">The second <see cref="Location"/> to compare.</param>
+        /// <param name="location1">The first <see cref="Location"/> to compare.</param>
+        /// <param name="location2">The second <see cref="Location"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(Location inLocation1, Location inLocation2)
-            => inLocation1.Equals(inLocation2);
+        public static bool operator ==(Location location1, Location location2)
+            => location1.Equals(location2);
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="Location"/> is not equal to another specified instance of <see cref="Location"/>.
         /// </summary>
-        /// <param name="inLocation1">The first <see cref="Location"/> to compare.</param>
-        /// <param name="inLocation2">The second <see cref="Location"/> to compare.</param>
+        /// <param name="location1">The first <see cref="Location"/> to compare.</param>
+        /// <param name="location2">The second <see cref="Location"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(Location inLocation1, Location inLocation2)
-            => !(inLocation1 == inLocation2);
+        public static bool operator !=(Location location1, Location location2)
+            => !(location1 == location2);
         #endregion
 
         #region ITypeConverter Implementation

--- a/ParquetClassLibrary/Location.cs
+++ b/ParquetClassLibrary/Location.cs
@@ -50,11 +50,11 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Location"/> is equal to the current <see cref="Location"/>.
         /// </summary>
-        /// <param name="location">The <see cref="Location"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="Location"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Location location)
-            => RegionID == location.RegionID
-            && Position == location.Position;
+        public bool Equals(Location other)
+            => RegionID == other.RegionID
+            && Position == other.Position;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Location"/>.

--- a/ParquetClassLibrary/Logger.cs
+++ b/ParquetClassLibrary/Logger.cs
@@ -19,12 +19,13 @@ namespace Parquet
         /// <summary>
         /// Sets up the logging system to use the provided instance when logging.
         /// </summary>
+        /// <param name="loggerToUse">The logger being provided to the logging system.</param>
         /// <remarks>
         /// Inspired by Microsoft.Extensions.Logging.ILogger but simpler.
         /// </remarks>
-        public static void SetLogger(ILogger inLoggerToUse)
-            => currentLogger = inLoggerToUse is not null
-                ? inLoggerToUse
+        public static void SetLogger(ILogger loggerToUse)
+            => currentLogger = loggerToUse is not null
+                ? loggerToUse
                 : currentLogger;
         #endregion
 
@@ -32,19 +33,19 @@ namespace Parquet
         /// <summary>
         /// Writes a log entry.
         /// </summary>
-        /// <param name="inLogLevel">The severity of the event being logged.</param>
-        /// <param name="inMessage">A message summarizing the event being logged.</param>
-        /// <param name="inException">The exception related to this event, if any.</param>
-        public static void Log(LogLevel inLogLevel, string inMessage = null, Exception inException = null)
-            => currentLogger.Log(inLogLevel, inMessage, inException);
+        /// <param name="logLevel">The severity of the event being logged.</param>
+        /// <param name="message">A message summarizing the event being logged.</param>
+        /// <param name="exception">The exception related to this event, if any.</param>
+        public static void Log(LogLevel logLevel, string message = null, Exception exception = null)
+            => currentLogger.Log(logLevel, message, exception);
 
         /// <summary>
         /// Writes a log entry.
         /// </summary>
-        /// <param name="inLogLevel">The severity of the event being logged.</param>
-        /// <param name="inObject">An object related to the event being logged.  This will be converted to a string.</param>
-        public static void Log(LogLevel inLogLevel, object inObject)
-            => currentLogger.Log(inLogLevel, inObject?.ToString() ?? "", null);
+        /// <param name="logLevel">The severity of the event being logged.</param>
+        /// <param name="objectToLog">An object related to the event being logged.  This will be converted to a string.</param>
+        public static void Log(LogLevel logLevel, object objectToLog)
+            => currentLogger.Log(logLevel, objectToLog?.ToString() ?? "", null);
         #endregion
 
         #region Convenience Routines
@@ -53,13 +54,13 @@ namespace Parquet
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
         /// <param name="name">The name of the item that cannot be used during play.</param>
-        /// <param name="inDefaultValue">The default value to return.</param>
+        /// <param name="defaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithImmutableInPlayLog<T>(string name, T inDefaultValue)
+        internal static T DefaultWithImmutableInPlayLog<T>(string name, T defaultValue)
         {
             currentLogger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.WarningImmutableDuringPlay,
                                                               name), null);
-            return inDefaultValue;
+            return defaultValue;
         }
 
         /// <summary>
@@ -68,13 +69,13 @@ namespace Parquet
         /// <typeparam name="T">The type of value to return.</typeparam>
         /// <param name="value">The value of the item that failed to convert.</param>
         /// <param name="name">The name of the item that failed to convert.</param>
-        /// <param name="inDefaultValue">The default value to return.</param>
+        /// <param name="defaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithConvertLog<T>(string value, string name, T inDefaultValue)
+        internal static T DefaultWithConvertLog<T>(string value, string name, T defaultValue)
         {
             currentLogger.Log(LogLevel.Error, string.Format(CultureInfo.CurrentCulture, Resources.ErrorCannotConvert,
                                                             value, name), null);
-            return inDefaultValue;
+            return defaultValue;
         }
 
         /// <summary>
@@ -83,13 +84,13 @@ namespace Parquet
         /// <typeparam name="T">The type of value to return.</typeparam>
         /// <param name="value">The value of the item that failed to parse.</param>
         /// <param name="name">The name of the item that failed to parse.</param>
-        /// <param name="inDefaultValue">The default value to return.</param>
+        /// <param name="defaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithParseLog<T>(string value, string name, T inDefaultValue)
+        internal static T DefaultWithParseLog<T>(string value, string name, T defaultValue)
         {
             currentLogger.Log(LogLevel.Error, string.Format(CultureInfo.CurrentCulture, Resources.ErrorCannotParse,
                                                             value, name), null);
-            return inDefaultValue;
+            return defaultValue;
         }
 
         /// <summary>
@@ -97,15 +98,15 @@ namespace Parquet
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
         /// <param name="name">The name of the command type.</param>
-        /// <param name="inCommandText">The text version of the unsupported command.</param>
-        /// <param name="inDefaultValue">The default value to return.</param>
+        /// <param name="commandText">The text version of the unsupported command.</param>
+        /// <param name="defaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithUnsupportedNodeLog<T>(string name, string inCommandText, T inDefaultValue)
+        internal static T DefaultWithUnsupportedNodeLog<T>(string name, string commandText, T defaultValue)
         {
             currentLogger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture,
                                                               Resources.ErrorUnsupportedNode,
-                                                              name, inCommandText), null);
-            return inDefaultValue;
+                                                              name, commandText), null);
+            return defaultValue;
         }
 
         /// <summary>
@@ -113,13 +114,13 @@ namespace Parquet
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
         /// <param name="name">The name of the item that failed to serialize.</param>
-        /// <param name="inDefaultValue">The default value to return.</param>
+        /// <param name="defaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithUnsupportedSerializationLog<T>(string name, T inDefaultValue)
+        internal static T DefaultWithUnsupportedSerializationLog<T>(string name, T defaultValue)
         {
             currentLogger.Log(LogLevel.Error, string.Format(CultureInfo.CurrentCulture, Resources.ErrorUnsupportedSerialization,
                                                             name), null);
-            return inDefaultValue;
+            return defaultValue;
         }
         #endregion
     }

--- a/ParquetClassLibrary/Logger.cs
+++ b/ParquetClassLibrary/Logger.cs
@@ -52,13 +52,13 @@ namespace Parquet
         /// Convenience method that logs a <see cref="LibraryState"/> error and returns the given default value.
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
-        /// <param name="inName">The name of the item that cannot be used during play.</param>
+        /// <param name="name">The name of the item that cannot be used during play.</param>
         /// <param name="inDefaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithImmutableInPlayLog<T>(string inName, T inDefaultValue)
+        internal static T DefaultWithImmutableInPlayLog<T>(string name, T inDefaultValue)
         {
             currentLogger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.WarningImmutableDuringPlay,
-                                                              inName), null);
+                                                              name), null);
             return inDefaultValue;
         }
 
@@ -66,14 +66,14 @@ namespace Parquet
         /// Convenience method that logs a conversion error and returns the given default value.
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
-        /// <param name="inValue">The value of the item that failed to convert.</param>
-        /// <param name="inName">The name of the item that failed to convert.</param>
+        /// <param name="value">The value of the item that failed to convert.</param>
+        /// <param name="name">The name of the item that failed to convert.</param>
         /// <param name="inDefaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithConvertLog<T>(string inValue, string inName, T inDefaultValue)
+        internal static T DefaultWithConvertLog<T>(string value, string name, T inDefaultValue)
         {
             currentLogger.Log(LogLevel.Error, string.Format(CultureInfo.CurrentCulture, Resources.ErrorCannotConvert,
-                                                            inValue, inName), null);
+                                                            value, name), null);
             return inDefaultValue;
         }
 
@@ -81,14 +81,14 @@ namespace Parquet
         /// Convenience method that logs a parsing error and returns the given default value.
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
-        /// <param name="inValue">The value of the item that failed to parse.</param>
-        /// <param name="inName">The name of the item that failed to parse.</param>
+        /// <param name="value">The value of the item that failed to parse.</param>
+        /// <param name="name">The name of the item that failed to parse.</param>
         /// <param name="inDefaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithParseLog<T>(string inValue, string inName, T inDefaultValue)
+        internal static T DefaultWithParseLog<T>(string value, string name, T inDefaultValue)
         {
             currentLogger.Log(LogLevel.Error, string.Format(CultureInfo.CurrentCulture, Resources.ErrorCannotParse,
-                                                            inValue, inName), null);
+                                                            value, name), null);
             return inDefaultValue;
         }
 
@@ -96,15 +96,15 @@ namespace Parquet
         /// Convenience method that logs an unsupported command error and returns the given default value.
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
-        /// <param name="inName">The name of the command type.</param>
+        /// <param name="name">The name of the command type.</param>
         /// <param name="inCommandText">The text version of the unsupported command.</param>
         /// <param name="inDefaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithUnsupportedNodeLog<T>(string inName, string inCommandText, T inDefaultValue)
+        internal static T DefaultWithUnsupportedNodeLog<T>(string name, string inCommandText, T inDefaultValue)
         {
             currentLogger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture,
                                                               Resources.ErrorUnsupportedNode,
-                                                              inName, inCommandText), null);
+                                                              name, inCommandText), null);
             return inDefaultValue;
         }
 
@@ -112,13 +112,13 @@ namespace Parquet
         /// Convenience method that logs a serialization error and returns the given default value.
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>
-        /// <param name="inName">The name of the item that failed to serialize.</param>
+        /// <param name="name">The name of the item that failed to serialize.</param>
         /// <param name="inDefaultValue">The default value to return.</param>
         /// <returns>The default value given.</returns>
-        internal static T DefaultWithUnsupportedSerializationLog<T>(string inName, T inDefaultValue)
+        internal static T DefaultWithUnsupportedSerializationLog<T>(string name, T inDefaultValue)
         {
             currentLogger.Log(LogLevel.Error, string.Format(CultureInfo.CurrentCulture, Resources.ErrorUnsupportedSerialization,
-                                                            inName), null);
+                                                            name), null);
             return inDefaultValue;
         }
         #endregion

--- a/ParquetClassLibrary/LoggerDefault.cs
+++ b/ParquetClassLibrary/LoggerDefault.cs
@@ -14,27 +14,27 @@ namespace Parquet
         /// <summary>
         /// Writes a log entry.
         /// </summary>
-        /// <param name="inLogLevel">The severity of the event being logged.</param>
-        /// <param name="inMessage">A message summarizing the event being logged.</param>
-        /// <param name="inException">The exception related to this event, if any.</param>
-        public void Log(LogLevel inLogLevel, string inMessage = null, Exception inException = null)
+        /// <param name="logLevel">The severity of the event being logged.</param>
+        /// <param name="message">A message summarizing the event being logged.</param>
+        /// <param name="exception">The exception related to this event, if any.</param>
+        public void Log(LogLevel logLevel, string message = null, Exception exception = null)
         {
-            if (inLogLevel == LogLevel.Debug && !LibraryState.IsDebugMode)
+            if (logLevel == LogLevel.Debug && !LibraryState.IsDebugMode)
             {
                 // Ignore debug logs when not running in debug mode.
                 return;
             }
 
-            var destination = inLogLevel == LogLevel.Info
+            var destination = logLevel == LogLevel.Info
                 ? Console.Out
                 : Console.Error;
-            var message = !string.IsNullOrEmpty(inMessage)
-                ? inMessage
-                : inException is not null
-                    ? inException.Message
+            var nonNullMessage = !string.IsNullOrEmpty(message)
+                ? message
+                : exception is not null
+                    ? exception.Message
                     : $"Parquet {nameof(LoggerDefault)} Trace at {DateTime.Now}.";
 
-            destination.WriteLine(message);
+            destination.WriteLine(nonNullMessage);
         }
     }
 }

--- a/ParquetClassLibrary/Model.cs
+++ b/ParquetClassLibrary/Model.cs
@@ -183,10 +183,10 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Model"/> is equal to the current <see cref="Model"/>.
         /// </summary>
-        /// <param name="model">The <see cref="Model"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="Model"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Model model)
-            => model?.ID == ID;
+        public bool Equals(Model other)
+            => other?.ID == ID;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Model"/>.

--- a/ParquetClassLibrary/Model.cs
+++ b/ParquetClassLibrary/Model.cs
@@ -64,22 +64,22 @@ namespace Parquet
         /// Initializes a new instance of concrete implementations of the <see cref="Model"/> class.
         /// </summary>
         /// <param name="inBounds">The bounds within which the derived type's <see cref="ModelID"/> is defined.</param>
-        /// <param name="inID">Unique identifier for the <see cref="Model"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="Model"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="Model"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="Model"/>.</param>
-        /// <param name="inTags">Any additional functionality this <see cref="Model"/> has, e.g. contributing to a <see cref="Biomes.BiomeRecipe"/>.</param>
-        protected Model(Range<ModelID> inBounds, ModelID inID, string inName, string inDescription, string inComment, IEnumerable<ModelTag> inTags)
+        /// <param name="id">Unique identifier for the <see cref="Model"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="Model"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="Model"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="Model"/>.</param>
+        /// <param name="tags">Any additional functionality this <see cref="Model"/> has, e.g. contributing to a <see cref="Biomes.BiomeRecipe"/>.</param>
+        protected Model(Range<ModelID> inBounds, ModelID id, string name, string description, string comment, IEnumerable<ModelTag> tags)
         {
-            Precondition.IsInRange(inID, inBounds, nameof(inID));
-            Precondition.IsNotNullOrEmpty(inName, nameof(inName));
+            Precondition.IsInRange(id, inBounds, nameof(id));
+            Precondition.IsNotNullOrEmpty(name, nameof(name));
 
-            var nonNullTags = (inTags ?? Enumerable.Empty<ModelTag>());
+            var nonNullTags = (tags ?? Enumerable.Empty<ModelTag>());
 
-            ID = inID;
-            Name = inName;
-            Description = inDescription ?? "";
-            Comment = inComment ?? "";
+            ID = id;
+            Name = name;
+            Description = description ?? "";
+            Comment = comment ?? "";
             Tags = nonNullTags.ToList();
         }
         #endregion

--- a/ParquetClassLibrary/Model.cs
+++ b/ParquetClassLibrary/Model.cs
@@ -63,15 +63,15 @@ namespace Parquet
         /// <summary>
         /// Initializes a new instance of concrete implementations of the <see cref="Model"/> class.
         /// </summary>
-        /// <param name="inBounds">The bounds within which the derived type's <see cref="ModelID"/> is defined.</param>
+        /// <param name="bounds">The bounds within which the derived type's <see cref="ModelID"/> is defined.</param>
         /// <param name="id">Unique identifier for the <see cref="Model"/>.  Cannot be null.</param>
         /// <param name="name">Player-friendly name of the <see cref="Model"/>.  Cannot be null or empty.</param>
         /// <param name="description">Player-friendly description of the <see cref="Model"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="Model"/>.</param>
         /// <param name="tags">Any additional functionality this <see cref="Model"/> has, e.g. contributing to a <see cref="Biomes.BiomeRecipe"/>.</param>
-        protected Model(Range<ModelID> inBounds, ModelID id, string name, string description, string comment, IEnumerable<ModelTag> tags)
+        protected Model(Range<ModelID> bounds, ModelID id, string name, string description, string comment, IEnumerable<ModelTag> tags)
         {
-            Precondition.IsInRange(id, inBounds, nameof(id));
+            Precondition.IsInRange(id, bounds, nameof(id));
             Precondition.IsNotNullOrEmpty(name, nameof(name));
 
             var nonNullTags = (tags ?? Enumerable.Empty<ModelTag>());
@@ -183,10 +183,10 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Model"/> is equal to the current <see cref="Model"/>.
         /// </summary>
-        /// <param name="inModel">The <see cref="Model"/> to compare with the current.</param>
+        /// <param name="model">The <see cref="Model"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Model inModel)
-            => inModel?.ID == ID;
+        public bool Equals(Model model)
+            => model?.ID == ID;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Model"/>.
@@ -200,20 +200,20 @@ namespace Parquet
         /// <summary>
         /// Determines whether a specified instance of <see cref="Model"/> is equal to another specified instance of <see cref="Model"/>.
         /// </summary>
-        /// <param name="inModel1">The first <see cref="Model"/> to compare.</param>
-        /// <param name="inModel2">The second <see cref="Model"/> to compare.</param>
+        /// <param name="model1">The first <see cref="Model"/> to compare.</param>
+        /// <param name="model2">The second <see cref="Model"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(Model inModel1, Model inModel2)
-            => inModel1?.Equals(inModel2) ?? inModel2?.Equals(inModel1) ?? true;
+        public static bool operator ==(Model model1, Model model2)
+            => model1?.Equals(model2) ?? model2?.Equals(model1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="Model"/> is not equal to another specified instance of <see cref="Model"/>.
         /// </summary>
-        /// <param name="inModel1">The first <see cref="Model"/> to compare.</param>
-        /// <param name="inModel2">The second <see cref="Model"/> to compare.</param>
+        /// <param name="model1">The first <see cref="Model"/> to compare.</param>
+        /// <param name="model2">The second <see cref="Model"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(Model inModel1, Model inModel2)
-            => !(inModel1 == inModel2);
+        public static bool operator !=(Model model1, Model model2)
+            => !(model1 == model2);
         #endregion
 
         #region Utilities
@@ -235,7 +235,7 @@ namespace Parquet
         /// A tag assigned to this <see cref="Model"/> that begins with the given attribute prefix,
         /// or <see cref="ModelTag.None"/> if no such tag has been assigned.
         /// </summary>
-        /// <param name="inPrefix">
+        /// <param name="prefix">
         /// A <see cref="ModelTag"/> substring indicating the sought attribute.
         /// No particular format is required for the prefix:suffix pair,
         /// although no library-wide <see cref="Delimiters"/> may be used.
@@ -246,8 +246,8 @@ namespace Parquet
         /// <remarks>
         /// This is a convenience for client code and not used by the library itself.
         /// </remarks>
-        public ModelTag AttributeTag(ModelTag inPrefix)
-            => Tags.FirstOrDefault(tag => tag.StartsWithOrdinalIgnoreCase(inPrefix)) ?? "";
+        public ModelTag AttributeTag(ModelTag prefix)
+            => Tags.FirstOrDefault(tag => tag.StartsWithOrdinalIgnoreCase(prefix)) ?? "";
         #endregion
     }
 }

--- a/ParquetClassLibrary/ModelCollection.cs
+++ b/ParquetClassLibrary/ModelCollection.cs
@@ -196,10 +196,10 @@ namespace Parquet
         /// <summary>
         /// Removes the <typeparamref name="TModel"/> associated with the given <see cref="ModelID"/> from the collection.
         /// </summary>
-        /// <param name="inID">The ID for a valid, defined <typeparamref name="TModel"/> contained in this collection.</param>
-        bool IMutableModelCollection<TModel>.Remove(ModelID inID)
-            => Models.ContainsKey(inID)
-            && Remove((TModel)Models[inID]);
+        /// <param name="id">The ID for a valid, defined <typeparamref name="TModel"/> contained in this collection.</param>
+        bool IMutableModelCollection<TModel>.Remove(ModelID id)
+            => Models.ContainsKey(id)
+            && Remove((TModel)Models[id]);
 
         /// <summary>
         /// Empties the entire collection.
@@ -262,15 +262,15 @@ namespace Parquet
         /// <summary>
         /// Indicates an external view onto associated data should be updated.
         /// </summary>
-        /// <param name="inSender">The instance that raised the event.</param>
-        /// <param name="inEventData">Additional information about the event.</param>
+        /// <param name="sender">The instance that raised the event.</param>
+        /// <param name="eventData">Additional information about the event.</param>
         /// <returns><c>true</c> if the operation succeeded; otherwise, <c>false</c>.</returns>
         /// <remarks>
         /// This event is provided for the convenience of client code, particularly tools, and is not used by the library itself.
         /// </remarks>
-        protected virtual bool OnVisibleDataChanged(object inSender = null, EventArgs inEventData = null)
+        protected virtual bool OnVisibleDataChanged(object sender = null, EventArgs eventData = null)
             // NOTE that if sender is non-null, this event was raised by a collected object; otherwise, this instance raised the event.
-            => VisibleDataChanged?.Invoke(inSender ?? this, inEventData ?? EventArgs.Empty) ?? true;
+            => VisibleDataChanged?.Invoke(sender ?? this, eventData ?? EventArgs.Empty) ?? true;
         #endregion
 
         #region IReadOnlyCollection Implementation
@@ -292,47 +292,47 @@ namespace Parquet
         /// Determines whether the <see cref="ModelCollection{TModel}"/> contains a <see cref="Model"/>
         /// with the specified <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inID">The <see cref="ModelID"/> of the <see cref="Model"/> to find.</param>
+        /// <param name="id">The <see cref="ModelID"/> of the <see cref="Model"/> to find.</param>
         /// <returns><c>true</c> if the <see cref="ModelID"/> was found; <c>false</c> otherwise.</returns>
-        public bool Contains(ModelID inID)
+        public bool Contains(ModelID id)
         {
-            Debug.Assert(inID.IsValidForRange(Bounds), string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                                     nameof(ModelCollection), inID, Bounds));
-            return inID == ModelID.None
-                || Models.ContainsKey(inID);
+            Debug.Assert(id.IsValidForRange(Bounds), string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
+                                                                     nameof(ModelCollection), id, Bounds));
+            return id == ModelID.None
+                || Models.ContainsKey(id);
         }
 
         /// <summary>
         /// Retrieves a specified <typeparamref name="TModel"/>.
         /// </summary>
-        /// <param name="inID">A valid, defined <typeparamref name="TModel"/> identifier.</param>
+        /// <param name="id">A valid, defined <typeparamref name="TModel"/> identifier.</param>
         /// <typeparam name="TTarget">
-        /// The type of <typeparamref name="TModel"/> sought.  Must correspond to the given <paramref name="inID"/>.
+        /// The type of <typeparamref name="TModel"/> sought.  Must correspond to the given <paramref name="id"/>.
         /// </typeparam>
         /// <returns>The specified <typeparamref name="TTarget"/>, or null if no such model exists in this collection.</returns>
         /// <remarks>
         /// This method will return null in the following cases:
-        /// 1, if <paramref name="inID"/> is out of range or undefined;
-        /// 2, if <paramref name="inID"/> is <see cref="ModelID.None"/>;
+        /// 1, if <paramref name="id"/> is out of range or undefined;
+        /// 2, if <paramref name="id"/> is <see cref="ModelID.None"/>;
         /// 3, if this collection is empty.
         /// </remarks>
-        public TTarget GetOrNull<TTarget>(ModelID inID)
+        public TTarget GetOrNull<TTarget>(ModelID id)
             where TTarget : TModel
         {
             if (Models.Count < 1)
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorEmptyCollection,
-                                                           $"{typeof(TTarget).Name} {inID}", nameof(ModelCollection<TModel>)));
+                                                           $"{typeof(TTarget).Name} {id}", nameof(ModelCollection<TModel>)));
                 return null;
             }
-            else if (!inID.IsValidForRange(Bounds))
+            else if (!id.IsValidForRange(Bounds))
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                           nameof(ModelCollection<TModel>), inID, Bounds));
+                                                           nameof(ModelCollection<TModel>), id, Bounds));
                 return null;
             }
-            else if (inID == ModelID.None
-                     || !Models.ContainsKey(inID))
+            else if (id == ModelID.None
+                     || !Models.ContainsKey(id))
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorModelNotFound,
                                                            typeof(TTarget).Name, nameof(ModelID.None)));
@@ -340,7 +340,7 @@ namespace Parquet
             }
             else
             {
-                return (TTarget)Models[inID];
+                return (TTarget)Models[id];
             }
         }
 

--- a/ParquetClassLibrary/ModelCollection.cs
+++ b/ParquetClassLibrary/ModelCollection.cs
@@ -408,6 +408,7 @@ namespace Parquet
         {
             var csvReader = new CsvReader(reader, CultureInfo.InvariantCulture);
             csvReader.Configuration.TypeConverterOptionsCache.AddOptions(typeof(ModelID), All.IdentifierOptions);
+            csvReader.Configuration.PrepareHeaderForMatch = (string header, int index) => header.ToUpperInvariant();
             foreach (var kvp in All.ConversionConverters)
             {
                 csvReader.Configuration.TypeConverterCache.AddConverter(kvp.Key, kvp.Value);

--- a/ParquetClassLibrary/ModelCollection.cs
+++ b/ParquetClassLibrary/ModelCollection.cs
@@ -174,7 +174,7 @@ namespace Parquet
             Precondition.IsNotNull(inModel);
             Precondition.IsNotNone(inModel.ID);
             Precondition.IsInRange(inModel.ID, Bounds, nameof(inModel.ID));
-            // In a release build, however, we want to silently abort such attempts without signalling a failure, which we do here.
+            // In a release build, however, we want to silently abort such attempts without signaling a failure, which we do here.
             if (inModel is null
                 || inModel.ID == ModelID.None)
             {
@@ -264,9 +264,9 @@ namespace Parquet
         /// </summary>
         /// <param name="inSender">The instance that raised the event.</param>
         /// <param name="inEventData">Additional information about the event.</param>
-        /// <returns><c>true</c> if the operation succeded; otherwise, <c>false</c>.</returns>
+        /// <returns><c>true</c> if the operation succeeded; otherwise, <c>false</c>.</returns>
         /// <remarks>
-        /// This event is provided for the convinience of clinet code, particularly tools, and is not used by the library itself.
+        /// This event is provided for the convenience of client code, particularly tools, and is not used by the library itself.
         /// </remarks>
         protected virtual bool OnVisibleDataChanged(object inSender = null, EventArgs inEventData = null)
             // NOTE that if sender is non-null, this event was raised by a collected object; otherwise, this instance raised the event.

--- a/ParquetClassLibrary/ModelCollection.cs
+++ b/ParquetClassLibrary/ModelCollection.cs
@@ -408,7 +408,6 @@ namespace Parquet
         {
             var csvReader = new CsvReader(inReader, CultureInfo.InvariantCulture);
             csvReader.Configuration.TypeConverterOptionsCache.AddOptions(typeof(ModelID), All.IdentifierOptions);
-            csvReader.Configuration.PrepareHeaderForMatch = RemoveHeaderPrefix;
             foreach (var kvp in All.ConversionConverters)
             {
                 csvReader.Configuration.TypeConverterCache.AddConverter(kvp.Key, kvp.Value);
@@ -416,18 +415,6 @@ namespace Parquet
 
             return csvReader;
         }
-
-        /// <summary>
-        /// Removes the "in" element used in the Parquet C# style from appearing in CSV file headers.
-        /// </summary>
-        /// <param name="inHeaderText">The text to modify.</param>
-        /// <param name="inHeaderIndex">Ignored.</param>
-        /// <returns>The modified text.</returns>
-        // TODO [API] Remove the "in" prefix at v1.0, and remove this routine, too.
-        private static string RemoveHeaderPrefix(string inHeaderText, int inHeaderIndex)
-            => inHeaderText.StartsWith("in", StringComparison.InvariantCulture)
-                ? inHeaderText[2..].ToUpperInvariant()
-                : inHeaderText.ToUpperInvariant();
 
         /// <summary>
         /// Assigns <see cref="ModelID"/>s to any models that need them.

--- a/ParquetClassLibrary/ModelID.cs
+++ b/ParquetClassLibrary/ModelID.cs
@@ -66,7 +66,7 @@ namespace Parquet
         /// This is implemented as an <see cref="int"/> rather than a <see cref="Guid"/>
         /// to support human-readable design documents and <see cref="Range{ModelID}"/> validation.
         /// </remarks>
-        private int id;
+        private int InternalID;
         #endregion
 
         #region Implicit Conversion To/From Underlying Type
@@ -76,22 +76,22 @@ namespace Parquet
         /// <param name="value">Any valid identifier value.</param>
         /// <returns>The given identifier value.</returns>
         public static implicit operator ModelID(int value)
-            => new() { id = value };
+            => new() { InternalID = value };
 
         /// <summary>
         /// Enables <see cref="ModelID"/> to be treated as their backing type.
         /// </summary>
-        /// <param name="inIDentifier">Any identifier.</param>
+        /// <param name="id">Any identifier.</param>
         /// <returns>The identifier's value.</returns>
-        public static implicit operator int(ModelID inIDentifier)
-            => inIDentifier.id;
+        public static implicit operator int(ModelID id)
+            => id.InternalID;
         #endregion
 
         #region IComparable Implementation
         /// <summary>
         /// Enables <see cref="ModelID"/> to be compared to one another.
         /// </summary>
-        /// <param name="inIDentifier">Any <see cref="ModelID"/>.</param>
+        /// <param name="id">Any <see cref="ModelID"/>.</param>
         /// <returns>
         /// A value indicating the relative ordering of the <see cref="ModelID"/>s being compared.
         /// The return value has these meanings:
@@ -99,46 +99,46 @@ namespace Parquet
         ///     Zero indicates that the current instance occurs in the same position in the sort order as the given <see cref="ModelID"/>.
         ///     Greater than zero indicates that the current instance follows the given <see cref="ModelID"/> in the sort order.
         /// </returns>
-        public readonly int CompareTo(ModelID inIDentifier)
-            => id.CompareTo(inIDentifier.id);
+        public readonly int CompareTo(ModelID id)
+            => InternalID.CompareTo(id.InternalID);
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ModelID"/> strictly precedes another specified instance of <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inIDentifier1">The first <see cref="ModelID"/> to compare.</param>
-        /// <param name="inIDentifier2">The second <see cref="ModelID"/> to compare.</param>
+        /// <param name="id1">The first <see cref="ModelID"/> to compare.</param>
+        /// <param name="id2">The second <see cref="ModelID"/> to compare.</param>
         /// <returns><c>true</c> if the first identifier strictly precedes the second; otherwise, <c>false</c>.</returns>
-        public static bool operator <(ModelID inIDentifier1, ModelID inIDentifier2)
-            => inIDentifier1.id < inIDentifier2.id;
+        public static bool operator <(ModelID id1, ModelID id2)
+            => id1.InternalID < id2.InternalID;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ModelID"/> precedes or is ordinally equivalent with
         /// another specified instance of <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inIDentifier1">The first <see cref="ModelID"/> to compare.</param>
-        /// <param name="inIDentifier2">The second <see cref="ModelID"/> to compare.</param>
+        /// <param name="id1">The first <see cref="ModelID"/> to compare.</param>
+        /// <param name="id2">The second <see cref="ModelID"/> to compare.</param>
         /// <returns><c>true</c> if the first identifier precedes or is ordinally equivalent with the second; otherwise, <c>false</c>.</returns>
-        public static bool operator <=(ModelID inIDentifier1, ModelID inIDentifier2)
-            => inIDentifier1.id <= inIDentifier2.id;
+        public static bool operator <=(ModelID id1, ModelID id2)
+            => id1.InternalID <= id2.InternalID;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ModelID"/> strictly follows another specified instance of <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inIDentifier1">The first <see cref="ModelID"/> to compare.</param>
-        /// <param name="inIDentifier2">The second <see cref="ModelID"/> to compare.</param>
+        /// <param name="id1">The first <see cref="ModelID"/> to compare.</param>
+        /// <param name="id2">The second <see cref="ModelID"/> to compare.</param>
         /// <returns><c>true</c> if the first identifier strictly follows the second; otherwise, <c>false</c>.</returns>
-        public static bool operator >(ModelID inIDentifier1, ModelID inIDentifier2)
-            => inIDentifier1.id > inIDentifier2.id;
+        public static bool operator >(ModelID id1, ModelID id2)
+            => id1.InternalID > id2.InternalID;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ModelID"/> follows or is ordinally equivalent with
         /// another specified instance of <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inIDentifier1">The first <see cref="ModelID"/> to compare.</param>
-        /// <param name="inIDentifier2">The second <see cref="ModelID"/> to compare.</param>
+        /// <param name="id1">The first <see cref="ModelID"/> to compare.</param>
+        /// <param name="id2">The second <see cref="ModelID"/> to compare.</param>
         /// <returns><c>true</c> if the first identifier follows or is ordinally equivalent with the second; otherwise, <c>false</c>.</returns>
-        public static bool operator >=(ModelID inIDentifier1, ModelID inIDentifier2)
-            => inIDentifier1.id >= inIDentifier2.id;
+        public static bool operator >=(ModelID id1, ModelID id2)
+            => id1.InternalID >= id2.InternalID;
         #endregion
 
         #region IEquatable Implementation
@@ -161,15 +161,15 @@ namespace Parquet
             // See:
             // https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/ValueTuple.cs
             // https://ericlippert.com/2011/02/28/guidelines-and-rules-for-gethashcode/
-            => id.GetHashCode();
+            => InternalID.GetHashCode();
 
         /// <summary>
         /// Determines whether the specified <see cref="ModelID"/> is equal to the current <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inIDentifier">The <see cref="ModelID"/> to compare with the current.</param>
+        /// <param name="id">The <see cref="ModelID"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public readonly bool Equals(ModelID inIDentifier)
-            => id == inIDentifier.id;
+        public readonly bool Equals(ModelID id)
+            => InternalID == id.InternalID;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="ModelID"/>.
@@ -183,20 +183,20 @@ namespace Parquet
         /// <summary>
         /// Determines whether a specified instance of <see cref="ModelID"/> is equal to another specified instance of <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inIDentifier1">The first <see cref="ModelID"/> to compare.</param>
-        /// <param name="inIDentifier2">The second <see cref="ModelID"/> to compare.</param>
+        /// <param name="id1">The first <see cref="ModelID"/> to compare.</param>
+        /// <param name="id2">The second <see cref="ModelID"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(ModelID inIDentifier1, ModelID inIDentifier2)
-            => inIDentifier1.id == inIDentifier2.id;
+        public static bool operator ==(ModelID id1, ModelID id2)
+            => id1.InternalID == id2.InternalID;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ModelID"/> is not equal to another specified instance of <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inIDentifier1">The first <see cref="ModelID"/> to compare.</param>
-        /// <param name="inIDentifier2">The second <see cref="ModelID"/> to compare.</param>
+        /// <param name="id1">The first <see cref="ModelID"/> to compare.</param>
+        /// <param name="id2">The second <see cref="ModelID"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(ModelID inIDentifier1, ModelID inIDentifier2)
-            => inIDentifier1.id != inIDentifier2.id;
+        public static bool operator !=(ModelID id1, ModelID id2)
+            => id1.InternalID != id2.InternalID;
         #endregion
 
         #region ITypeConverter Implementation
@@ -211,10 +211,10 @@ namespace Parquet
         /// <summary>
         /// Registers the given record as a <see cref="Model"/> in need of a <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inRawRecord">The record to register.</param>
+        /// <param name="rawRecord">The record to register.</param>
         /// <remarks>Used during deserialization to allow the library to generate appropriate IDs.</remarks>
-        private static void RegisterMissingID(string inRawRecord)
-            => RecordsWithMissingIDs.Add(inRawRecord);
+        private static void RegisterMissingID(string rawRecord)
+            => RecordsWithMissingIDs.Add(rawRecord);
 
         /// <summary>
         /// Converts the given record column to <see cref="ModelID"/>.
@@ -243,11 +243,11 @@ namespace Parquet
 
             // Convenience method that logs a fatal parsing error and returns the given default value.
             // This is a fatal error as the library is unlikely to be able to accommodate a corrupted ModelID.
-            static ModelID DefaultWithFatalParseLog(string value, string name, ModelID inDefaultValue)
+            static ModelID DefaultWithFatalParseLog(string value, string name, ModelID defaultValue)
             {
                 Logger.Log(LogLevel.Fatal, string.Format(CultureInfo.CurrentCulture, Resources.ErrorCannotParse,
                                                          value, name), null);
-                return inDefaultValue;
+                return defaultValue;
             }
         }
 
@@ -272,14 +272,14 @@ namespace Parquet
         /// 1. It is <see cref="None"/>.
         /// 2. It is defined within the given <see cref="Range{ModelID}"/>, inclusive, regardless of sign.
         /// </summary>
-        /// <param name="inRange">The <see cref="Range{ModelID}"/> within which the absolute value of the <see cref="ModelID"/> must fall.</param>
+        /// <param name="range">The <see cref="Range{ModelID}"/> within which the absolute value of the <see cref="ModelID"/> must fall.</param>
         /// <returns>
         /// <c>true</c>, if the <see cref="ModelID"/> is valid given the <see cref="Range{ModelID}"/>, <c>false</c> otherwise.
         /// </returns>
         [Pure]
-        public readonly bool IsValidForRange(Range<ModelID> inRange)
-            => id == None
-            || inRange.ContainsValue(Math.Abs(id));
+        public readonly bool IsValidForRange(Range<ModelID> range)
+            => InternalID == None
+            || range.ContainsValue(Math.Abs(InternalID));
 
         /// <summary>
         /// Validates the current <see cref="ModelID"/> over a <see cref="IEnumerable{T}"/>.
@@ -287,19 +287,19 @@ namespace Parquet
         /// 1. It is <see cref="None"/>.
         /// 2. It is defined within any of the <see cref="Range{ModelID}"/>a in the given <see cref="IEnumerable{ModelID}"/>, inclusive, regardless of sign.
         /// </summary>
-        /// <param name="inRanges">
+        /// <param name="ranges">
         /// The <see cref="IEnumerable{T}"/> within which the <see cref="ModelID"/> must fall.
         /// </param>
         /// <returns>
         /// <c>true</c>, if the <see cref="ModelID"/> is valid given the <see cref="IEnumerable{T}"/>, <c>false</c> otherwise.
         /// </returns>
         [Pure]
-        public readonly bool IsValidForRange(IEnumerable<Range<ModelID>> inRanges)
+        public readonly bool IsValidForRange(IEnumerable<Range<ModelID>> ranges)
         {
-            Precondition.IsNotNull(inRanges, nameof(inRanges));
+            Precondition.IsNotNull(ranges, nameof(ranges));
             var result = false;
 
-            foreach (var idRange in inRanges ?? Enumerable.Empty<Range<ModelID>>())
+            foreach (var idRange in ranges ?? Enumerable.Empty<Range<ModelID>>())
             {
                 if (IsValidForRange(idRange))
                 {
@@ -316,7 +316,7 @@ namespace Parquet
         /// </summary>
         /// <returns>The representation.</returns>
         public override readonly string ToString()
-            => id.ToString(CultureInfo.InvariantCulture);
+            => InternalID.ToString(CultureInfo.InvariantCulture);
         #endregion
     }
 
@@ -328,13 +328,13 @@ namespace Parquet
         /// <summary>
         /// Determines if the given position corresponds to a point within the current array.
         /// </summary>
-        /// <param name="inIDArray">The <see cref="ModelID"/> array to validate against.</param>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="idArray">The <see cref="ModelID"/> array to validate against.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public static bool IsValidPosition(this ModelID[,] inIDArray, Point2D inPosition)
-            => inPosition.X > -1
-            && inPosition.Y > -1
-            && inPosition.X < inIDArray.GetLength(1)
-            && inPosition.Y < inIDArray.GetLength(0);
+        public static bool IsValidPosition(this ModelID[,] idArray, Point2D position)
+            => position.X > -1
+            && position.Y > -1
+            && position.X < idArray.GetLength(1)
+            && position.Y < idArray.GetLength(0);
     }
 }

--- a/ParquetClassLibrary/ModelID.cs
+++ b/ParquetClassLibrary/ModelID.cs
@@ -73,10 +73,10 @@ namespace Parquet
         /// <summary>
         /// Enables <see cref="ModelID"/>s to be treated as their backing type.
         /// </summary>
-        /// <param name="inValue">Any valid identifier value.</param>
+        /// <param name="value">Any valid identifier value.</param>
         /// <returns>The given identifier value.</returns>
-        public static implicit operator ModelID(int inValue)
-            => new() { id = inValue };
+        public static implicit operator ModelID(int value)
+            => new() { id = value };
 
         /// <summary>
         /// Enables <see cref="ModelID"/> to be treated as their backing type.
@@ -219,34 +219,34 @@ namespace Parquet
         /// <summary>
         /// Converts the given record column to <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inText">The record column to convert to an object.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The record column to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <returns>The <see cref="ModelID"/> created from the record column.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(None), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(None), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
-                if (inRow?.Context.CurrentIndex == 0)
+                if (row?.Context.CurrentIndex == 0)
                 {
-                    RegisterMissingID(inRow.Context.RawRecord);
+                    RegisterMissingID(row.Context.RawRecord);
                 }
                 return None;
             }
 
-            var id = int.TryParse(inText, All.SerializedNumberStyle, CultureInfo.InvariantCulture, out var temp)
+            var id = int.TryParse(text, All.SerializedNumberStyle, CultureInfo.InvariantCulture, out var temp)
                 ? (ModelID)temp
-                : DefaultWithFatalParseLog(inText, nameof(ModelID), None);
+                : DefaultWithFatalParseLog(text, nameof(ModelID), None);
 
             return id;
 
             // Convenience method that logs a fatal parsing error and returns the given default value.
             // This is a fatal error as the library is unlikely to be able to accommodate a corrupted ModelID.
-            static ModelID DefaultWithFatalParseLog(string inValue, string inName, ModelID inDefaultValue)
+            static ModelID DefaultWithFatalParseLog(string value, string name, ModelID inDefaultValue)
             {
                 Logger.Log(LogLevel.Fatal, string.Format(CultureInfo.CurrentCulture, Resources.ErrorCannotParse,
-                                                         inValue, inName), null);
+                                                         value, name), null);
                 return inDefaultValue;
             }
         }
@@ -254,16 +254,16 @@ namespace Parquet
         /// <summary>
         /// Converts the given <see cref="ModelID"/> to a record column.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
         /// <returns>The <see cref="ModelID"/> as a CSV record.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is ModelID id
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is ModelID id
                 ? None != id
                     ? id.ToString()
                     : nameof(None)
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(ModelID), nameof(None));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(ModelID), nameof(None));
         #endregion
 
         #region Utilities

--- a/ParquetClassLibrary/ModelID.cs
+++ b/ParquetClassLibrary/ModelID.cs
@@ -91,7 +91,7 @@ namespace Parquet
         /// <summary>
         /// Enables <see cref="ModelID"/> to be compared to one another.
         /// </summary>
-        /// <param name="id">Any <see cref="ModelID"/>.</param>
+        /// <param name="other">Any <see cref="ModelID"/>.</param>
         /// <returns>
         /// A value indicating the relative ordering of the <see cref="ModelID"/>s being compared.
         /// The return value has these meanings:
@@ -99,8 +99,8 @@ namespace Parquet
         ///     Zero indicates that the current instance occurs in the same position in the sort order as the given <see cref="ModelID"/>.
         ///     Greater than zero indicates that the current instance follows the given <see cref="ModelID"/> in the sort order.
         /// </returns>
-        public readonly int CompareTo(ModelID id)
-            => InternalID.CompareTo(id.InternalID);
+        public readonly int CompareTo(ModelID other)
+            => InternalID.CompareTo(other.InternalID);
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ModelID"/> strictly precedes another specified instance of <see cref="ModelID"/>.
@@ -166,10 +166,10 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="ModelID"/> is equal to the current <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="id">The <see cref="ModelID"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="ModelID"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public readonly bool Equals(ModelID id)
-            => InternalID == id.InternalID;
+        public readonly bool Equals(ModelID other)
+            => InternalID == other.InternalID;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="ModelID"/>.

--- a/ParquetClassLibrary/ModelIDGrid.cs
+++ b/ParquetClassLibrary/ModelIDGrid.cs
@@ -37,14 +37,14 @@ namespace Parquet
         /// <summary>
         /// Initializes a new <see cref="ModelID"/>.
         /// </summary>
-        /// <param name="inRowCount">The length of the Y dimension of the collection.</param>
-        /// <param name="inColumnCount">The length of the X dimension of the collection.</param>
-        public ModelIDGrid(int inRowCount, int inColumnCount)
+        /// <param name="rowCount">The length of the Y dimension of the collection.</param>
+        /// <param name="columnCount">The length of the X dimension of the collection.</param>
+        public ModelIDGrid(int rowCount, int columnCount)
         {
-            IDs = new ModelID[inRowCount, inColumnCount];
-            for (var y = 0; y < inRowCount; y++)
+            IDs = new ModelID[rowCount, columnCount];
+            for (var y = 0; y < rowCount; y++)
             {
-                for (var x = 0; x < inColumnCount; x++)
+                for (var x = 0; x < columnCount; x++)
                 {
                     IDs[y, x] = ModelID.None;
                 }
@@ -124,10 +124,10 @@ namespace Parquet
         /// <summary>
         /// Determines if the given position corresponds to a point within the collection.
         /// </summary>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public bool IsValidPosition(Point2D inPosition)
-            => IDs.IsValidPosition(inPosition);
+        public bool IsValidPosition(Point2D position)
+            => IDs.IsValidPosition(position);
         #endregion
     }
 }

--- a/ParquetClassLibrary/ModelTag.cs
+++ b/ParquetClassLibrary/ModelTag.cs
@@ -61,7 +61,7 @@ namespace Parquet
         /// <summary>
         /// Enables <see cref="ModelTag"/>s to be compared one another.
         /// </summary>
-        /// <param name="tag">Any valid <see cref="ModelTag"/>.</param>
+        /// <param name="other">Any valid <see cref="ModelTag"/>.</param>
         /// <returns>
         /// A value indicating the relative ordering of the <see cref="ModelTag"/>s being compared.
         /// The return value has these meanings:
@@ -69,8 +69,8 @@ namespace Parquet
         ///     Zero indicates that the current instance occurs in the same position in the sort order as the given <see cref="ModelTag"/>.
         ///     Greater than zero indicates that the current instance follows the given <see cref="ModelTag"/> in the sort order.
         /// </returns>
-        public int CompareTo(ModelTag tag)
-            => string.Compare(tagContent, tag?.tagContent ?? "", StringComparison.Ordinal);
+        public int CompareTo(ModelTag other)
+            => string.Compare(tagContent, other?.tagContent ?? "", StringComparison.Ordinal);
         #endregion
 
         #region ITypeConverter Implementation

--- a/ParquetClassLibrary/ModelTag.cs
+++ b/ParquetClassLibrary/ModelTag.cs
@@ -43,25 +43,25 @@ namespace Parquet
         /// <summary>
         /// Enables <see cref="ModelTag"/>s to be treated as their backing type.
         /// </summary>
-        /// <param name="inValue">Any valid tag value.  Invalid values will be sanitized.</param>
+        /// <param name="value">Any valid tag value.  Invalid values will be sanitized.</param>
         /// <returns>The given value as a tag.</returns>
-        public static implicit operator ModelTag(string inValue)
-            => new() { tagContent = inValue };
+        public static implicit operator ModelTag(string value)
+            => new() { tagContent = value };
 
         /// <summary>
         /// Enables <see cref="ModelTag"/>s to be treated as their backing type.
         /// </summary>
-        /// <param name="inTag">Any tag.</param>
+        /// <param name="tag">Any tag.</param>
         /// <returns>The tag's value.</returns>
-        public static implicit operator string(ModelTag inTag)
-            => inTag?.tagContent ?? "";
+        public static implicit operator string(ModelTag tag)
+            => tag?.tagContent ?? "";
         #endregion
 
         #region IComparable Implementation
         /// <summary>
         /// Enables <see cref="ModelTag"/>s to be compared one another.
         /// </summary>
-        /// <param name="inTag">Any valid <see cref="ModelTag"/>.</param>
+        /// <param name="tag">Any valid <see cref="ModelTag"/>.</param>
         /// <returns>
         /// A value indicating the relative ordering of the <see cref="ModelTag"/>s being compared.
         /// The return value has these meanings:
@@ -69,8 +69,8 @@ namespace Parquet
         ///     Zero indicates that the current instance occurs in the same position in the sort order as the given <see cref="ModelTag"/>.
         ///     Greater than zero indicates that the current instance follows the given <see cref="ModelTag"/> in the sort order.
         /// </returns>
-        public int CompareTo(ModelTag inTag)
-            => string.Compare(tagContent, inTag?.tagContent ?? "", StringComparison.Ordinal);
+        public int CompareTo(ModelTag tag)
+            => string.Compare(tagContent, tag?.tagContent ?? "", StringComparison.Ordinal);
         #endregion
 
         #region ITypeConverter Implementation
@@ -81,28 +81,28 @@ namespace Parquet
         /// <summary>
         /// Converts the given <see cref="string"/> to a <see cref="ModelTag"/>.
         /// </summary>
-        /// <param name="inText">The <see cref="string"/> to convert to an object.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The <see cref="string"/> to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <returns>The <see cref="ModelTag"/> created from the <see cref="string"/>.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
-            => string.Compare(nameof(None), inText, StringComparison.OrdinalIgnoreCase) == 0
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+            => string.Compare(nameof(None), text, StringComparison.OrdinalIgnoreCase) == 0
                 ? (ModelTag)""
-                : (ModelTag)inText;
+                : (ModelTag)text;
 
         /// <summary>
         /// Converts the given <see cref="ModelTag"/> to a record column.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
         /// <returns>The <see cref="ModelTag"/> as a CSV record.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is ModelTag tag
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is ModelTag tag
                 ? string.Compare("", tag, StringComparison.OrdinalIgnoreCase) == 0
                     ? nameof(None)
                     : (string)tag
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(ModelTag), "");
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(ModelTag), "");
         #endregion
 
         #region Utilities
@@ -117,10 +117,10 @@ namespace Parquet
         /// <summary>
         /// Determines whether the this <see cref="ModelTag"/> instance matches the given ModelTag.
         /// </summary>
-        /// <param name="inTag">The <see cref="ModelTag"/> to check against the current ModelTag.</param>
+        /// <param name="tag">The <see cref="ModelTag"/> to check against the current ModelTag.</param>
         /// <returns><c>true</c> if this and the given instance are identical, ignoring case; otherwise, <c>false</c>.</returns>
-        public bool EqualsOrdinalIgnoreCase(ModelTag inTag)
-            => string.Compare(tagContent, inTag?.tagContent ?? "", StringComparison.OrdinalIgnoreCase) == 0;
+        public bool EqualsOrdinalIgnoreCase(ModelTag tag)
+            => string.Compare(tagContent, tag?.tagContent ?? "", StringComparison.OrdinalIgnoreCase) == 0;
 
         /// <summary>
         /// Returns a <see cref="string"/> that represents the current <see cref="ModelTag"/>.

--- a/ParquetClassLibrary/ModelTag.cs
+++ b/ParquetClassLibrary/ModelTag.cs
@@ -109,10 +109,10 @@ namespace Parquet
         /// <summary>
         /// Determines whether the beginning of this <see cref="ModelTag"/> instance matches the given ModelTag.
         /// </summary>
-        /// <param name="inPrefix">The <see cref="ModelTag"/> to check against the beginning of the current ModelTag.</param>
+        /// <param name="prefix">The <see cref="ModelTag"/> to check against the beginning of the current ModelTag.</param>
         /// <returns><c>true</c> if this instance begins with the given prefix; otherwise, <c>false</c>.</returns>
-        public bool StartsWithOrdinalIgnoreCase(ModelTag inPrefix)
-            => tagContent.StartsWith(inPrefix, StringComparison.OrdinalIgnoreCase);
+        public bool StartsWithOrdinalIgnoreCase(ModelTag prefix)
+            => tagContent.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Determines whether the this <see cref="ModelTag"/> instance matches the given ModelTag.

--- a/ParquetClassLibrary/Pack.cs
+++ b/ParquetClassLibrary/Pack.cs
@@ -21,18 +21,18 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified Pack is equal to the current Pack.
         /// </summary>
-        /// <param name="inPack">The Pack to compare with the current.</param>
+        /// <param name="pack">The Pack to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public abstract bool Equals<TDerived>(TDerived inPack)
+        public abstract bool Equals<TDerived>(TDerived pack)
             where TDerived : Pack<T>;
 
         /// <summary>
         /// Determines whether the specified <see cref="Pack{T}"/> is equal to the current <see cref="Pack{T}"/>.
         /// </summary>
-        /// <param name="inPack">The <see cref="Pack{T}"/> to compare with the current.</param>
+        /// <param name="pack">The <see cref="Pack{T}"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Pack<T> inPack)
-            => Equals<Pack<T>>(inPack);
+        public bool Equals(Pack<T> pack)
+            => Equals<Pack<T>>(pack);
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Pack{T}"/>.
@@ -41,8 +41,8 @@ namespace Parquet
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
         public abstract override bool Equals(object obj);
 
-        // NOTE that derived classes should also declare static bool operator ==(Pack<T> inPack1, Pack<T> inPack2)
-        // NOTE that derived classes should also declare static bool operator !=(Pack<T> inPack1, Pack<T> inPack2)
+        // NOTE that derived classes should also declare static bool operator ==(Pack<T> pack1, Pack<T> pack2)
+        // NOTE that derived classes should also declare static bool operator !=(Pack<T> pack1, Pack<T> pack2)
         #endregion
 
         #region ITypeConverter Implementation
@@ -93,14 +93,14 @@ namespace Parquet
         /// <summary>
         /// Determines if the given position corresponds to a point within the current array.
         /// </summary>
-        /// <param name="inArray">The <see cref="Pack{T}"/> array to validate against.</param>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="array">The <see cref="Pack{T}"/> array to validate against.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public static bool IsValidPosition<T>(this Pack<T>[,] inArray, Point2D inPosition)
-            => inArray is not null
-            && inPosition.X > -1
-            && inPosition.Y > -1
-            && inPosition.X < inArray.GetLength(1)
-            && inPosition.Y < inArray.GetLength(0);
+        public static bool IsValidPosition<T>(this Pack<T>[,] array, Point2D position)
+            => array is not null
+            && position.X > -1
+            && position.Y > -1
+            && position.X < array.GetLength(1)
+            && position.Y < array.GetLength(0);
     }
 }

--- a/ParquetClassLibrary/Pack.cs
+++ b/ParquetClassLibrary/Pack.cs
@@ -51,20 +51,20 @@ namespace Parquet
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public abstract object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData);
+        public abstract object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData);
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public abstract string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData);
+        public abstract string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData);
         #endregion
 
         #region IDeeplyCloneable Implementation

--- a/ParquetClassLibrary/Pack.cs
+++ b/ParquetClassLibrary/Pack.cs
@@ -29,10 +29,10 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Pack{T}"/> is equal to the current <see cref="Pack{T}"/>.
         /// </summary>
-        /// <param name="pack">The <see cref="Pack{T}"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="Pack{T}"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Pack<T> pack)
-            => Equals<Pack<T>>(pack);
+        public bool Equals(Pack<T> other)
+            => Equals<Pack<T>>(other);
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Pack{T}"/>.

--- a/ParquetClassLibrary/ParquetClassLibrary.csproj
+++ b/ParquetClassLibrary/ParquetClassLibrary.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -6,9 +6,9 @@
 
     <Product>Parquet</Product>
     <PackageId>Parquet</PackageId>
-    <Version>0.4.9.0</Version>
+    <Version>0.4.10.0</Version>
     <AssemblyVersion>0.4.0.0</AssemblyVersion>
-    <FileVersion>0.4.9.0</FileVersion>
+    <FileVersion>0.4.10.0</FileVersion>
     <InformationalVersion>Parquet Pre-Alpha 3</InformationalVersion>
 
     <Authors>Paige Ashlynn</Authors>

--- a/ParquetClassLibrary/Parquets/BlockModel.cs
+++ b/ParquetClassLibrary/Parquets/BlockModel.cs
@@ -55,11 +55,11 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="BlockModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="BlockModel"/>.  Cannot be null.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="BlockModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="BlockModel"/>.</param>
-        /// <param name="inTags">Any additional information about the <see cref="BlockModel"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="BlockModel"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="BlockModel"/>.  Cannot be null.</param>
+        /// <param name="description">Player-friendly description of the <see cref="BlockModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="BlockModel"/>.</param>
+        /// <param name="tags">Any additional information about the <see cref="BlockModel"/>.</param>
         /// <param name="inItemID">The item that this <see cref="BlockModel"/> corresponds to, if any.</param>
         /// <param name="inAddsToBiome">A set of flags indicating which, if any, <see cref="BiomeRecipe"/> this <see cref="BlockModel"/> helps to generate.</param>
         /// <param name="inAddsToRoom">A set of flags indicating which, if any, <see cref="Rooms.RoomRecipe"/> this <see cref="BlockModel"/> helps to generate.</param>
@@ -69,15 +69,15 @@ namespace Parquet.Parquets
         /// <param name="inIsFlammable">If <c>true</c> this <see cref="BlockModel"/> may burn.</param>
         /// <param name="inIsLiquid">If <c>true</c> this <see cref="BlockModel"/> will flow.</param>
         /// <param name="inMaxToughness">Representation of the difficulty involved in gathering this <see cref="BlockModel"/>.</param>
-        public BlockModel(ModelID inID, string inName, string inDescription, string inComment,
-                          IEnumerable<ModelTag> inTags = null,
+        public BlockModel(ModelID id, string name, string description, string comment,
+                          IEnumerable<ModelTag> tags = null,
                           ModelID? inItemID = null, IEnumerable<ModelTag> inAddsToBiome = null,
                           IEnumerable<ModelTag> inAddsToRoom = null,
                           GatheringTool inGatherTool = GatheringTool.None,
                           GatheringEffect inGatherEffect = GatheringEffect.None,
                           ModelID? inCollectibleID = null, bool inIsFlammable = false,
                           bool inIsLiquid = false, int inMaxToughness = DefaultMaxToughness)
-            : base(Bounds, inID, inName, inDescription, inComment, inTags, inItemID, inAddsToBiome, inAddsToRoom)
+            : base(Bounds, id, name, description, comment, tags, inItemID, inAddsToBiome, inAddsToRoom)
         {
             var nonNullCollectibleID = inCollectibleID ?? ModelID.None;
 

--- a/ParquetClassLibrary/Parquets/BlockModel.cs
+++ b/ParquetClassLibrary/Parquets/BlockModel.cs
@@ -60,35 +60,35 @@ namespace Parquet.Parquets
         /// <param name="description">Player-friendly description of the <see cref="BlockModel"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="BlockModel"/>.</param>
         /// <param name="tags">Any additional information about the <see cref="BlockModel"/>.</param>
-        /// <param name="inItemID">The item that this <see cref="BlockModel"/> corresponds to, if any.</param>
-        /// <param name="inAddsToBiome">A set of flags indicating which, if any, <see cref="BiomeRecipe"/> this <see cref="BlockModel"/> helps to generate.</param>
-        /// <param name="inAddsToRoom">A set of flags indicating which, if any, <see cref="Rooms.RoomRecipe"/> this <see cref="BlockModel"/> helps to generate.</param>
-        /// <param name="inGatherTool">The tool used to gather this <see cref="BlockModel"/>.</param>
-        /// <param name="inGatherEffect">Effect of this <see cref="BlockModel"/> when gathered.</param>
-        /// <param name="inCollectibleID">The <see cref="CollectibleModel"/> to spawn, if any, when this <see cref="BlockModel"/> is gathered.</param>
-        /// <param name="inIsFlammable">If <c>true</c> this <see cref="BlockModel"/> may burn.</param>
-        /// <param name="inIsLiquid">If <c>true</c> this <see cref="BlockModel"/> will flow.</param>
-        /// <param name="inMaxToughness">Representation of the difficulty involved in gathering this <see cref="BlockModel"/>.</param>
+        /// <param name="itemID">The item that this <see cref="BlockModel"/> corresponds to, if any.</param>
+        /// <param name="addsToBiome">A set of flags indicating which, if any, <see cref="BiomeRecipe"/> this <see cref="BlockModel"/> helps to generate.</param>
+        /// <param name="addsToRoom">A set of flags indicating which, if any, <see cref="Rooms.RoomRecipe"/> this <see cref="BlockModel"/> helps to generate.</param>
+        /// <param name="gatherTool">The tool used to gather this <see cref="BlockModel"/>.</param>
+        /// <param name="gatherEffect">Effect of this <see cref="BlockModel"/> when gathered.</param>
+        /// <param name="collectibleID">The <see cref="CollectibleModel"/> to spawn, if any, when this <see cref="BlockModel"/> is gathered.</param>
+        /// <param name="isFlammable">If <c>true</c> this <see cref="BlockModel"/> may burn.</param>
+        /// <param name="isLiquid">If <c>true</c> this <see cref="BlockModel"/> will flow.</param>
+        /// <param name="maxToughness">Representation of the difficulty involved in gathering this <see cref="BlockModel"/>.</param>
         public BlockModel(ModelID id, string name, string description, string comment,
                           IEnumerable<ModelTag> tags = null,
-                          ModelID? inItemID = null, IEnumerable<ModelTag> inAddsToBiome = null,
-                          IEnumerable<ModelTag> inAddsToRoom = null,
-                          GatheringTool inGatherTool = GatheringTool.None,
-                          GatheringEffect inGatherEffect = GatheringEffect.None,
-                          ModelID? inCollectibleID = null, bool inIsFlammable = false,
-                          bool inIsLiquid = false, int inMaxToughness = DefaultMaxToughness)
-            : base(Bounds, id, name, description, comment, tags, inItemID, inAddsToBiome, inAddsToRoom)
+                          ModelID? itemID = null, IEnumerable<ModelTag> addsToBiome = null,
+                          IEnumerable<ModelTag> addsToRoom = null,
+                          GatheringTool gatherTool = GatheringTool.None,
+                          GatheringEffect gatherEffect = GatheringEffect.None,
+                          ModelID? collectibleID = null, bool isFlammable = false,
+                          bool isLiquid = false, int maxToughness = DefaultMaxToughness)
+            : base(Bounds, id, name, description, comment, tags, itemID, addsToBiome, addsToRoom)
         {
-            var nonNullCollectibleID = inCollectibleID ?? ModelID.None;
+            var nonNullCollectibleID = collectibleID ?? ModelID.None;
 
-            Precondition.IsInRange(nonNullCollectibleID, All.CollectibleIDs, nameof(inCollectibleID));
+            Precondition.IsInRange(nonNullCollectibleID, All.CollectibleIDs, nameof(collectibleID));
 
-            GatherTool = inGatherTool;
-            GatherEffect = inGatherEffect;
+            GatherTool = gatherTool;
+            GatherEffect = gatherEffect;
             CollectibleID = nonNullCollectibleID;
-            IsFlammable = inIsFlammable;
-            IsLiquid = inIsLiquid;
-            MaxToughness = inMaxToughness;
+            IsFlammable = isFlammable;
+            IsLiquid = isLiquid;
+            MaxToughness = maxToughness;
         }
         #endregion
 

--- a/ParquetClassLibrary/Parquets/BlockStatus.cs
+++ b/ParquetClassLibrary/Parquets/BlockStatus.cs
@@ -45,22 +45,22 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockStatus"/> class.
         /// </summary>
-        /// <param name="inToughness">The toughness of the <see cref="BlockModel"/> associated with this status.</param>
-        /// <param name="inMaxToughness">The native toughness of the <see cref="BlockModel"/> associated with this status.</param>
-        public BlockStatus(int inToughness, int inMaxToughness)
+        /// <param name="toughness">The toughness of the <see cref="BlockModel"/> associated with this status.</param>
+        /// <param name="maxToughness">The native toughness of the <see cref="BlockModel"/> associated with this status.</param>
+        public BlockStatus(int toughness, int maxToughness)
         {
-            Toughness = inToughness;
-            MaxToughness = inMaxToughness;
+            Toughness = toughness;
+            MaxToughness = maxToughness;
         }
 
         /// <summary>
         /// Initializes an instance of the <see cref="BlockStatus"/> class
         /// based on a given <see cref="BlockModel"/> identifier.
         /// </summary>
-        /// <param name="inBlockID">The <see cref="ModelID"/> of the definitions being tracked.</param>
-        public BlockStatus(ModelID inBlockID)
+        /// <param name="blockID">The <see cref="ModelID"/> of the definitions being tracked.</param>
+        public BlockStatus(ModelID blockID)
             => Toughness =
-               MaxToughness = All.Blocks.GetOrNull<BlockModel>(inBlockID)?.MaxToughness ?? BlockModel.DefaultMaxToughness;
+               MaxToughness = All.Blocks.GetOrNull<BlockModel>(blockID)?.MaxToughness ?? BlockModel.DefaultMaxToughness;
         #endregion
 
         #region IEquatable Implementation

--- a/ParquetClassLibrary/Parquets/BlockStatus.cs
+++ b/ParquetClassLibrary/Parquets/BlockStatus.cs
@@ -74,10 +74,10 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether the specified <see cref="BlockStatus"/> is equal to the current <see cref="BlockStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="BlockStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="BlockStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is BlockStatus blockStatus
+        public override bool Equals<T>(T status)
+            => status is BlockStatus blockStatus
             && Toughness == blockStatus.Toughness
             && MaxToughness == blockStatus.MaxToughness;
 
@@ -93,20 +93,20 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether a specified instance of <see cref="BlockStatus"/> is equal to another specified instance of <see cref="BlockStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="BlockStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="BlockStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="BlockStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="BlockStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(BlockStatus inStatus1, BlockStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(BlockStatus status1, BlockStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="BlockStatus"/> is not equal to another specified instance of <see cref="BlockStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="BlockStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="BlockStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="BlockStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="BlockStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(BlockStatus inStatus1, BlockStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(BlockStatus status1, BlockStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -116,32 +116,32 @@ namespace Parquet.Parquets
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is BlockStatus status
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is BlockStatus status
                 ? $"{status.Toughness}{Delimiters.InternalDelimiter}" +
                   $"{status.MaxToughness}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(BlockStatus), nameof(Default));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(BlockStatus), nameof(Default));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Default), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Default), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Default.DeepClone();
             }
 
-            var parameterText = inText.Split(Delimiters.InternalDelimiter);
+            var parameterText = text.Split(Delimiters.InternalDelimiter);
 
             var parsedToughness = int.TryParse(parameterText[0], All.SerializedNumberStyle,
                                                CultureInfo.InvariantCulture, out var temp0)

--- a/ParquetClassLibrary/Parquets/CollectibleModel.cs
+++ b/ParquetClassLibrary/Parquets/CollectibleModel.cs
@@ -35,21 +35,21 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="CollectibleModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="CollectibleModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="CollectibleModel"/>.  Cannot be null.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="CollectibleModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="CollectibleModel"/>.</param>
-        /// <param name="inTags">Any additional information about the <see cref="CollectibleModel"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="CollectibleModel"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="CollectibleModel"/>.  Cannot be null.</param>
+        /// <param name="description">Player-friendly description of the <see cref="CollectibleModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="CollectibleModel"/>.</param>
+        /// <param name="tags">Any additional information about the <see cref="CollectibleModel"/>.</param>
         /// <param name="inItemID">The <see cref="ModelID"/> of the <see cref="Items.ItemModel"/> that this <see cref="CollectibleModel"/> corresponds to, if any.</param>
         /// <param name="inAddsToBiome">A set of flags indicating which, if any, <see cref="BiomeRecipe"/> this parquet helps to generate.</param>
         /// <param name="inAddsToRoom">A set of flags indicating which, if any, <see cref="Rooms.RoomRecipe"/> this parquet helps to generate.</param>
         /// <param name="inCollectionEffect">Effect of this <see cref="CollectibleModel"/>.</param>
         /// <param name="inEffectAmount">The scale in points of the effect. For example, how much to alter a stat if <paramref name="inCollectionEffect"/> is set to alter a stat.</param>
-        public CollectibleModel(ModelID inID, string inName, string inDescription, string inComment,
-                                IEnumerable<ModelTag> inTags = null, ModelID? inItemID = null,
+        public CollectibleModel(ModelID id, string name, string description, string comment,
+                                IEnumerable<ModelTag> tags = null, ModelID? inItemID = null,
                                 IEnumerable<ModelTag> inAddsToBiome = null, IEnumerable<ModelTag> inAddsToRoom = null,
                                 CollectingEffect inCollectionEffect = CollectingEffect.None, int inEffectAmount = 0)
-            : base(Bounds, inID, inName, inDescription, inComment, inTags, inItemID, inAddsToBiome, inAddsToRoom)
+            : base(Bounds, id, name, description, comment, tags, inItemID, inAddsToBiome, inAddsToRoom)
         {
             CollectionEffect = inCollectionEffect;
             EffectAmount = inEffectAmount;

--- a/ParquetClassLibrary/Parquets/CollectibleModel.cs
+++ b/ParquetClassLibrary/Parquets/CollectibleModel.cs
@@ -40,19 +40,19 @@ namespace Parquet.Parquets
         /// <param name="description">Player-friendly description of the <see cref="CollectibleModel"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="CollectibleModel"/>.</param>
         /// <param name="tags">Any additional information about the <see cref="CollectibleModel"/>.</param>
-        /// <param name="inItemID">The <see cref="ModelID"/> of the <see cref="Items.ItemModel"/> that this <see cref="CollectibleModel"/> corresponds to, if any.</param>
-        /// <param name="inAddsToBiome">A set of flags indicating which, if any, <see cref="BiomeRecipe"/> this parquet helps to generate.</param>
-        /// <param name="inAddsToRoom">A set of flags indicating which, if any, <see cref="Rooms.RoomRecipe"/> this parquet helps to generate.</param>
-        /// <param name="inCollectionEffect">Effect of this <see cref="CollectibleModel"/>.</param>
-        /// <param name="inEffectAmount">The scale in points of the effect. For example, how much to alter a stat if <paramref name="inCollectionEffect"/> is set to alter a stat.</param>
+        /// <param name="itemID">The <see cref="ModelID"/> of the <see cref="Items.ItemModel"/> that this <see cref="CollectibleModel"/> corresponds to, if any.</param>
+        /// <param name="addsToBiome">A set of flags indicating which, if any, <see cref="BiomeRecipe"/> this parquet helps to generate.</param>
+        /// <param name="addsToRoom">A set of flags indicating which, if any, <see cref="Rooms.RoomRecipe"/> this parquet helps to generate.</param>
+        /// <param name="collectionEffect">Effect of this <see cref="CollectibleModel"/>.</param>
+        /// <param name="effectAmount">The scale in points of the effect. For example, how much to alter a stat if <paramref name="collectionEffect"/> is set to alter a stat.</param>
         public CollectibleModel(ModelID id, string name, string description, string comment,
-                                IEnumerable<ModelTag> tags = null, ModelID? inItemID = null,
-                                IEnumerable<ModelTag> inAddsToBiome = null, IEnumerable<ModelTag> inAddsToRoom = null,
-                                CollectingEffect inCollectionEffect = CollectingEffect.None, int inEffectAmount = 0)
-            : base(Bounds, id, name, description, comment, tags, inItemID, inAddsToBiome, inAddsToRoom)
+                                IEnumerable<ModelTag> tags = null, ModelID? itemID = null,
+                                IEnumerable<ModelTag> addsToBiome = null, IEnumerable<ModelTag> addsToRoom = null,
+                                CollectingEffect collectionEffect = CollectingEffect.None, int effectAmount = 0)
+            : base(Bounds, id, name, description, comment, tags, itemID, addsToBiome, addsToRoom)
         {
-            CollectionEffect = inCollectionEffect;
-            EffectAmount = inEffectAmount;
+            CollectionEffect = collectionEffect;
+            EffectAmount = effectAmount;
         }
         #endregion
 

--- a/ParquetClassLibrary/Parquets/FloorModel.cs
+++ b/ParquetClassLibrary/Parquets/FloorModel.cs
@@ -43,23 +43,23 @@ namespace Parquet.Parquets
         /// <param name="description">Player-friendly description of the <see cref="FloorModel"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="FloorModel"/>.</param>
         /// <param name="tags">Any additional information about the <see cref="FloorModel"/>.</param>
-        /// <param name="inItemID">The <see cref="ModelID"/> of the <see cref="ItemModel"/> awarded to the player when a character gathers this <see cref="FloorModel"/>.</param>
-        /// <param name="inAddsToBiome">Which, if any, <see cref="BiomeRecipe"/> this <see cref="FloorModel"/> helps to generate.</param>
-        /// <param name="inAddsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this <see cref="FloorModel"/> helps form.</param>
-        /// <param name="inModTool">The tool used to modify this <see cref="FloorModel"/>.</param>
-        /// <param name="inTrenchName">The name to use for this <see cref="FloorModel"/> when it has been dug out.</param>
+        /// <param name="itemID">The <see cref="ModelID"/> of the <see cref="ItemModel"/> awarded to the player when a character gathers this <see cref="FloorModel"/>.</param>
+        /// <param name="addsToBiome">Which, if any, <see cref="BiomeRecipe"/> this <see cref="FloorModel"/> helps to generate.</param>
+        /// <param name="addsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this <see cref="FloorModel"/> helps form.</param>
+        /// <param name="modTool">The tool used to modify this <see cref="FloorModel"/>.</param>
+        /// <param name="trenchName">The name to use for this <see cref="FloorModel"/> when it has been dug out.</param>
         public FloorModel(ModelID id, string name, string description, string comment,
-                          IEnumerable<ModelTag> tags = null, ModelID? inItemID = null,
-                          IEnumerable<ModelTag> inAddsToBiome = null, IEnumerable<ModelTag> inAddsToRoom = null,
-                          ModificationTool inModTool = ModificationTool.None, string inTrenchName = null)
-            : base(Bounds, id, name, description, comment, tags, inItemID, inAddsToBiome, inAddsToRoom)
+                          IEnumerable<ModelTag> tags = null, ModelID? itemID = null,
+                          IEnumerable<ModelTag> addsToBiome = null, IEnumerable<ModelTag> addsToRoom = null,
+                          ModificationTool modTool = ModificationTool.None, string trenchName = null)
+            : base(Bounds, id, name, description, comment, tags, itemID, addsToBiome, addsToRoom)
         {
-            ModTool = inModTool;
+            ModTool = modTool;
             TrenchName =
                 // TODO [Robustness] Are there places we use IsNullOrEmpty where IsNullOrWhiteSpace would be more appropriate?
-                string.IsNullOrWhiteSpace(inTrenchName)
+                string.IsNullOrWhiteSpace(trenchName)
                     ? DefaultTrenchName
-                    : inTrenchName;
+                    : trenchName;
         }
         #endregion
 

--- a/ParquetClassLibrary/Parquets/FloorModel.cs
+++ b/ParquetClassLibrary/Parquets/FloorModel.cs
@@ -38,21 +38,21 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="FloorModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="FloorModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="FloorModel"/>.  Cannot be null.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="FloorModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="FloorModel"/>.</param>
-        /// <param name="inTags">Any additional information about the <see cref="FloorModel"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="FloorModel"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="FloorModel"/>.  Cannot be null.</param>
+        /// <param name="description">Player-friendly description of the <see cref="FloorModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="FloorModel"/>.</param>
+        /// <param name="tags">Any additional information about the <see cref="FloorModel"/>.</param>
         /// <param name="inItemID">The <see cref="ModelID"/> of the <see cref="ItemModel"/> awarded to the player when a character gathers this <see cref="FloorModel"/>.</param>
         /// <param name="inAddsToBiome">Which, if any, <see cref="BiomeRecipe"/> this <see cref="FloorModel"/> helps to generate.</param>
         /// <param name="inAddsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this <see cref="FloorModel"/> helps form.</param>
         /// <param name="inModTool">The tool used to modify this <see cref="FloorModel"/>.</param>
         /// <param name="inTrenchName">The name to use for this <see cref="FloorModel"/> when it has been dug out.</param>
-        public FloorModel(ModelID inID, string inName, string inDescription, string inComment,
-                          IEnumerable<ModelTag> inTags = null, ModelID? inItemID = null,
+        public FloorModel(ModelID id, string name, string description, string comment,
+                          IEnumerable<ModelTag> tags = null, ModelID? inItemID = null,
                           IEnumerable<ModelTag> inAddsToBiome = null, IEnumerable<ModelTag> inAddsToRoom = null,
                           ModificationTool inModTool = ModificationTool.None, string inTrenchName = null)
-            : base(Bounds, inID, inName, inDescription, inComment, inTags, inItemID, inAddsToBiome, inAddsToRoom)
+            : base(Bounds, id, name, description, comment, tags, inItemID, inAddsToBiome, inAddsToRoom)
         {
             ModTool = inModTool;
             TrenchName =

--- a/ParquetClassLibrary/Parquets/FloorStatus.cs
+++ b/ParquetClassLibrary/Parquets/FloorStatus.cs
@@ -65,10 +65,10 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether the specified <see cref="FloorStatus"/> is equal to the current <see cref="FloorStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="FloorStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="FloorStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is FloorStatus floorStatus
+        public override bool Equals<T>(T status)
+            => status is FloorStatus floorStatus
             && IsTrench == floorStatus.IsTrench;
 
         /// <summary>
@@ -83,20 +83,20 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether a specified instance of <see cref="FloorStatus"/> is equal to another specified instance of <see cref="FloorStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="FloorStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="FloorStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="FloorStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="FloorStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(FloorStatus inStatus1, FloorStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(FloorStatus status1, FloorStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="FloorStatus"/> is not equal to another specified instance of <see cref="FloorStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="FloorStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="FloorStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="FloorStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="FloorStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(FloorStatus inStatus1, FloorStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(FloorStatus status1, FloorStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -106,33 +106,33 @@ namespace Parquet.Parquets
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is FloorStatus status
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is FloorStatus status
                 ? $"{status.IsTrench}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(FloorStatus), nameof(Default));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(FloorStatus), nameof(Default));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Default), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Default), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Default.DeepClone();
             }
 
-            var parsedIsTrench = bool.TryParse(inText, out var temp1)
+            var parsedIsTrench = bool.TryParse(text, out var temp1)
                 ? temp1
-                : Logger.DefaultWithParseLog(inText, nameof(IsTrench), false);
+                : Logger.DefaultWithParseLog(text, nameof(IsTrench), false);
 
             return new FloorStatus(parsedIsTrench);
         }

--- a/ParquetClassLibrary/Parquets/FloorStatus.cs
+++ b/ParquetClassLibrary/Parquets/FloorStatus.cs
@@ -33,20 +33,20 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="FloorStatus"/> class.
         /// </summary>
-        /// <param name="inIsTrench">Whether or not the <see cref="FloorModel"/> associated with this status has been dug out.</param>
-        public FloorStatus(bool inIsTrench)
-            => IsTrench = inIsTrench;
+        /// <param name="isTrench">Whether or not the <see cref="FloorModel"/> associated with this status has been dug out.</param>
+        public FloorStatus(bool isTrench)
+            => IsTrench = isTrench;
 
         /// <summary>
         /// Initializes an instance of the <see cref="FloorStatus"/> class
         /// based on a given <see cref="FloorModel"/> identifier.
         /// </summary>
-        /// <param name="inFloorID">The <see cref="ModelID"/> of the definitions being tracked.</param>
+        /// <param name="floorID">The <see cref="ModelID"/> of the definitions being tracked.</param>
         [SuppressMessage("Usage", "CA1801:Review unused parameters",
             Justification = "This constructor is provided for consistency.  The parameter is currently ignored, but may not be in the future.")]
         [SuppressMessage("Style", "IDE0060:Remove unused parameter",
             Justification = "This constructor is provided for consistency.  The parameter is currently ignored, but may not be in the future.")]
-        public FloorStatus(ModelID inFloorID)
+        public FloorStatus(ModelID floorID)
             // NOTE Currently, by design, no Floor starts as a trench.
             : this(false)
         { }

--- a/ParquetClassLibrary/Parquets/FurnishingModel.cs
+++ b/ParquetClassLibrary/Parquets/FurnishingModel.cs
@@ -44,11 +44,11 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="FurnishingModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="FurnishingModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="FurnishingModel"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="FurnishingModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="FurnishingModel"/>.</param>
-        /// <param name="inTags">Any additional information about the <see cref="FurnishingModel"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="FurnishingModel"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="FurnishingModel"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="FurnishingModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="FurnishingModel"/>.</param>
+        /// <param name="tags">Any additional information about the <see cref="FurnishingModel"/>.</param>
         /// <param name="inItemID">The <see cref="ModelID"/> that represents this <see cref="FurnishingModel"/> in the <see cref="Items.InventoryCollection"/>.</param>
         /// <param name="inAddsToBiome">Indicates which, if any, <see cref="BiomeRecipe"/> this parquet helps to generate.</param>
         /// <param name="inAddsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this parquet helps form.</param>
@@ -57,12 +57,12 @@ namespace Parquet.Parquets
         /// <param name="inIsEnclosing">If <c>true</c> this <see cref="FurnishingModel"/> serves as part of a perimeter of a <see cref="Rooms.Room"/>.</param>
         /// <param name="inIsFlammable">If <c>true</c> this <see cref="FurnishingModel"/> may catch fire.</param>
         /// <param name="inIsOpenable">If <c>true</c> this <see cref="FurnishingModel"/> may be opened and closed.</param>
-        public FurnishingModel(ModelID inID, string inName, string inDescription, string inComment,
-                               IEnumerable<ModelTag> inTags = null, ModelID? inItemID = null,
+        public FurnishingModel(ModelID id, string name, string description, string comment,
+                               IEnumerable<ModelTag> tags = null, ModelID? inItemID = null,
                                IEnumerable<ModelTag> inAddsToBiome = null, IEnumerable<ModelTag> inAddsToRoom = null,
                                bool inIsWalkable = false, EntryType inEntry = EntryType.None, bool inIsEnclosing = false,
                                bool inIsFlammable = false, bool inIsOpenable = false)
-            : base(Bounds, inID, inName, inDescription, inComment, inTags, inItemID, inAddsToBiome, inAddsToRoom)
+            : base(Bounds, id, name, description, comment, tags, inItemID, inAddsToBiome, inAddsToRoom)
         {
             IsWalkable = inIsWalkable;
             Entry = inEntry;

--- a/ParquetClassLibrary/Parquets/FurnishingModel.cs
+++ b/ParquetClassLibrary/Parquets/FurnishingModel.cs
@@ -53,19 +53,19 @@ namespace Parquet.Parquets
         /// <param name="addsToBiome">Indicates which, if any, <see cref="BiomeRecipe"/> this parquet helps to generate.</param>
         /// <param name="addsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this parquet helps form.</param>
         /// <param name="isWalkable">If <c>true</c> this <see cref="FurnishingModel"/> may be walked on.</param>
-        /// <param name="isEntry">If <c>true</c> this <see cref="FurnishingModel"/> serves as an entry to a <see cref="Rooms.Room"/>.</param>
+        /// <param name="entry">If <c>true</c> this <see cref="FurnishingModel"/> serves as an entry to a <see cref="Rooms.Room"/>.</param>
         /// <param name="isEnclosing">If <c>true</c> this <see cref="FurnishingModel"/> serves as part of a perimeter of a <see cref="Rooms.Room"/>.</param>
         /// <param name="isFlammable">If <c>true</c> this <see cref="FurnishingModel"/> may catch fire.</param>
         /// <param name="isOpenable">If <c>true</c> this <see cref="FurnishingModel"/> may be opened and closed.</param>
         public FurnishingModel(ModelID id, string name, string description, string comment,
                                IEnumerable<ModelTag> tags = null, ModelID? itemID = null,
                                IEnumerable<ModelTag> addsToBiome = null, IEnumerable<ModelTag> addsToRoom = null,
-                               bool isWalkable = false, EntryType isEntry = EntryType.None, bool isEnclosing = false,
+                               bool isWalkable = false, EntryType entry = EntryType.None, bool isEnclosing = false,
                                bool isFlammable = false, bool isOpenable = false)
             : base(Bounds, id, name, description, comment, tags, itemID, addsToBiome, addsToRoom)
         {
             IsWalkable = isWalkable;
-            Entry = isEntry;
+            Entry = entry;
             IsEnclosing = isEnclosing;
             IsFlammable = isFlammable;
             IsOpenable = isOpenable;

--- a/ParquetClassLibrary/Parquets/FurnishingModel.cs
+++ b/ParquetClassLibrary/Parquets/FurnishingModel.cs
@@ -49,26 +49,26 @@ namespace Parquet.Parquets
         /// <param name="description">Player-friendly description of the <see cref="FurnishingModel"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="FurnishingModel"/>.</param>
         /// <param name="tags">Any additional information about the <see cref="FurnishingModel"/>.</param>
-        /// <param name="inItemID">The <see cref="ModelID"/> that represents this <see cref="FurnishingModel"/> in the <see cref="Items.InventoryCollection"/>.</param>
-        /// <param name="inAddsToBiome">Indicates which, if any, <see cref="BiomeRecipe"/> this parquet helps to generate.</param>
-        /// <param name="inAddsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this parquet helps form.</param>
-        /// <param name="inIsWalkable">If <c>true</c> this <see cref="FurnishingModel"/> may be walked on.</param>
-        /// <param name="inEntry">If <c>true</c> this <see cref="FurnishingModel"/> serves as an entry to a <see cref="Rooms.Room"/>.</param>
-        /// <param name="inIsEnclosing">If <c>true</c> this <see cref="FurnishingModel"/> serves as part of a perimeter of a <see cref="Rooms.Room"/>.</param>
-        /// <param name="inIsFlammable">If <c>true</c> this <see cref="FurnishingModel"/> may catch fire.</param>
-        /// <param name="inIsOpenable">If <c>true</c> this <see cref="FurnishingModel"/> may be opened and closed.</param>
+        /// <param name="itemID">The <see cref="ModelID"/> that represents this <see cref="FurnishingModel"/> in the <see cref="Items.InventoryCollection"/>.</param>
+        /// <param name="addsToBiome">Indicates which, if any, <see cref="BiomeRecipe"/> this parquet helps to generate.</param>
+        /// <param name="addsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this parquet helps form.</param>
+        /// <param name="isWalkable">If <c>true</c> this <see cref="FurnishingModel"/> may be walked on.</param>
+        /// <param name="isEntry">If <c>true</c> this <see cref="FurnishingModel"/> serves as an entry to a <see cref="Rooms.Room"/>.</param>
+        /// <param name="isEnclosing">If <c>true</c> this <see cref="FurnishingModel"/> serves as part of a perimeter of a <see cref="Rooms.Room"/>.</param>
+        /// <param name="isFlammable">If <c>true</c> this <see cref="FurnishingModel"/> may catch fire.</param>
+        /// <param name="isOpenable">If <c>true</c> this <see cref="FurnishingModel"/> may be opened and closed.</param>
         public FurnishingModel(ModelID id, string name, string description, string comment,
-                               IEnumerable<ModelTag> tags = null, ModelID? inItemID = null,
-                               IEnumerable<ModelTag> inAddsToBiome = null, IEnumerable<ModelTag> inAddsToRoom = null,
-                               bool inIsWalkable = false, EntryType inEntry = EntryType.None, bool inIsEnclosing = false,
-                               bool inIsFlammable = false, bool inIsOpenable = false)
-            : base(Bounds, id, name, description, comment, tags, inItemID, inAddsToBiome, inAddsToRoom)
+                               IEnumerable<ModelTag> tags = null, ModelID? itemID = null,
+                               IEnumerable<ModelTag> addsToBiome = null, IEnumerable<ModelTag> addsToRoom = null,
+                               bool isWalkable = false, EntryType isEntry = EntryType.None, bool isEnclosing = false,
+                               bool isFlammable = false, bool isOpenable = false)
+            : base(Bounds, id, name, description, comment, tags, itemID, addsToBiome, addsToRoom)
         {
-            IsWalkable = inIsWalkable;
-            Entry = inEntry;
-            IsEnclosing = inIsEnclosing;
-            IsFlammable = inIsFlammable;
-            IsOpenable = inIsOpenable;
+            IsWalkable = isWalkable;
+            Entry = isEntry;
+            IsEnclosing = isEnclosing;
+            IsFlammable = isFlammable;
+            IsOpenable = isOpenable;
         }
         #endregion
 

--- a/ParquetClassLibrary/Parquets/FurnishingStatus.cs
+++ b/ParquetClassLibrary/Parquets/FurnishingStatus.cs
@@ -33,20 +33,20 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="FurnishingStatus"/> class.
         /// </summary>
-        /// <param name="inIsOpen">When <c>true</c>, the <see cref="FurnishingModel"/> associated with this status is open.</param>
-        public FurnishingStatus(bool inIsOpen)
-            => IsOpen = inIsOpen;
+        /// <param name="isOpen">When <c>true</c>, the <see cref="FurnishingModel"/> associated with this status is open.</param>
+        public FurnishingStatus(bool isOpen)
+            => IsOpen = isOpen;
 
         /// <summary>
         /// Initializes an instance of the <see cref="FurnishingStatus"/> class
         /// based on a given <see cref="FurnishingModel"/> identifier.
         /// </summary>
-        /// <param name="inFloorID">The <see cref="ModelID"/> of the definitions being tracked.</param>
+        /// <param name="furnishingID">The <see cref="ModelID"/> of the definitions being tracked.</param>
         [SuppressMessage("Usage", "CA1801:Review unused parameters",
             Justification = "This constructor is provided for consistency.  The parameter is currently ignored, but may not be in the future.")]
         [SuppressMessage("Style", "IDE0060:Remove unused parameter",
             Justification = "This constructor is provided for consistency.  The parameter is currently ignored, but may not be in the future.")]
-        public FurnishingStatus(ModelID inFloorID)
+        public FurnishingStatus(ModelID furnishingID)
             // NOTE Currently, by design, no Furnishing starts open.
             : this(false)
         { }

--- a/ParquetClassLibrary/Parquets/FurnishingStatus.cs
+++ b/ParquetClassLibrary/Parquets/FurnishingStatus.cs
@@ -65,10 +65,10 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether the specified <see cref="FurnishingStatus"/> is equal to the current <see cref="FurnishingStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="FurnishingStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="FurnishingStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is FurnishingStatus FurnishingStatus
+        public override bool Equals<T>(T status)
+            => status is FurnishingStatus FurnishingStatus
             && IsOpen == FurnishingStatus.IsOpen;
 
         /// <summary>
@@ -83,20 +83,20 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether a specified instance of <see cref="FurnishingStatus"/> is equal to another specified instance of <see cref="FurnishingStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="FurnishingStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="FurnishingStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="FurnishingStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="FurnishingStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(FurnishingStatus inStatus1, FurnishingStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(FurnishingStatus status1, FurnishingStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="FurnishingStatus"/> is not equal to another specified instance of <see cref="FurnishingStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="FurnishingStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="FurnishingStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="FurnishingStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="FurnishingStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(FurnishingStatus inStatus1, FurnishingStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(FurnishingStatus status1, FurnishingStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -106,33 +106,33 @@ namespace Parquet.Parquets
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is FurnishingStatus status
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is FurnishingStatus status
                 ? $"{status.IsOpen}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(FurnishingStatus), nameof(Default));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(FurnishingStatus), nameof(Default));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Default), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Default), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Default.DeepClone();
             }
 
-            var parsedIsTrench = bool.TryParse(inText, out var temp1)
+            var parsedIsTrench = bool.TryParse(text, out var temp1)
                 ? temp1
-                : Logger.DefaultWithParseLog(inText, nameof(IsOpen), false);
+                : Logger.DefaultWithParseLog(text, nameof(IsOpen), false);
 
             return new FurnishingStatus(parsedIsTrench);
         }

--- a/ParquetClassLibrary/Parquets/ParquetModel.cs
+++ b/ParquetClassLibrary/Parquets/ParquetModel.cs
@@ -40,25 +40,25 @@ namespace Parquet.Parquets
         /// <summary>
         /// Used by subtypes of the <see cref="ParquetModel"/> class.
         /// </summary>
-        /// <param name="inBounds">The bounds within which the derived parquet type's ModelID is defined.</param>
+        /// <param name="bounds">The bounds within which the derived parquet type's ModelID is defined.</param>
         /// <param name="id">Unique identifier for the parquet.  Cannot be null.</param>
         /// <param name="name">Player-friendly name of the parquet.  Cannot be null or empty.</param>
         /// <param name="description">Player-friendly description of the parquet.</param>
         /// <param name="comment">Comment of, on, or by the parquet.</param>
         /// <param name="tags">Any additional information about this parquet.</param>
-        /// <param name="inItemID">The <see cref="ModelID"/> of the <see cref="Items.ItemModel"/> awarded to the player when a character gathers or collects this parquet.</param>
-        /// <param name="inAddsToBiome">Describes which, if any, <see cref="BiomeRecipe"/>(s) this parquet helps form.</param>
-        /// <param name="inAddsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this parquet helps form.</param>
-        protected ParquetModel(Range<ModelID> inBounds, ModelID id, string name, string description, string comment,
-                               IEnumerable<ModelTag> tags = null, ModelID? inItemID = null,
-                               IEnumerable<ModelTag> inAddsToBiome = null, IEnumerable<ModelTag> inAddsToRoom = null)
-            : base(inBounds, id, name, description, comment, tags)
+        /// <param name="itemID">The <see cref="ModelID"/> of the <see cref="Items.ItemModel"/> awarded to the player when a character gathers or collects this parquet.</param>
+        /// <param name="addsToBiome">Describes which, if any, <see cref="BiomeRecipe"/>(s) this parquet helps form.</param>
+        /// <param name="addsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this parquet helps form.</param>
+        protected ParquetModel(Range<ModelID> bounds, ModelID id, string name, string description, string comment,
+                               IEnumerable<ModelTag> tags = null, ModelID? itemID = null,
+                               IEnumerable<ModelTag> addsToBiome = null, IEnumerable<ModelTag> addsToRoom = null)
+            : base(bounds, id, name, description, comment, tags)
         {
-            var nonNullItemID = inItemID ?? ModelID.None;
-            var nonNullAddsToBiome = (inAddsToBiome ?? Enumerable.Empty<ModelTag>()).ToList();
-            var nonNullAddsToRoom = (inAddsToRoom ?? Enumerable.Empty<ModelTag>()).ToList();
+            var nonNullItemID = itemID ?? ModelID.None;
+            var nonNullAddsToBiome = (addsToBiome ?? Enumerable.Empty<ModelTag>()).ToList();
+            var nonNullAddsToRoom = (addsToRoom ?? Enumerable.Empty<ModelTag>()).ToList();
 
-            Precondition.IsInRange(nonNullItemID, All.ItemIDs, nameof(inItemID));
+            Precondition.IsInRange(nonNullItemID, All.ItemIDs, nameof(itemID));
 
             ItemID = nonNullItemID;
             AddsToBiome = nonNullAddsToBiome;

--- a/ParquetClassLibrary/Parquets/ParquetModel.cs
+++ b/ParquetClassLibrary/Parquets/ParquetModel.cs
@@ -41,18 +41,18 @@ namespace Parquet.Parquets
         /// Used by subtypes of the <see cref="ParquetModel"/> class.
         /// </summary>
         /// <param name="inBounds">The bounds within which the derived parquet type's ModelID is defined.</param>
-        /// <param name="inID">Unique identifier for the parquet.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the parquet.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the parquet.</param>
-        /// <param name="inComment">Comment of, on, or by the parquet.</param>
-        /// <param name="inTags">Any additional information about this parquet.</param>
+        /// <param name="id">Unique identifier for the parquet.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the parquet.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the parquet.</param>
+        /// <param name="comment">Comment of, on, or by the parquet.</param>
+        /// <param name="tags">Any additional information about this parquet.</param>
         /// <param name="inItemID">The <see cref="ModelID"/> of the <see cref="Items.ItemModel"/> awarded to the player when a character gathers or collects this parquet.</param>
         /// <param name="inAddsToBiome">Describes which, if any, <see cref="BiomeRecipe"/>(s) this parquet helps form.</param>
         /// <param name="inAddsToRoom">Describes which, if any, <see cref="Rooms.RoomRecipe"/>(s) this parquet helps form.</param>
-        protected ParquetModel(Range<ModelID> inBounds, ModelID inID, string inName, string inDescription, string inComment,
-                               IEnumerable<ModelTag> inTags = null, ModelID? inItemID = null,
+        protected ParquetModel(Range<ModelID> inBounds, ModelID id, string name, string description, string comment,
+                               IEnumerable<ModelTag> tags = null, ModelID? inItemID = null,
                                IEnumerable<ModelTag> inAddsToBiome = null, IEnumerable<ModelTag> inAddsToRoom = null)
-            : base(inBounds, inID, inName, inDescription, inComment, inTags)
+            : base(inBounds, id, name, description, comment, tags)
         {
             var nonNullItemID = inItemID ?? ModelID.None;
             var nonNullAddsToBiome = (inAddsToBiome ?? Enumerable.Empty<ModelTag>()).ToList();

--- a/ParquetClassLibrary/Parquets/ParquetModelPack.cs
+++ b/ParquetClassLibrary/Parquets/ParquetModelPack.cs
@@ -42,21 +42,21 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="ParquetModelPack"/> class.
         /// </summary>
-        /// <param name="inFloor">The floor-layer parquet.</param>
-        /// <param name="inBlock">The block-layer parquet.</param>
-        /// <param name="inFurnishing">The furnishing-layer parquet.</param>
-        /// <param name="inCollectible">The collectible-layer parquet.</param>
-        public ParquetModelPack(ModelID inFloor, ModelID inBlock, ModelID inFurnishing, ModelID inCollectible)
+        /// <param name="floor">The floor-layer parquet.</param>
+        /// <param name="block">The block-layer parquet.</param>
+        /// <param name="furnishing">The furnishing-layer parquet.</param>
+        /// <param name="collectible">The collectible-layer parquet.</param>
+        public ParquetModelPack(ModelID floor, ModelID block, ModelID furnishing, ModelID collectible)
         {
-            Precondition.IsInRange(inFloor, All.FloorIDs, nameof(inFloor));
-            Precondition.IsInRange(inBlock, All.BlockIDs, nameof(inBlock));
-            Precondition.IsInRange(inFurnishing, All.FurnishingIDs, nameof(inFurnishing));
-            Precondition.IsInRange(inCollectible, All.CollectibleIDs, nameof(inCollectible));
+            Precondition.IsInRange(floor, All.FloorIDs, nameof(floor));
+            Precondition.IsInRange(block, All.BlockIDs, nameof(block));
+            Precondition.IsInRange(furnishing, All.FurnishingIDs, nameof(furnishing));
+            Precondition.IsInRange(collectible, All.CollectibleIDs, nameof(collectible));
 
-            FloorID = inFloor;
-            BlockID = inBlock;
-            FurnishingID = inFurnishing;
-            CollectibleID = inCollectible;
+            FloorID = floor;
+            BlockID = block;
+            FurnishingID = furnishing;
+            CollectibleID = collectible;
         }
         #endregion
 
@@ -127,10 +127,10 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether the specified <see cref="ParquetModelPack"/> is equal to the current <see cref="ParquetModelPack"/>.
         /// </summary>
-        /// <param name="inPack">The <see cref="ParquetModelPack"/> to compare with the current.</param>
+        /// <param name="pack">The <see cref="ParquetModelPack"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inPack)
-            => inPack is ParquetModelPack parquetModelPack
+        public override bool Equals<T>(T pack)
+            => pack is ParquetModelPack parquetModelPack
             && FloorID == parquetModelPack.FloorID
             && BlockID == parquetModelPack.BlockID
             && FurnishingID == parquetModelPack.FurnishingID
@@ -148,20 +148,20 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether a specified instance of <see cref="ParquetModelPack"/> is equal to another specified instance of <see cref="ParquetModelPack"/>.
         /// </summary>
-        /// <param name="inPack1">The first <see cref="ParquetModelPack"/> to compare.</param>
-        /// <param name="inPack2">The second <see cref="ParquetModelPack"/> to compare.</param>
+        /// <param name="pack1">The first <see cref="ParquetModelPack"/> to compare.</param>
+        /// <param name="pack2">The second <see cref="ParquetModelPack"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(ParquetModelPack inPack1, ParquetModelPack inPack2)
-            => inPack1?.Equals(inPack2) ?? inPack2?.Equals(inPack1) ?? true;
+        public static bool operator ==(ParquetModelPack pack1, ParquetModelPack pack2)
+            => pack1?.Equals(pack2) ?? pack2?.Equals(pack1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ParquetModelPack"/> is not equal to another specified instance of <see cref="ParquetModelPack"/>.
         /// </summary>
-        /// <param name="inPack1">The first <see cref="ParquetModelPack"/> to compare.</param>
-        /// <param name="inPack2">The second <see cref="ParquetModelPack"/> to compare.</param>
+        /// <param name="pack1">The first <see cref="ParquetModelPack"/> to compare.</param>
+        /// <param name="pack2">The second <see cref="ParquetModelPack"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(ParquetModelPack inPack1, ParquetModelPack inPack2)
-            => !(inPack1 == inPack2);
+        public static bool operator !=(ParquetModelPack pack1, ParquetModelPack pack2)
+            => !(pack1 == pack2);
         #endregion
 
         #region ITypeConverter Implementation

--- a/ParquetClassLibrary/Parquets/ParquetModelPack.cs
+++ b/ParquetClassLibrary/Parquets/ParquetModelPack.cs
@@ -171,39 +171,39 @@ namespace Parquet.Parquets
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is ParquetModelPack pack
-                ? $"{pack.FloorID.ConvertToString(pack.FloorID, inRow, inMemberMapData)}{Delimiters.PackDelimiter}" +
-                  $"{pack.BlockID.ConvertToString(pack.BlockID, inRow, inMemberMapData)}{Delimiters.PackDelimiter}" +
-                  $"{pack.FurnishingID.ConvertToString(pack.FurnishingID, inRow, inMemberMapData)}{Delimiters.PackDelimiter}" +
-                  $"{pack.CollectibleID.ConvertToString(pack.CollectibleID, inRow, inMemberMapData)}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(ParquetModelPack), nameof(Empty));
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is ParquetModelPack pack
+                ? $"{pack.FloorID.ConvertToString(pack.FloorID, row, memberMapData)}{Delimiters.PackDelimiter}" +
+                  $"{pack.BlockID.ConvertToString(pack.BlockID, row, memberMapData)}{Delimiters.PackDelimiter}" +
+                  $"{pack.FurnishingID.ConvertToString(pack.FurnishingID, row, memberMapData)}{Delimiters.PackDelimiter}" +
+                  $"{pack.CollectibleID.ConvertToString(pack.CollectibleID, row, memberMapData)}"
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(ParquetModelPack), nameof(Empty));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Empty), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Empty), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Empty;
             }
 
-            var parameterText = inText.Split(Delimiters.PackDelimiter);
+            var parameterText = text.Split(Delimiters.PackDelimiter);
 
-            var parsedFloor = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[0], inRow, inMemberMapData);
-            var parsedBlock = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[1], inRow, inMemberMapData);
-            var parsedFurnishing = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[2], inRow, inMemberMapData);
-            var parsedCollectible = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[3], inRow, inMemberMapData);
+            var parsedFloor = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[0], row, memberMapData);
+            var parsedBlock = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[1], row, memberMapData);
+            var parsedFurnishing = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[2], row, memberMapData);
+            var parsedCollectible = (ModelID)ModelID.ConverterFactory.ConvertFromString(parameterText[3], row, memberMapData);
 
             return new ParquetModelPack(parsedFloor, parsedBlock, parsedFurnishing, parsedCollectible);
         }

--- a/ParquetClassLibrary/Parquets/ParquetModelPackGrid.cs
+++ b/ParquetClassLibrary/Parquets/ParquetModelPackGrid.cs
@@ -39,14 +39,14 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new empty <see cref="ParquetModelPackGrid"/>.
         /// </summary>
-        /// <param name="inRowCount">The length of the Y dimension of the collection.</param>
-        /// <param name="inColumnCount">The length of the X dimension of the collection.</param>
-        public ParquetModelPackGrid(int inRowCount, int inColumnCount)
+        /// <param name="rowCount">The length of the Y dimension of the collection.</param>
+        /// <param name="columnCount">The length of the X dimension of the collection.</param>
+        public ParquetModelPackGrid(int rowCount, int columnCount)
         {
-            ParquetPacks = new ParquetModelPack[inRowCount, inColumnCount];
-            for (var y = 0; y < inRowCount; y++)
+            ParquetPacks = new ParquetModelPack[rowCount, columnCount];
+            for (var y = 0; y < rowCount; y++)
             {
-                for (var x = 0; x < inColumnCount; x++)
+                for (var x = 0; x < columnCount; x++)
                 {
                     ParquetPacks[y, x] = new ParquetModelPack();
                 }
@@ -56,9 +56,9 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new <see cref="ParquetModelPackGrid"/> from the given 2D <see cref="ParquetModelPack"/> array.
         /// </summary>
-        /// <param name="inParquetPackArray">The array containing the <see cref="ParquetModelPack"/>s.</param>
-        public ParquetModelPackGrid(ParquetModelPack[,] inParquetPackArray)
-            => ParquetPacks = inParquetPackArray;
+        /// <param name="parquetPackArray">The array containing the <see cref="ParquetModelPack"/>s.</param>
+        public ParquetModelPackGrid(ParquetModelPack[,] parquetPackArray)
+            => ParquetPacks = parquetPackArray;
         #endregion
 
         #region Finding Subgrids
@@ -72,37 +72,37 @@ namespace Parquet.Parquets
         /// <summary>
         /// Provides all parquet definitions within the specified rectangular subsection of the current grid.
         /// </summary>
-        /// <param name="inUpperLeft">The position of the upper-leftmost corner of the subgrid.</param>
-        /// <param name="inLowerRight">The position of the lower-rightmost corner of the subgrid.</param>
+        /// <param name="upperLeft">The position of the upper-leftmost corner of the subgrid.</param>
+        /// <param name="lowerRight">The position of the lower-rightmost corner of the subgrid.</param>
         /// <returns>A portion of the grid.</returns>
         /// <remarks>If the coordinates given are not well-formed, the subgrid returned will be invalid.</remarks>
-        public IReadOnlyGrid<ParquetModelPack> GetSubgrid(Point2D inUpperLeft, Point2D inLowerRight)
+        public IReadOnlyGrid<ParquetModelPack> GetSubgrid(Point2D upperLeft, Point2D lowerRight)
         {
-            if (!ParquetPacks.IsValidPosition(inUpperLeft))
+            if (!ParquetPacks.IsValidPosition(upperLeft))
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorInvalidPosition,
-                                                           nameof(inUpperLeft), nameof(ParquetPacks)));
+                                                           nameof(upperLeft), nameof(ParquetPacks)));
             }
-            else if (!ParquetPacks.IsValidPosition(inLowerRight))
+            else if (!ParquetPacks.IsValidPosition(lowerRight))
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorInvalidPosition,
-                                                           nameof(inLowerRight), nameof(ParquetPacks)));
+                                                           nameof(lowerRight), nameof(ParquetPacks)));
             }
-            else if (inLowerRight.X < inUpperLeft.X || inLowerRight.Y < inUpperLeft.Y)
+            else if (lowerRight.X < upperLeft.X || lowerRight.Y < upperLeft.Y)
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfOrderGTE,
-                                                           nameof(inLowerRight), inLowerRight, inUpperLeft));
+                                                           nameof(lowerRight), lowerRight, upperLeft));
             }
             else
             {
-                var subgrid = new ParquetModelPack[inLowerRight.X - inUpperLeft.X + 1,
-                                                     inLowerRight.Y - inUpperLeft.Y + 1];
+                var subgrid = new ParquetModelPack[lowerRight.X - upperLeft.X + 1,
+                                                     lowerRight.Y - upperLeft.Y + 1];
 
-                for (var x = inUpperLeft.X; x <= inLowerRight.X; x++)
+                for (var x = upperLeft.X; x <= lowerRight.X; x++)
                 {
-                    for (var y = inUpperLeft.Y; y <= inLowerRight.Y; y++)
+                    for (var y = upperLeft.Y; y <= lowerRight.Y; y++)
                     {
-                        subgrid[y - inUpperLeft.Y, x - inUpperLeft.X] = ParquetPacks[y, x];
+                        subgrid[y - upperLeft.Y, x - upperLeft.X] = ParquetPacks[y, x];
                     }
                 }
 
@@ -200,10 +200,10 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines if the given position corresponds to a point within the collection.
         /// </summary>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public bool IsValidPosition(Point2D inPosition)
-            => ParquetPacks.IsValidPosition(inPosition);
+        public bool IsValidPosition(Point2D position)
+            => ParquetPacks.IsValidPosition(position);
         #endregion
     }
 }

--- a/ParquetClassLibrary/Parquets/ParquetStatusPack.cs
+++ b/ParquetClassLibrary/Parquets/ParquetStatusPack.cs
@@ -116,35 +116,35 @@ namespace Parquet.Parquets
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is ParquetStatusPack pack
-                ? $"{pack.CurrentFloorStatus.ConvertToString(pack.CurrentFloorStatus, inRow, inMemberMapData)}{Delimiters.PackDelimiter}" +
-                  $"{pack.CurrentBlockStatus.ConvertToString(pack.CurrentBlockStatus, inRow, inMemberMapData)}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(ParquetStatusPack), nameof(Default));
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is ParquetStatusPack pack
+                ? $"{pack.CurrentFloorStatus.ConvertToString(pack.CurrentFloorStatus, row, memberMapData)}{Delimiters.PackDelimiter}" +
+                  $"{pack.CurrentBlockStatus.ConvertToString(pack.CurrentBlockStatus, row, memberMapData)}"
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(ParquetStatusPack), nameof(Default));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Default), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Default), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Default;
             }
 
-            var parameterText = inText.Split(Delimiters.PackDelimiter);
+            var parameterText = text.Split(Delimiters.PackDelimiter);
 
-            var parsedFloorStatus = (FloorStatus)FloorStatus.ConverterFactory.ConvertFromString(parameterText[0], inRow, inMemberMapData);
-            var parsedBlockStatus = (BlockStatus)BlockStatus.ConverterFactory.ConvertFromString(parameterText[1], inRow, inMemberMapData);
+            var parsedFloorStatus = (FloorStatus)FloorStatus.ConverterFactory.ConvertFromString(parameterText[0], row, memberMapData);
+            var parsedBlockStatus = (BlockStatus)BlockStatus.ConverterFactory.ConvertFromString(parameterText[1], row, memberMapData);
 
             return new ParquetStatusPack(parsedFloorStatus, parsedBlockStatus);
         }

--- a/ParquetClassLibrary/Parquets/ParquetStatusPack.cs
+++ b/ParquetClassLibrary/Parquets/ParquetStatusPack.cs
@@ -36,25 +36,25 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new instance of the <see cref="ParquetStatusPack"/> class.
         /// </summary>
-        /// <param name="inFloorStatus">The status of the tracked floor-layer parquet.</param>
-        /// <param name="inBlockStatus">The status of the tracked block-layer parquet.</param>
-        public ParquetStatusPack(FloorStatus inFloorStatus = null, BlockStatus inBlockStatus = null)
+        /// <param name="floorStatus">The status of the tracked floor-layer parquet.</param>
+        /// <param name="blockStatus">The status of the tracked block-layer parquet.</param>
+        public ParquetStatusPack(FloorStatus floorStatus = null, BlockStatus blockStatus = null)
         {
-            CurrentFloorStatus = inFloorStatus ?? FloorStatus.Default;
-            CurrentBlockStatus = inBlockStatus ?? BlockStatus.Default;
+            CurrentFloorStatus = floorStatus ?? FloorStatus.Default;
+            CurrentBlockStatus = blockStatus ?? BlockStatus.Default;
         }
 
         /// <summary>
         /// Initializes an instance of the <see cref="ParquetStatusPack"/> class
         /// based on a given <see cref="ParquetModelPack"/> instance.
         /// </summary>
-        /// <param name="inParquetModelPack">The definitions being tracked.</param>
-        public ParquetStatusPack(ParquetModelPack inParquetModelPack)
+        /// <param name="parquetModelPack">The definitions being tracked.</param>
+        public ParquetStatusPack(ParquetModelPack parquetModelPack)
         {
-            Precondition.IsNotNull(inParquetModelPack);
-            var nonNullParquetModelPack = inParquetModelPack is null
+            Precondition.IsNotNull(parquetModelPack);
+            var nonNullParquetModelPack = parquetModelPack is null
                 ? ParquetModelPack.Empty
-                : inParquetModelPack;
+                : parquetModelPack;
 
             CurrentFloorStatus = new FloorStatus(nonNullParquetModelPack.FloorID);
             CurrentBlockStatus = new BlockStatus(nonNullParquetModelPack.BlockID);
@@ -74,12 +74,12 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether the specified <see cref="ParquetStatusPack"/> is equal to the current <see cref="ParquetStatusPack"/>.
         /// </summary>
-        /// <param name="inPack">The <see cref="ParquetStatusPack"/> to compare with the current.</param>
+        /// <param name="pack">The <see cref="ParquetStatusPack"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inPack)
-            => inPack is ParquetStatusPack pack
-            && CurrentFloorStatus == pack.CurrentFloorStatus
-            && CurrentBlockStatus == pack.CurrentBlockStatus;
+        public override bool Equals<T>(T pack)
+            => pack is ParquetStatusPack statusPack
+            && CurrentFloorStatus == statusPack.CurrentFloorStatus
+            && CurrentBlockStatus == statusPack.CurrentBlockStatus;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="ParquetStatusPack"/>.
@@ -93,20 +93,20 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines whether a specified instance of <see cref="ParquetStatusPack"/> is equal to another specified instance of <see cref="ParquetStatusPack"/>.
         /// </summary>
-        /// <param name="inPack1">The first <see cref="ParquetStatusPack"/> to compare.</param>
-        /// <param name="inPack2">The second <see cref="ParquetStatusPack"/> to compare.</param>
+        /// <param name="pack1">The first <see cref="ParquetStatusPack"/> to compare.</param>
+        /// <param name="pack2">The second <see cref="ParquetStatusPack"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(ParquetStatusPack inPack1, ParquetStatusPack inPack2)
-            => inPack1?.Equals(inPack2) ?? inPack2?.Equals(inPack1) ?? true;
+        public static bool operator ==(ParquetStatusPack pack1, ParquetStatusPack pack2)
+            => pack1?.Equals(pack2) ?? pack2?.Equals(pack1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ParquetStatusPack"/> is not equal to another specified instance of <see cref="ParquetStatusPack"/>.
         /// </summary>
-        /// <param name="inPack1">The first <see cref="ParquetStatusPack"/> to compare.</param>
-        /// <param name="inPack2">The second <see cref="ParquetStatusPack"/> to compare.</param>
+        /// <param name="pack1">The first <see cref="ParquetStatusPack"/> to compare.</param>
+        /// <param name="pack2">The second <see cref="ParquetStatusPack"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(ParquetStatusPack inPack1, ParquetStatusPack inPack2)
-            => !(inPack1 == inPack2);
+        public static bool operator !=(ParquetStatusPack pack1, ParquetStatusPack pack2)
+            => !(pack1 == pack2);
         #endregion
 
         #region ITypeConverter Implementation

--- a/ParquetClassLibrary/Parquets/ParquetStatusPackGrid.cs
+++ b/ParquetClassLibrary/Parquets/ParquetStatusPackGrid.cs
@@ -38,14 +38,14 @@ namespace Parquet.Parquets
         /// <summary>
         /// Initializes a new <see cref="ParquetStatusPackGrid"/>.
         /// </summary>
-        /// <param name="inRowCount">The length of the Y dimension of the collection.</param>
-        /// <param name="inColumnCount">The length of the X dimension of the collection.</param>
-        public ParquetStatusPackGrid(int inRowCount, int inColumnCount)
+        /// <param name="rowCount">The length of the Y dimension of the collection.</param>
+        /// <param name="columnCount">The length of the X dimension of the collection.</param>
+        public ParquetStatusPackGrid(int rowCount, int columnCount)
         {
-            ParquetStatuses = new ParquetStatusPack[inRowCount, inColumnCount];
-            for (var y = 0; y < inRowCount; y++)
+            ParquetStatuses = new ParquetStatusPack[rowCount, columnCount];
+            for (var y = 0; y < rowCount; y++)
             {
-                for (var x = 0; x < inColumnCount; x++)
+                for (var x = 0; x < columnCount; x++)
                 {
                     ParquetStatuses[y, x] = ParquetStatusPack.Default.DeepClone();
                 }
@@ -56,13 +56,13 @@ namespace Parquet.Parquets
         /// Initializes an instance of the <see cref="ParquetStatusPackGrid"/> class
         /// based on a given <see cref="ParquetModelPackGrid"/> instance.
         /// </summary>
-        /// <param name="inParquetModelPackGrid">The grid of definitions being tracked.</param>
-        public ParquetStatusPackGrid(ParquetModelPackGrid inParquetModelPackGrid)
+        /// <param name="parquetModelPackGrid">The grid of definitions being tracked.</param>
+        public ParquetStatusPackGrid(ParquetModelPackGrid parquetModelPackGrid)
         {
-            Precondition.IsNotNull(inParquetModelPackGrid);
-            var nonNullParquetModelPackGrid = inParquetModelPackGrid is null
+            Precondition.IsNotNull(parquetModelPackGrid);
+            var nonNullParquetModelPackGrid = parquetModelPackGrid is null
                 ? new ParquetModelPackGrid()
-                : inParquetModelPackGrid;
+                : parquetModelPackGrid;
 
             ParquetStatuses = new ParquetStatusPack[nonNullParquetModelPackGrid.Rows, nonNullParquetModelPackGrid.Columns];
             for (var y = 0; y < nonNullParquetModelPackGrid.Rows; y++)
@@ -145,10 +145,10 @@ namespace Parquet.Parquets
         /// <summary>
         /// Determines if the given position corresponds to a point within the collection.
         /// </summary>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public bool IsValidPosition(Point2D inPosition)
-            => ParquetStatuses.IsValidPosition(inPosition);
+        public bool IsValidPosition(Point2D position)
+            => ParquetStatuses.IsValidPosition(position);
         #endregion
     }
 }

--- a/ParquetClassLibrary/Point2D.cs
+++ b/ParquetClassLibrary/Point2D.cs
@@ -47,21 +47,21 @@ namespace Parquet
         /// <summary>
         /// Initializes a new instance of the <see cref="Point2D"/> struct.
         /// </summary>
-        /// <param name="inX">The X coordinate.</param>
-        /// <param name="inY">The Y coordinate.</param>
-        public Point2D(int inX, int inY)
+        /// <param name="x">The X coordinate.</param>
+        /// <param name="y">The Y coordinate.</param>
+        public Point2D(int x, int y)
         {
-            X = inX;
-            Y = inY;
+            X = x;
+            Y = y;
             Magnitude = Convert.ToInt32(Math.Floor(Math.Sqrt((X * X) + (Y * Y))));
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Point2D"/> struct.
         /// </summary>
-        /// <param name="inCoordinates">The coordinates.</param>
-        public Point2D((int X, int Y) inCoordinates)
-            : this(inCoordinates.X, inCoordinates.Y)
+        /// <param name="coordinates">The coordinates.</param>
+        public Point2D((int X, int Y) coordinates)
+            : this(coordinates.X, coordinates.Y)
         { }
         #endregion
 
@@ -69,29 +69,29 @@ namespace Parquet
         /// <summary>
         /// Sums the given points as if they were vectors.
         /// </summary>
-        /// <param name="inPoint1">First operand.</param>
-        /// <param name="inPoint2">Second operand.</param>
+        /// <param name="point1">First operand.</param>
+        /// <param name="point2">Second operand.</param>
         /// <returns>A point representing the sum of the given points.</returns>
-        public static Point2D operator +(Point2D inPoint1, Point2D inPoint2)
-            => new(inPoint1.X + inPoint2.X, inPoint1.Y + inPoint2.Y);
+        public static Point2D operator +(Point2D point1, Point2D point2)
+            => new(point1.X + point2.X, point1.Y + point2.Y);
 
         /// <summary>
         /// Finds the difference between the given points as if they were points.
         /// </summary>
-        /// <param name="inPoint1">First operand.</param>
-        /// <param name="inPoint2">Second operand.</param>
+        /// <param name="point1">First operand.</param>
+        /// <param name="point2">Second operand.</param>
         /// <returns>A point representing the difference of the given points.</returns>
-        public static Point2D operator -(Point2D inPoint1, Point2D inPoint2)
-            => new(inPoint1.X - inPoint2.X, inPoint1.Y - inPoint2.Y);
+        public static Point2D operator -(Point2D point1, Point2D point2)
+            => new(point1.X - point2.X, point1.Y - point2.Y);
 
         /// <summary>
         /// Scales a the point.
         /// </summary>
-        /// <param name="inScalar">The scale factor.</param>
-        /// <param name="inPoint">The point.</param>
+        /// <param name="scalar">The scale factor.</param>
+        /// <param name="point">The point.</param>
         /// <returns>A point representing the scaled point.</returns>
-        public static Point2D operator *(int inScalar, Point2D inPoint)
-            => new(inScalar * inPoint.X, inScalar * inPoint.Y);
+        public static Point2D operator *(int scalar, Point2D point)
+            => new(scalar * point.X, scalar * point.Y);
         #endregion
 
         #region IEquatable Implementation
@@ -105,11 +105,11 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Point2D"/> is equal to the current <see cref="Point2D"/>.
         /// </summary>
-        /// <param name="inPoint">The <see cref="Point2D"/> to compare with the current.</param>
+        /// <param name="point">The <see cref="Point2D"/> to compare with the current.</param>
         /// <returns><c>true</c> if the <see cref="Point2D"/>s are equal.</returns>
-        public bool Equals(Point2D inPoint)
-            => X == inPoint.X
-            && Y == inPoint.Y;
+        public bool Equals(Point2D point)
+            => X == point.X
+            && Y == point.Y;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Point2D"/>.
@@ -124,21 +124,21 @@ namespace Parquet
         /// Determines whether a specified instance of <see cref="Point2D"/> is equal to
         /// another specified instance of <see cref="Point2D"/>.
         /// </summary>
-        /// <param name="inPoint1">The first <see cref="Point2D"/> to compare.</param>
-        /// <param name="inPoint2">The second <see cref="Point2D"/> to compare.</param>
+        /// <param name="point1">The first <see cref="Point2D"/> to compare.</param>
+        /// <param name="point2">The second <see cref="Point2D"/> to compare.</param>
         /// <returns><c>true</c> if the two operands are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(Point2D inPoint1, Point2D inPoint2)
-            => inPoint1.Equals(inPoint2);
+        public static bool operator ==(Point2D point1, Point2D point2)
+            => point1.Equals(point2);
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="Point2D"/> is not equal
         /// to another specified instance of <see cref="Point2D"/>.
         /// </summary>
-        /// <param name="inPoint1">The first <see cref="Point2D"/> to compare.</param>
-        /// <param name="inPoint2">The second <see cref="Point2D"/> to compare.</param>
+        /// <param name="point1">The first <see cref="Point2D"/> to compare.</param>
+        /// <param name="point2">The second <see cref="Point2D"/> to compare.</param>
         /// <returns><c>true</c> if the two operands are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(Point2D inPoint1, Point2D inPoint2)
-            => !inPoint1.Equals(inPoint2);
+        public static bool operator !=(Point2D point1, Point2D point2)
+            => !point1.Equals(point2);
         #endregion
 
         #region ITypeConverter Implementation

--- a/ParquetClassLibrary/Point2D.cs
+++ b/ParquetClassLibrary/Point2D.cs
@@ -105,11 +105,11 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Point2D"/> is equal to the current <see cref="Point2D"/>.
         /// </summary>
-        /// <param name="point">The <see cref="Point2D"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="Point2D"/> to compare with the current.</param>
         /// <returns><c>true</c> if the <see cref="Point2D"/>s are equal.</returns>
-        public bool Equals(Point2D point)
-            => X == point.X
-            && Y == point.Y;
+        public bool Equals(Point2D other)
+            => X == other.X
+            && Y == other.Y;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Point2D"/>.

--- a/ParquetClassLibrary/Point2D.cs
+++ b/ParquetClassLibrary/Point2D.cs
@@ -148,32 +148,32 @@ namespace Parquet
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is Point2D point
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is Point2D point
                 ? $"{point.X}{Delimiters.ElementDelimiter}" +
                   $"{point.Y}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(Point2D), nameof(Origin));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(Point2D), nameof(Origin));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Origin), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Origin), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Origin;
             }
 
-            var parameterText = inText.Split(Delimiters.ElementDelimiter);
+            var parameterText = text.Split(Delimiters.ElementDelimiter);
 
             var x = int.TryParse(parameterText[0], All.SerializedNumberStyle, CultureInfo.InvariantCulture, out var temp1)
                 ? temp1

--- a/ParquetClassLibrary/Point2D.cs
+++ b/ParquetClassLibrary/Point2D.cs
@@ -190,10 +190,10 @@ namespace Parquet
         /// <summary>
         /// Deconstructs the current <see cref="Point2D"/> into its constituent coordinates.
         /// </summary>
-        /// <param name="outX">The X coordinate.</param>
-        /// <param name="outY">The Y coordinate.</param>
-        public void Deconstruct(out int outX, out int outY)
-            => (outX, outY) = (X, Y);
+        /// <param name="x">The X coordinate.</param>
+        /// <param name="y">The Y coordinate.</param>
+        public void Deconstruct(out int x, out int y)
+            => (x, y) = (X, Y);
 
         /// <summary>
         /// Returns a <see cref="string"/> that represents the current <see cref="Point2D"/>.

--- a/ParquetClassLibrary/Precondition.cs
+++ b/ParquetClassLibrary/Precondition.cs
@@ -39,20 +39,20 @@ namespace Parquet
         /// <summary>
         /// Checks if the given <see cref="ModelID"/> falls within the given <see cref="Range{ModelID}"/>, inclusive.
         /// </summary>
-        /// <param name="inID">The identifier to test.</param>
+        /// <param name="id">The identifier to test.</param>
         /// <param name="inBounds">The range it must fall within.</param>
         /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsInRange(ModelID inID, Range<ModelID> inBounds, string inArgumentName)
+        public static void IsInRange(ModelID id, Range<ModelID> inBounds, string inArgumentName)
         {
-            if (!inID.IsValidForRange(inBounds))
+            if (!id.IsValidForRange(inBounds))
             {
                 if (string.IsNullOrEmpty(inArgumentName))
                 {
                     inArgumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                         inArgumentName, inID, inBounds));
+                                                         inArgumentName, id, inBounds));
             }
         }
 
@@ -80,15 +80,15 @@ namespace Parquet
         /// Checks if the first given <see cref="ModelID"/> falls within at least one of the
         /// given collection of <see cref="Range{ModelID}"/>s, inclusive.
         /// </summary>
-        /// <param name="inID">The identifier to test.</param>
+        /// <param name="id">The identifier to test.</param>
         /// <param name="inBoundsCollection">The collection of ranges it must fall within.</param>
         /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsInRange(ModelID inID, IEnumerable<Range<ModelID>> inBoundsCollection, string inArgumentName)
+        public static void IsInRange(ModelID id, IEnumerable<Range<ModelID>> inBoundsCollection, string inArgumentName)
         {
             IsNotNull(inBoundsCollection, nameof(inBoundsCollection));
 
-            if (!inID.IsValidForRange(inBoundsCollection))
+            if (!id.IsValidForRange(inBoundsCollection))
             {
                 var allBounds = new System.Text.StringBuilder();
                 foreach (var range in inBoundsCollection)
@@ -101,7 +101,7 @@ namespace Parquet
                     inArgumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                         inArgumentName, inID, allBounds));
+                                                         inArgumentName, id, allBounds));
             }
         }
 
@@ -195,12 +195,12 @@ namespace Parquet
         /// <summary>
         /// Verifies that the given <see cref="ModelID"/> is not <see cref="ModelID.None"/>.
         /// </summary>
-        /// <param name="inID">The number to test.</param>
+        /// <param name="id">The number to test.</param>
         /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsNotNone(ModelID inID, string inArgumentName = DefaultArgumentName)
+        public static void IsNotNone(ModelID id, string inArgumentName = DefaultArgumentName)
         {
-            if (inID == ModelID.None)
+            if (id == ModelID.None)
             {
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorMustNotBeNone,
                                                          inArgumentName));

--- a/ParquetClassLibrary/Precondition.cs
+++ b/ParquetClassLibrary/Precondition.cs
@@ -19,20 +19,20 @@ namespace Parquet
         /// <summary>
         /// Checks if the given <see cref="int"/> falls within the given <see cref="Range{T}"/>, inclusive.
         /// </summary>
-        /// <param name="inInt">The integer to test.</param>
-        /// <param name="inBounds">The range it must fall within.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="integerToTest">The integer to test.</param>
+        /// <param name="bounds">The range it must fall within.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsInRange(int inInt, Range<int> inBounds, string inArgumentName)
+        public static void IsInRange(int integerToTest, Range<int> bounds, string argumentName)
         {
-            if (!inBounds.ContainsValue(inInt))
+            if (!bounds.ContainsValue(integerToTest))
             {
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                         inArgumentName, inInt, inBounds));
+                                                         argumentName, integerToTest, bounds));
             }
         }
 
@@ -40,39 +40,39 @@ namespace Parquet
         /// Checks if the given <see cref="ModelID"/> falls within the given <see cref="Range{ModelID}"/>, inclusive.
         /// </summary>
         /// <param name="id">The identifier to test.</param>
-        /// <param name="inBounds">The range it must fall within.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="bounds">The range it must fall within.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsInRange(ModelID id, Range<ModelID> inBounds, string inArgumentName)
+        public static void IsInRange(ModelID id, Range<ModelID> bounds, string argumentName)
         {
-            if (!id.IsValidForRange(inBounds))
+            if (!id.IsValidForRange(bounds))
             {
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                         inArgumentName, id, inBounds));
+                                                         argumentName, id, bounds));
             }
         }
 
         /// <summary>
         /// Checks if the first given <see cref="Range{ModelID}"/> falls within the second given <see cref="Range{ModelID}"/>, inclusive.
         /// </summary>
-        /// <param name="inInnerBounds">The range to test.</param>
-        /// <param name="inOuterBounds">The range it must fall within.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="innerBounds">The range to test.</param>
+        /// <param name="outerBounds">The range it must fall within.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsInRange(Range<ModelID> inInnerBounds, Range<ModelID> inOuterBounds, string inArgumentName)
+        public static void IsInRange(Range<ModelID> innerBounds, Range<ModelID> outerBounds, string argumentName)
         {
-            if (!inOuterBounds.ContainsRange(inInnerBounds))
+            if (!outerBounds.ContainsRange(innerBounds))
             {
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                         inArgumentName, inInnerBounds, inOuterBounds));
+                                                         argumentName, innerBounds, outerBounds));
             }
         }
 
@@ -81,27 +81,27 @@ namespace Parquet
         /// given collection of <see cref="Range{ModelID}"/>s, inclusive.
         /// </summary>
         /// <param name="id">The identifier to test.</param>
-        /// <param name="inBoundsCollection">The collection of ranges it must fall within.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="boundsCollection">The collection of ranges it must fall within.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsInRange(ModelID id, IEnumerable<Range<ModelID>> inBoundsCollection, string inArgumentName)
+        public static void IsInRange(ModelID id, IEnumerable<Range<ModelID>> boundsCollection, string argumentName)
         {
-            IsNotNull(inBoundsCollection, nameof(inBoundsCollection));
+            IsNotNull(boundsCollection, nameof(boundsCollection));
 
-            if (!id.IsValidForRange(inBoundsCollection))
+            if (!id.IsValidForRange(boundsCollection))
             {
                 var allBounds = new System.Text.StringBuilder();
-                foreach (var range in inBoundsCollection)
+                foreach (var range in boundsCollection)
                 {
                     allBounds.Append(range);
                     allBounds.Append(' ');
                 }
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                         inArgumentName, id, allBounds));
+                                                         argumentName, id, allBounds));
             }
         }
 
@@ -109,37 +109,37 @@ namespace Parquet
         /// Checks if the given <see cref="Range{ModelID}"/> falls within at least one of the
         /// given collection of <see cref="Range{ModelID}"/>s, inclusive.
         /// </summary>
-        /// <param name="inInnerBounds">The range to test.</param>
-        /// <param name="inBoundsCollection">The collection of ranges it must fall within.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="innerBounds">The range to test.</param>
+        /// <param name="boundsCollection">The collection of ranges it must fall within.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsInRange(Range<ModelID> inInnerBounds, IEnumerable<Range<ModelID>> inBoundsCollection, string inArgumentName)
+        public static void IsInRange(Range<ModelID> innerBounds, IEnumerable<Range<ModelID>> boundsCollection, string argumentName)
         {
-            if (!inBoundsCollection.ContainsRange(inInnerBounds))
+            if (!boundsCollection.ContainsRange(innerBounds))
             {
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                         inArgumentName, inInnerBounds, inBoundsCollection));
+                                                         argumentName, innerBounds, boundsCollection));
             }
         }
 
         /// <summary>
         /// Verifies that the first given class is or is derived from the second given class.
         /// </summary>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         /// <typeparam name="TToCheck">The type to check.</typeparam>
         /// <typeparam name="TTarget">The type of which it must be a subtype.</typeparam>
         [Conditional("DEBUG")]
-        public static void IsOfType<TToCheck, TTarget>(string inArgumentName = DefaultArgumentName)
+        public static void IsOfType<TToCheck, TTarget>(string argumentName = DefaultArgumentName)
         {
             if (!typeof(TToCheck).IsSubclassOf(typeof(TTarget))
                 && typeof(TToCheck) != typeof(TTarget))
             {
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorInvalidCast,
-                                                         inArgumentName, typeof(TToCheck), typeof(TTarget)));
+                                                         argumentName, typeof(TToCheck), typeof(TTarget)));
             }
         }
 
@@ -147,22 +147,22 @@ namespace Parquet
         /// Verifies that all of the given <see cref="ModelID"/>s fall within the given
         /// <see cref="Range{ModelID}"/>, inclusive.
         /// </summary>
-        /// <param name="inEnumerable">The identifiers to test.</param>
-        /// <param name="inBounds">The range they must fall within.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="enumerable">The identifiers to test.</param>
+        /// <param name="bounds">The range they must fall within.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void AreInRange(IEnumerable<ModelID> inEnumerable, Range<ModelID> inBounds, string inArgumentName)
+        public static void AreInRange(IEnumerable<ModelID> enumerable, Range<ModelID> bounds, string argumentName)
         {
-            foreach (var id in inEnumerable ?? Enumerable.Empty<ModelID>())
+            foreach (var id in enumerable ?? Enumerable.Empty<ModelID>())
             {
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
-                if (!id.IsValidForRange(inBounds))
+                if (!id.IsValidForRange(bounds))
                 {
                     Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                             inArgumentName, id, inBounds));
+                                                             argumentName, id, bounds));
                 }
             }
         }
@@ -171,23 +171,23 @@ namespace Parquet
         /// Verifies that all of the given <see cref="ModelID"/>s fall within the given 
         /// collection of <see cref="Range{ModelID}"/>s, inclusive.
         /// </summary>
-        /// <param name="inEnumerable">The identifiers to test.</param>
-        /// <param name="inBoundsCollection">The collection of ranges they must fall within.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="enumerable">The identifiers to test.</param>
+        /// <param name="boundsCollection">The collection of ranges they must fall within.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void AreInRange(IEnumerable<ModelID> inEnumerable, IEnumerable<Range<ModelID>> inBoundsCollection,
-                                      string inArgumentName)
+        public static void AreInRange(IEnumerable<ModelID> enumerable, IEnumerable<Range<ModelID>> boundsCollection,
+                                      string argumentName)
         {
-            foreach (var id in inEnumerable ?? Enumerable.Empty<ModelID>())
+            foreach (var id in enumerable ?? Enumerable.Empty<ModelID>())
             {
-                if (!id.IsValidForRange(inBoundsCollection))
+                if (!id.IsValidForRange(boundsCollection))
                 {
-                    if (string.IsNullOrEmpty(inArgumentName))
+                    if (string.IsNullOrEmpty(argumentName))
                     {
-                        inArgumentName = DefaultArgumentName;
+                        argumentName = DefaultArgumentName;
                     }
                     Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfBounds,
-                                                             inArgumentName, id, inBoundsCollection));
+                                                             argumentName, id, boundsCollection));
                 }
             }
         }
@@ -196,106 +196,106 @@ namespace Parquet
         /// Verifies that the given <see cref="ModelID"/> is not <see cref="ModelID.None"/>.
         /// </summary>
         /// <param name="id">The number to test.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsNotNone(ModelID id, string inArgumentName = DefaultArgumentName)
+        public static void IsNotNone(ModelID id, string argumentName = DefaultArgumentName)
         {
             if (id == ModelID.None)
             {
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorMustNotBeNone,
-                                                         inArgumentName));
+                                                         argumentName));
             }
         }
 
         /// <summary>
         /// Verifies that the given number is zero or positive.
         /// </summary>
-        /// <param name="inNumber">The number to test.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="number">The number to test.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void MustBeNonNegative(int inNumber, string inArgumentName = DefaultArgumentName)
+        public static void MustBeNonNegative(int number, string argumentName = DefaultArgumentName)
         {
-            if (inNumber < 0)
+            if (number < 0)
             {
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorMustBeNonNegative,
-                                                         inArgumentName));
+                                                         argumentName));
             }
         }
 
         /// <summary>
         /// Verifies that the given number is positive.
         /// </summary>
-        /// <param name="inNumber">The number to test.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="number">The number to test.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void MustBePositive(int inNumber, string inArgumentName = DefaultArgumentName)
+        public static void MustBePositive(int number, string argumentName = DefaultArgumentName)
         {
-            if (inNumber < 1)
+            if (number < 1)
             {
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorMustBePositive,
-                                                         inArgumentName));
+                                                         argumentName));
             }
         }
 
         /// <summary>
         /// Verifies that the given <see cref="string"/> is not empty.
         /// </summary>
-        /// <param name="inString">The string to test.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="stringToTest">The string to test.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsNotNullOrEmpty(string inString, string inArgumentName)
+        public static void IsNotNullOrEmpty(string stringToTest, string argumentName)
         {
-            if (string.IsNullOrEmpty(inString))
+            if (string.IsNullOrEmpty(stringToTest))
             {
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorMustNotBeNullEmpty,
-                                                         inArgumentName));
+                                                         argumentName));
             }
         }
 
         /// <summary>
         /// Verifies that the given <see cref="IEnumerable{TElement}"/> is not empty.
         /// </summary>
-        /// <param name="inEnumerable">The collection to test.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="enumerable">The collection to test.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsNotNullOrEmpty<TElement>(IEnumerable<TElement> inEnumerable, string inArgumentName)
+        public static void IsNotNullOrEmpty<TElement>(IEnumerable<TElement> enumerable, string argumentName)
         {
-            if (inEnumerable is null)
+            if (enumerable is null)
             {
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorMustNotBeNull,
-                                                         inArgumentName));
+                                                         argumentName));
             }
-            else if (!inEnumerable.Any())
+            else if (!enumerable.Any())
             {
-                if (string.IsNullOrEmpty(inArgumentName))
+                if (string.IsNullOrEmpty(argumentName))
                 {
-                    inArgumentName = DefaultArgumentName;
+                    argumentName = DefaultArgumentName;
                 }
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorMustNotBeEmpty,
-                                                         inArgumentName));
+                                                         argumentName));
             }
         }
 
         /// <summary>
         /// Verifies that the given reference is not <c>null</c>.
         /// </summary>
-        /// <param name="inReference">The reference to test.</param>
-        /// <param name="inArgumentName">The name of the argument to use in error reporting.</param>
+        /// <param name="reference">The reference to test.</param>
+        /// <param name="argumentName">The name of the argument to use in error reporting.</param>
         [Conditional("DEBUG")]
-        public static void IsNotNull(object inReference, string inArgumentName = DefaultArgumentName)
+        public static void IsNotNull(object reference, string argumentName = DefaultArgumentName)
         {
-            if (inReference is null)
+            if (reference is null)
             {
                 Logger.Log(LogLevel.Debug, string.Format(CultureInfo.CurrentCulture, Resources.ErrorMustNotBeNull,
-                                                         inArgumentName));
+                                                         argumentName));
             }
         }
     }

--- a/ParquetClassLibrary/PublicAPI.Unshipped.txt
+++ b/ParquetClassLibrary/PublicAPI.Unshipped.txt
@@ -697,7 +697,7 @@ Parquet.Parquets.ParquetStatusPackGrid.this[int y, int x].get -> Parquet.Parquet
 Parquet.Point2D
 Parquet.Point2D.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
 Parquet.Point2D.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
-Parquet.Point2D.Deconstruct(out int outX, out int outY) -> void
+Parquet.Point2D.Deconstruct(out int x, out int y) -> void
 Parquet.Point2D.Equals(Parquet.Point2D inPoint) -> bool
 Parquet.Point2D.Magnitude.get -> int
 Parquet.Point2D.Point2D((int X, int Y) inCoordinates) -> void
@@ -711,7 +711,7 @@ Parquet.Range<TElement>.ContainsRange(Parquet.Range<TElement> inRange) -> bool
 Parquet.Range<TElement>.ContainsValue(TElement inValue) -> bool
 Parquet.Range<TElement>.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
 Parquet.Range<TElement>.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
-Parquet.Range<TElement>.Deconstruct(out TElement outMinimum, out TElement outMaximum) -> void
+Parquet.Range<TElement>.Deconstruct(out TElement minimum, out TElement maximum) -> void
 Parquet.Range<TElement>.Equals(Parquet.Range<TElement> inRange) -> bool
 Parquet.Range<TElement>.IsValid() -> bool
 Parquet.Range<TElement>.Maximum.get -> TElement

--- a/ParquetClassLibrary/PublicAPI.Unshipped.txt
+++ b/ParquetClassLibrary/PublicAPI.Unshipped.txt
@@ -389,6 +389,7 @@ Parquet.IMutableModel.Tags.get -> System.Collections.Generic.ICollection<Parquet
 Parquet.IMutableModelCollection<TModel>
 Parquet.IMutableModelCollection<TModel>.Remove(Parquet.ModelID id) -> bool
 Parquet.IMutableModelCollection<TModel>.Replace(TModel model) -> void
+Parquet.IReadOnlyCollectionOfTagsExtensions
 Parquet.IReadOnlyGrid<TElement>
 Parquet.IReadOnlyGrid<TElement>.Columns.get -> int
 Parquet.IReadOnlyGrid<TElement>.Rows.get -> int
@@ -978,8 +979,10 @@ static Parquet.Games.GameModel.Empty.get -> Parquet.Games.GameModel
 static Parquet.Games.GameStatus.Default.get -> Parquet.Games.GameStatus
 static Parquet.Games.GameStatus.operator !=(Parquet.Games.GameStatus status1, Parquet.Games.GameStatus status2) -> bool
 static Parquet.Games.GameStatus.operator ==(Parquet.Games.GameStatus status1, Parquet.Games.GameStatus status2) -> bool
-static Parquet.IReadOnlyListOfTagsExtensions.ContainsOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyList<Parquet.ModelTag> inList, Parquet.ModelTag tag) -> bool
-static Parquet.IReadOnlyListOfTagsExtensions.ContainsPrefixOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyList<Parquet.ModelTag> inList, Parquet.ModelTag inPrefix) -> bool
+static Parquet.IReadOnlyCollectionOfTagsExtensions.ContainsOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyCollection<Parquet.ModelTag> collection, Parquet.ModelTag tag) -> bool
+static Parquet.IReadOnlyCollectionOfTagsExtensions.ContainsPrefixOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyCollection<Parquet.ModelTag> collection, Parquet.ModelTag prefix) -> bool
+static Parquet.IReadOnlyListOfTagsExtensions.ContainsOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyList<Parquet.ModelTag> collection, Parquet.ModelTag tag) -> bool
+static Parquet.IReadOnlyListOfTagsExtensions.ContainsPrefixOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyList<Parquet.ModelTag> collection, Parquet.ModelTag prefix) -> bool
 static Parquet.Items.InventoryCollection.Empty.get -> Parquet.Items.InventoryCollection
 static Parquet.Items.InventoryConfiguration.DefaultCapacity.get -> int
 static Parquet.Items.InventoryConfiguration.DefaultCapacity.set -> void

--- a/ParquetClassLibrary/PublicAPI.Unshipped.txt
+++ b/ParquetClassLibrary/PublicAPI.Unshipped.txt
@@ -421,7 +421,7 @@ Parquet.Items.InventoryCollection.Add(Parquet.Items.InventorySlot slot) -> void
 Parquet.Items.InventoryCollection.Capacity.get -> int
 Parquet.Items.InventoryCollection.Capacity.set -> void
 Parquet.Items.InventoryCollection.Clear() -> void
-Parquet.Items.InventoryCollection.Contains(Parquet.Items.InventorySlot slot) -> bool
+Parquet.Items.InventoryCollection.Contains(Parquet.Items.InventorySlot other) -> bool
 Parquet.Items.InventoryCollection.Contains(Parquet.ModelID itemID) -> int
 Parquet.Items.InventoryCollection.CopyTo(Parquet.Items.InventorySlot[] array, int arrayIndex) -> void
 Parquet.Items.InventoryCollection.Count.get -> int
@@ -477,7 +477,7 @@ Parquet.LibraryState
 Parquet.Location
 Parquet.Location.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Location.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
-Parquet.Location.Equals(Parquet.Location location) -> bool
+Parquet.Location.Equals(Parquet.Location other) -> bool
 Parquet.Location.Location() -> void
 Parquet.Location.Location(Parquet.ModelID? regionID = null, Parquet.Point2D? position = null) -> void
 Parquet.Location.Position.get -> Parquet.Point2D
@@ -493,7 +493,7 @@ Parquet.Model
 Parquet.Model.AttributeTag(Parquet.ModelTag prefix) -> Parquet.ModelTag
 Parquet.Model.Comment.get -> string
 Parquet.Model.Description.get -> string
-Parquet.Model.Equals(Parquet.Model model) -> bool
+Parquet.Model.Equals(Parquet.Model other) -> bool
 Parquet.Model.ID.get -> Parquet.ModelID
 Parquet.Model.Model(Parquet.Range<Parquet.ModelID> bounds, Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags) -> void
 Parquet.Model.Name.get -> string
@@ -514,10 +514,10 @@ Parquet.ModelCollection<TModel>.ModelCollection(System.Collections.Generic.IEnum
 Parquet.ModelCollection<TModel>.PutRecordsForType<TModelInner>() -> void
 Parquet.ModelCollection<TModel>.VisibleDataChanged -> Parquet.DataChangedEventHandler
 Parquet.ModelID
-Parquet.ModelID.CompareTo(Parquet.ModelID id) -> int
+Parquet.ModelID.CompareTo(Parquet.ModelID other) -> int
 Parquet.ModelID.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.ModelID.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
-Parquet.ModelID.Equals(Parquet.ModelID id) -> bool
+Parquet.ModelID.Equals(Parquet.ModelID other) -> bool
 Parquet.ModelID.IsValidForRange(Parquet.Range<Parquet.ModelID> range) -> bool
 Parquet.ModelID.IsValidForRange(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> ranges) -> bool
 Parquet.ModelID.ModelID() -> void
@@ -533,14 +533,14 @@ Parquet.ModelIDGrid.ModelIDGrid(int rowCount, int columnCount) -> void
 Parquet.ModelIDGrid.Rows.get -> int
 Parquet.ModelIDGrid.this[int y, int x].get -> Parquet.ModelID
 Parquet.ModelTag
-Parquet.ModelTag.CompareTo(Parquet.ModelTag tag) -> int
+Parquet.ModelTag.CompareTo(Parquet.ModelTag other) -> int
 Parquet.ModelTag.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.ModelTag.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.ModelTag.EqualsOrdinalIgnoreCase(Parquet.ModelTag tag) -> bool
 Parquet.ModelTag.ModelTag() -> void
 Parquet.ModelTag.StartsWithOrdinalIgnoreCase(Parquet.ModelTag prefix) -> bool
 Parquet.Pack<T>
-Parquet.Pack<T>.Equals(Parquet.Pack<T> pack) -> bool
+Parquet.Pack<T>.Equals(Parquet.Pack<T> other) -> bool
 Parquet.Pack<T>.Pack() -> void
 Parquet.PackArrayExtensions
 Parquet.Parquets.BlockModel
@@ -699,7 +699,7 @@ Parquet.Point2D
 Parquet.Point2D.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Point2D.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Point2D.Deconstruct(out int x, out int y) -> void
-Parquet.Point2D.Equals(Parquet.Point2D point) -> bool
+Parquet.Point2D.Equals(Parquet.Point2D other) -> bool
 Parquet.Point2D.Magnitude.get -> int
 Parquet.Point2D.Point2D((int X, int Y) coordinates) -> void
 Parquet.Point2D.Point2D() -> void
@@ -713,7 +713,7 @@ Parquet.Range<TElement>.ContainsValue(TElement value) -> bool
 Parquet.Range<TElement>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Range<TElement>.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Range<TElement>.Deconstruct(out TElement minimum, out TElement maximum) -> void
-Parquet.Range<TElement>.Equals(Parquet.Range<TElement> range) -> bool
+Parquet.Range<TElement>.Equals(Parquet.Range<TElement> other) -> bool
 Parquet.Range<TElement>.IsValid() -> bool
 Parquet.Range<TElement>.Maximum.get -> TElement
 Parquet.Range<TElement>.Minimum.get -> TElement
@@ -726,7 +726,7 @@ Parquet.RecipeElement.ConvertFromString(string text, CsvHelper.IReaderRow row, C
 Parquet.RecipeElement.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.RecipeElement.ElementAmount.get -> int
 Parquet.RecipeElement.ElementTag.get -> Parquet.ModelTag
-Parquet.RecipeElement.Equals(Parquet.RecipeElement element) -> bool
+Parquet.RecipeElement.Equals(Parquet.RecipeElement other) -> bool
 Parquet.RecipeElement.RecipeElement() -> void
 Parquet.RecipeElement.RecipeElement(int elementAmount, Parquet.ModelTag elementTag) -> void
 Parquet.Regions.ChunkDetail
@@ -737,7 +737,7 @@ Parquet.Regions.ChunkDetail.ChunkDetail(Parquet.Regions.ChunkTopography baseTopo
 Parquet.Regions.ChunkDetail.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Regions.ChunkDetail.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Regions.ChunkDetail.DeepClone() -> Parquet.Regions.ChunkDetail
-Parquet.Regions.ChunkDetail.Equals(Parquet.Regions.ChunkDetail chunkType) -> bool
+Parquet.Regions.ChunkDetail.Equals(Parquet.Regions.ChunkDetail other) -> bool
 Parquet.Regions.ChunkDetail.ModifierComposition.get -> Parquet.ModelTag
 Parquet.Regions.ChunkDetail.ModifierTopography.get -> Parquet.Regions.ChunkTopography
 Parquet.Regions.ChunkTopography
@@ -779,7 +779,7 @@ Parquet.Regions.MapChunk.DeepClone() -> Parquet.Regions.MapChunk
 Parquet.Regions.MapChunk.Details.get -> Parquet.Regions.ChunkDetail
 Parquet.Regions.MapChunk.Details.set -> void
 Parquet.Regions.MapChunk.DimensionsInParquets.get -> Parquet.Point2D
-Parquet.Regions.MapChunk.Equals(Parquet.Regions.MapChunk chunk) -> bool
+Parquet.Regions.MapChunk.Equals(Parquet.Regions.MapChunk other) -> bool
 Parquet.Regions.MapChunk.Generate() -> Parquet.Regions.MapChunk
 Parquet.Regions.MapChunk.IsFilledOut.get -> bool
 Parquet.Regions.MapChunk.MapChunk() -> void
@@ -829,7 +829,7 @@ Parquet.Rooms.IMutableRoomRecipe.OptionallyRequiredWalkableFloors.get -> System.
 Parquet.Rooms.MapSpace
 Parquet.Rooms.MapSpace.Content.get -> Parquet.Parquets.ParquetModelPack
 Parquet.Rooms.MapSpace.EastNeighbor() -> Parquet.Rooms.MapSpace
-Parquet.Rooms.MapSpace.Equals(Parquet.Rooms.MapSpace space) -> bool
+Parquet.Rooms.MapSpace.Equals(Parquet.Rooms.MapSpace other) -> bool
 Parquet.Rooms.MapSpace.Grid.get -> Parquet.Parquets.ParquetModelPackGrid
 Parquet.Rooms.MapSpace.IsEmpty.get -> bool
 Parquet.Rooms.MapSpace.IsEnclosing.get -> bool
@@ -845,7 +845,7 @@ Parquet.Rooms.MapSpaceSetExtensions
 Parquet.Rooms.ReadOnlyRoomCollectionExtensions
 Parquet.Rooms.Room
 Parquet.Rooms.Room.ContainsPosition(Parquet.Point2D position) -> bool
-Parquet.Rooms.Room.Equals(Parquet.Rooms.Room room) -> bool
+Parquet.Rooms.Room.Equals(Parquet.Rooms.Room other) -> bool
 Parquet.Rooms.Room.FurnishingTags.get -> System.Collections.Generic.IEnumerable<Parquet.ModelTag>
 Parquet.Rooms.Room.Perimeter.get -> System.Collections.Generic.IReadOnlySet<Parquet.Rooms.MapSpace>
 Parquet.Rooms.Room.Position.get -> Parquet.Point2D
@@ -890,7 +890,7 @@ Parquet.Scripts.ScriptModel.GetActions() -> System.Collections.Generic.IEnumerab
 Parquet.Scripts.ScriptModel.Nodes.get -> System.Collections.Generic.IReadOnlyList<Parquet.Scripts.ScriptNode>
 Parquet.Scripts.ScriptModel.ScriptModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, System.Collections.Generic.IEnumerable<Parquet.Scripts.ScriptNode> nodes = null) -> void
 Parquet.Scripts.ScriptNode
-Parquet.Scripts.ScriptNode.CompareTo(Parquet.Scripts.ScriptNode tag) -> int
+Parquet.Scripts.ScriptNode.CompareTo(Parquet.Scripts.ScriptNode other) -> int
 Parquet.Scripts.ScriptNode.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Scripts.ScriptNode.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Scripts.ScriptNode.GetAction() -> System.Action
@@ -908,7 +908,7 @@ Parquet.SeriesConverter<TElement, TCollection>.ConvertFromString(string text, Cs
 Parquet.SeriesConverter<TElement, TCollection>.SeriesConverter() -> void
 Parquet.Status<T>
 Parquet.Status<T>.DeepClone() -> Parquet.Status<T>
-Parquet.Status<T>.Equals(Parquet.Status<T> status) -> bool
+Parquet.Status<T>.Equals(Parquet.Status<T> other) -> bool
 Parquet.Status<T>.Status() -> void
 Parquet.StatusArrayExtensions
 static Parquet.All.Beings.get -> Parquet.ModelCollection<Parquet.Beings.BeingModel>

--- a/ParquetClassLibrary/PublicAPI.Unshipped.txt
+++ b/ParquetClassLibrary/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 abstract Parquet.Pack<T>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 abstract Parquet.Pack<T>.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 abstract Parquet.Pack<T>.DeepClone<TDerived>() -> TDerived
-abstract Parquet.Pack<T>.Equals<TDerived>(TDerived inPack) -> bool
+abstract Parquet.Pack<T>.Equals<TDerived>(TDerived pack) -> bool
 abstract Parquet.Status<T>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 abstract Parquet.Status<T>.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 abstract Parquet.Status<T>.DeepClone<TDerived>() -> TDerived
@@ -129,7 +129,7 @@ override Parquet.Parquets.ParquetModelPack.ConvertToString(object value, CsvHelp
 override Parquet.Parquets.ParquetModelPack.DeepClone() -> Parquet.Parquets.ParquetModelPack
 override Parquet.Parquets.ParquetModelPack.DeepClone<T>() -> T
 override Parquet.Parquets.ParquetModelPack.Equals(object obj) -> bool
-override Parquet.Parquets.ParquetModelPack.Equals<T>(T inPack) -> bool
+override Parquet.Parquets.ParquetModelPack.Equals<T>(T pack) -> bool
 override Parquet.Parquets.ParquetModelPack.GetHashCode() -> int
 override Parquet.Parquets.ParquetModelPack.ToString() -> string
 override Parquet.Parquets.ParquetStatusPack.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
@@ -137,7 +137,7 @@ override Parquet.Parquets.ParquetStatusPack.ConvertToString(object value, CsvHel
 override Parquet.Parquets.ParquetStatusPack.DeepClone() -> Parquet.Parquets.ParquetStatusPack
 override Parquet.Parquets.ParquetStatusPack.DeepClone<T>() -> T
 override Parquet.Parquets.ParquetStatusPack.Equals(object obj) -> bool
-override Parquet.Parquets.ParquetStatusPack.Equals<T>(T inPack) -> bool
+override Parquet.Parquets.ParquetStatusPack.Equals<T>(T pack) -> bool
 override Parquet.Parquets.ParquetStatusPack.GetHashCode() -> int
 override Parquet.Parquets.ParquetStatusPack.ToString() -> string
 override Parquet.Point2D.Equals(object obj) -> bool
@@ -184,7 +184,7 @@ override Parquet.Scripts.ScriptStatus.Equals<T>(T status) -> bool
 override Parquet.Scripts.ScriptStatus.GetHashCode() -> int
 override Parquet.Scripts.ScriptStatus.ToString() -> string
 override Parquet.SeriesConverter<TElement, TCollection>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
-override Parquet.SeriesConverter<TElement, TCollection>.ConvertToString(object inCollection, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
+override Parquet.SeriesConverter<TElement, TCollection>.ConvertToString(object collection, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.All
 Parquet.AssemblyInfo
 Parquet.AssemblyInfo.AssemblyInfo() -> void
@@ -328,11 +328,11 @@ Parquet.Crafts.StrikePanelGrid.Count.get -> int
 Parquet.Crafts.StrikePanelGrid.DeepClone() -> Parquet.IGrid<Parquet.Crafts.StrikePanel>
 Parquet.Crafts.StrikePanelGrid.GetEnumerator() -> System.Collections.IEnumerator
 Parquet.Crafts.StrikePanelGrid.GridDelimiter.get -> string
-Parquet.Crafts.StrikePanelGrid.IsValidPosition(Parquet.Point2D inPosition) -> bool
+Parquet.Crafts.StrikePanelGrid.IsValidPosition(Parquet.Point2D position) -> bool
 Parquet.Crafts.StrikePanelGrid.Rows.get -> int
 Parquet.Crafts.StrikePanelGrid.StrikePanelGrid() -> void
-Parquet.Crafts.StrikePanelGrid.StrikePanelGrid(int inRowCount, int inColumnCount) -> void
-Parquet.Crafts.StrikePanelGrid.StrikePanelGrid(Parquet.IGrid<Parquet.Crafts.StrikePanel> inContent, int inRowCount, int inColumnCount) -> void
+Parquet.Crafts.StrikePanelGrid.StrikePanelGrid(int rowCount, int columnCount) -> void
+Parquet.Crafts.StrikePanelGrid.StrikePanelGrid(Parquet.IGrid<Parquet.Crafts.StrikePanel> content, int rowCount, int columnCount) -> void
 Parquet.Crafts.StrikePanelGrid.this[int y, int x].get -> Parquet.Crafts.StrikePanel
 Parquet.DataChangedEventHandler
 Parquet.Delimiters
@@ -417,18 +417,18 @@ Parquet.Items.IMutableItemModel.Subtype.set -> void
 Parquet.Items.IMutableItemModel.Worth.get -> int
 Parquet.Items.IMutableItemModel.Worth.set -> void
 Parquet.Items.InventoryCollection
-Parquet.Items.InventoryCollection.Add(Parquet.Items.InventorySlot inSlot) -> void
+Parquet.Items.InventoryCollection.Add(Parquet.Items.InventorySlot slot) -> void
 Parquet.Items.InventoryCollection.Capacity.get -> int
 Parquet.Items.InventoryCollection.Capacity.set -> void
 Parquet.Items.InventoryCollection.Clear() -> void
 Parquet.Items.InventoryCollection.Contains(Parquet.Items.InventorySlot slot) -> bool
 Parquet.Items.InventoryCollection.Contains(Parquet.ModelID itemID) -> int
-Parquet.Items.InventoryCollection.CopyTo(Parquet.Items.InventorySlot[] inArray, int inArrayIndex) -> void
+Parquet.Items.InventoryCollection.CopyTo(Parquet.Items.InventorySlot[] array, int arrayIndex) -> void
 Parquet.Items.InventoryCollection.Count.get -> int
 Parquet.Items.InventoryCollection.DeepClone() -> Parquet.Items.InventoryCollection
 Parquet.Items.InventoryCollection.GetEnumerator() -> System.Collections.Generic.IEnumerator<Parquet.Items.InventorySlot>
-Parquet.Items.InventoryCollection.Give(Parquet.Items.InventorySlot inSlot) -> int
-Parquet.Items.InventoryCollection.Give(Parquet.ModelID inItemID, int inHowMany) -> int
+Parquet.Items.InventoryCollection.Give(Parquet.Items.InventorySlot slot) -> int
+Parquet.Items.InventoryCollection.Give(Parquet.ModelID itemID, int howMany) -> int
 Parquet.Items.InventoryCollection.Has(Parquet.Items.InventorySlot slot) -> bool
 Parquet.Items.InventoryCollection.Has(Parquet.ModelID itemID, int howMany = 1) -> bool
 Parquet.Items.InventoryCollection.Has(System.Collections.Generic.IEnumerable<(Parquet.ModelID, int)> items) -> bool
@@ -438,9 +438,9 @@ Parquet.Items.InventoryCollection.InventoryCollection(int capacity) -> void
 Parquet.Items.InventoryCollection.InventoryCollection(System.Collections.Generic.IEnumerable<Parquet.Items.InventorySlot> slots, int capacity) -> void
 Parquet.Items.InventoryCollection.IsReadOnly.get -> bool
 Parquet.Items.InventoryCollection.ItemCount.get -> int
-Parquet.Items.InventoryCollection.Remove(Parquet.Items.InventorySlot inSlot) -> bool
-Parquet.Items.InventoryCollection.Take(Parquet.Items.InventorySlot inSlot) -> int
-Parquet.Items.InventoryCollection.Take(Parquet.ModelID inItemID, int inHowMany) -> int
+Parquet.Items.InventoryCollection.Remove(Parquet.Items.InventorySlot slot) -> bool
+Parquet.Items.InventoryCollection.Take(Parquet.Items.InventorySlot slot) -> int
+Parquet.Items.InventoryCollection.Take(Parquet.ModelID itemID, int howMany) -> int
 Parquet.Items.InventoryConfiguration
 Parquet.Items.InventorySlot
 Parquet.Items.InventorySlot.Count.get -> int
@@ -477,9 +477,9 @@ Parquet.LibraryState
 Parquet.Location
 Parquet.Location.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Location.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
-Parquet.Location.Equals(Parquet.Location inLocation) -> bool
+Parquet.Location.Equals(Parquet.Location location) -> bool
 Parquet.Location.Location() -> void
-Parquet.Location.Location(Parquet.ModelID? inRegionID = null, Parquet.Point2D? inPosition = null) -> void
+Parquet.Location.Location(Parquet.ModelID? regionID = null, Parquet.Point2D? position = null) -> void
 Parquet.Location.Position.get -> Parquet.Point2D
 Parquet.Location.RegionID.get -> Parquet.ModelID
 Parquet.Logger
@@ -490,36 +490,36 @@ Parquet.LogLevel.Fatal = 4 -> Parquet.LogLevel
 Parquet.LogLevel.Info = 1 -> Parquet.LogLevel
 Parquet.LogLevel.Warning = 2 -> Parquet.LogLevel
 Parquet.Model
-Parquet.Model.AttributeTag(Parquet.ModelTag inPrefix) -> Parquet.ModelTag
+Parquet.Model.AttributeTag(Parquet.ModelTag prefix) -> Parquet.ModelTag
 Parquet.Model.Comment.get -> string
 Parquet.Model.Description.get -> string
-Parquet.Model.Equals(Parquet.Model inModel) -> bool
+Parquet.Model.Equals(Parquet.Model model) -> bool
 Parquet.Model.ID.get -> Parquet.ModelID
-Parquet.Model.Model(Parquet.Range<Parquet.ModelID> inBounds, Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags) -> void
+Parquet.Model.Model(Parquet.Range<Parquet.ModelID> bounds, Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags) -> void
 Parquet.Model.Name.get -> string
 Parquet.Model.Tags.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelTag>
 Parquet.Model.VisibleDataChanged -> Parquet.DataChangedEventHandler
 Parquet.ModelCollection
 Parquet.ModelCollection<TModel>
 Parquet.ModelCollection<TModel>.Bounds.get -> System.Collections.Generic.IReadOnlyList<Parquet.Range<Parquet.ModelID>>
-Parquet.ModelCollection<TModel>.Contains(Parquet.Model inModel) -> bool
+Parquet.ModelCollection<TModel>.Contains(Parquet.Model model) -> bool
 Parquet.ModelCollection<TModel>.Contains(Parquet.ModelID id) -> bool
 Parquet.ModelCollection<TModel>.Count.get -> int
 Parquet.ModelCollection<TModel>.GetEnumerator() -> System.Collections.Generic.IEnumerator<Parquet.Model>
 Parquet.ModelCollection<TModel>.GetOrNull<TTarget>(Parquet.ModelID id) -> TTarget
-Parquet.ModelCollection<TModel>.GetRecordsForType<TModelInner>(Parquet.Range<Parquet.ModelID> inBounds) -> Parquet.ModelCollection<TModel>
-Parquet.ModelCollection<TModel>.GetRecordsForType<TModelInner>(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBounds) -> Parquet.ModelCollection<TModel>
-Parquet.ModelCollection<TModel>.ModelCollection(Parquet.Range<Parquet.ModelID> inBounds, System.Collections.Generic.IEnumerable<Parquet.Model> inModels) -> void
-Parquet.ModelCollection<TModel>.ModelCollection(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBounds, System.Collections.Generic.IEnumerable<Parquet.Model> inModels) -> void
+Parquet.ModelCollection<TModel>.GetRecordsForType<TModelInner>(Parquet.Range<Parquet.ModelID> bounds) -> Parquet.ModelCollection<TModel>
+Parquet.ModelCollection<TModel>.GetRecordsForType<TModelInner>(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> bounds) -> Parquet.ModelCollection<TModel>
+Parquet.ModelCollection<TModel>.ModelCollection(Parquet.Range<Parquet.ModelID> bounds, System.Collections.Generic.IEnumerable<Parquet.Model> models) -> void
+Parquet.ModelCollection<TModel>.ModelCollection(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> bounds, System.Collections.Generic.IEnumerable<Parquet.Model> models) -> void
 Parquet.ModelCollection<TModel>.PutRecordsForType<TModelInner>() -> void
 Parquet.ModelCollection<TModel>.VisibleDataChanged -> Parquet.DataChangedEventHandler
 Parquet.ModelID
-Parquet.ModelID.CompareTo(Parquet.ModelID inIDentifier) -> int
+Parquet.ModelID.CompareTo(Parquet.ModelID id) -> int
 Parquet.ModelID.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.ModelID.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
-Parquet.ModelID.Equals(Parquet.ModelID inIDentifier) -> bool
-Parquet.ModelID.IsValidForRange(Parquet.Range<Parquet.ModelID> inRange) -> bool
-Parquet.ModelID.IsValidForRange(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inRanges) -> bool
+Parquet.ModelID.Equals(Parquet.ModelID id) -> bool
+Parquet.ModelID.IsValidForRange(Parquet.Range<Parquet.ModelID> range) -> bool
+Parquet.ModelID.IsValidForRange(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> ranges) -> bool
 Parquet.ModelID.ModelID() -> void
 Parquet.ModelIDGrid
 Parquet.ModelIDGrid.Columns.get -> int
@@ -527,9 +527,9 @@ Parquet.ModelIDGrid.Count.get -> int
 Parquet.ModelIDGrid.DeepClone() -> Parquet.IGrid<Parquet.ModelID>
 Parquet.ModelIDGrid.GetEnumerator() -> System.Collections.IEnumerator
 Parquet.ModelIDGrid.GridDelimiter.get -> string
-Parquet.ModelIDGrid.IsValidPosition(Parquet.Point2D inPosition) -> bool
+Parquet.ModelIDGrid.IsValidPosition(Parquet.Point2D position) -> bool
 Parquet.ModelIDGrid.ModelIDGrid() -> void
-Parquet.ModelIDGrid.ModelIDGrid(int inRowCount, int inColumnCount) -> void
+Parquet.ModelIDGrid.ModelIDGrid(int rowCount, int columnCount) -> void
 Parquet.ModelIDGrid.Rows.get -> int
 Parquet.ModelIDGrid.this[int y, int x].get -> Parquet.ModelID
 Parquet.ModelTag
@@ -538,13 +538,13 @@ Parquet.ModelTag.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHel
 Parquet.ModelTag.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.ModelTag.EqualsOrdinalIgnoreCase(Parquet.ModelTag tag) -> bool
 Parquet.ModelTag.ModelTag() -> void
-Parquet.ModelTag.StartsWithOrdinalIgnoreCase(Parquet.ModelTag inPrefix) -> bool
+Parquet.ModelTag.StartsWithOrdinalIgnoreCase(Parquet.ModelTag prefix) -> bool
 Parquet.Pack<T>
-Parquet.Pack<T>.Equals(Parquet.Pack<T> inPack) -> bool
+Parquet.Pack<T>.Equals(Parquet.Pack<T> pack) -> bool
 Parquet.Pack<T>.Pack() -> void
 Parquet.PackArrayExtensions
 Parquet.Parquets.BlockModel
-Parquet.Parquets.BlockModel.BlockModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Items.GatheringTool inGatherTool = Parquet.Items.GatheringTool.None, Parquet.Parquets.GatheringEffect inGatherEffect = Parquet.Parquets.GatheringEffect.None, Parquet.ModelID? inCollectibleID = null, bool inIsFlammable = false, bool inIsLiquid = false, int inMaxToughness = 10) -> void
+Parquet.Parquets.BlockModel.BlockModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? itemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToRoom = null, Parquet.Items.GatheringTool gatherTool = Parquet.Items.GatheringTool.None, Parquet.Parquets.GatheringEffect gatherEffect = Parquet.Parquets.GatheringEffect.None, Parquet.ModelID? collectibleID = null, bool isFlammable = false, bool isLiquid = false, int maxToughness = 10) -> void
 Parquet.Parquets.BlockModel.CollectibleID.get -> Parquet.ModelID
 Parquet.Parquets.BlockModel.GatherEffect.get -> Parquet.Parquets.GatheringEffect
 Parquet.Parquets.BlockModel.GatherTool.get -> Parquet.Items.GatheringTool
@@ -553,12 +553,12 @@ Parquet.Parquets.BlockModel.IsLiquid.get -> bool
 Parquet.Parquets.BlockModel.MaxToughness.get -> int
 Parquet.Parquets.BlockStatus
 Parquet.Parquets.BlockStatus.BlockStatus() -> void
-Parquet.Parquets.BlockStatus.BlockStatus(int inToughness, int inMaxToughness) -> void
-Parquet.Parquets.BlockStatus.BlockStatus(Parquet.ModelID inBlockID) -> void
+Parquet.Parquets.BlockStatus.BlockStatus(int toughness, int maxToughness) -> void
+Parquet.Parquets.BlockStatus.BlockStatus(Parquet.ModelID blockID) -> void
 Parquet.Parquets.BlockStatus.Toughness.get -> int
 Parquet.Parquets.BlockStatus.Toughness.set -> void
 Parquet.Parquets.CollectibleModel
-Parquet.Parquets.CollectibleModel.CollectibleModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Parquets.CollectingEffect inCollectionEffect = Parquet.Parquets.CollectingEffect.None, int inEffectAmount = 0) -> void
+Parquet.Parquets.CollectibleModel.CollectibleModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? itemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToRoom = null, Parquet.Parquets.CollectingEffect collectionEffect = Parquet.Parquets.CollectingEffect.None, int effectAmount = 0) -> void
 Parquet.Parquets.CollectibleModel.CollectionEffect.get -> Parquet.Parquets.CollectingEffect
 Parquet.Parquets.CollectibleModel.EffectAmount.get -> int
 Parquet.Parquets.CollectingEffect
@@ -572,26 +572,26 @@ Parquet.Parquets.EntryType.Room = 1 -> Parquet.Parquets.EntryType
 Parquet.Parquets.EntryType.Up = 2 -> Parquet.Parquets.EntryType
 Parquet.Parquets.FloorModel
 Parquet.Parquets.FloorModel.DefaultTrenchName.get -> string
-Parquet.Parquets.FloorModel.FloorModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Items.ModificationTool inModTool = Parquet.Items.ModificationTool.None, string inTrenchName = null) -> void
+Parquet.Parquets.FloorModel.FloorModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? itemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToRoom = null, Parquet.Items.ModificationTool modTool = Parquet.Items.ModificationTool.None, string trenchName = null) -> void
 Parquet.Parquets.FloorModel.ModTool.get -> Parquet.Items.ModificationTool
 Parquet.Parquets.FloorModel.TrenchName.get -> string
 Parquet.Parquets.FloorStatus
 Parquet.Parquets.FloorStatus.FloorStatus() -> void
-Parquet.Parquets.FloorStatus.FloorStatus(bool inIsTrench) -> void
-Parquet.Parquets.FloorStatus.FloorStatus(Parquet.ModelID inFloorID) -> void
+Parquet.Parquets.FloorStatus.FloorStatus(bool isTrench) -> void
+Parquet.Parquets.FloorStatus.FloorStatus(Parquet.ModelID floorID) -> void
 Parquet.Parquets.FloorStatus.IsTrench.get -> bool
 Parquet.Parquets.FloorStatus.IsTrench.set -> void
 Parquet.Parquets.FurnishingModel
 Parquet.Parquets.FurnishingModel.Entry.get -> Parquet.Parquets.EntryType
-Parquet.Parquets.FurnishingModel.FurnishingModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, bool inIsWalkable = false, Parquet.Parquets.EntryType inEntry = Parquet.Parquets.EntryType.None, bool inIsEnclosing = false, bool inIsFlammable = false, bool inIsOpenable = false) -> void
+Parquet.Parquets.FurnishingModel.FurnishingModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? itemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToRoom = null, bool isWalkable = false, Parquet.Parquets.EntryType isEntry = Parquet.Parquets.EntryType.None, bool isEnclosing = false, bool isFlammable = false, bool isOpenable = false) -> void
 Parquet.Parquets.FurnishingModel.IsEnclosing.get -> bool
 Parquet.Parquets.FurnishingModel.IsFlammable.get -> bool
 Parquet.Parquets.FurnishingModel.IsOpenable.get -> bool
 Parquet.Parquets.FurnishingModel.IsWalkable.get -> bool
 Parquet.Parquets.FurnishingStatus
 Parquet.Parquets.FurnishingStatus.FurnishingStatus() -> void
-Parquet.Parquets.FurnishingStatus.FurnishingStatus(bool inIsOpen) -> void
-Parquet.Parquets.FurnishingStatus.FurnishingStatus(Parquet.ModelID inFloorID) -> void
+Parquet.Parquets.FurnishingStatus.FurnishingStatus(bool isOpen) -> void
+Parquet.Parquets.FurnishingStatus.FurnishingStatus(Parquet.ModelID furnishingID) -> void
 Parquet.Parquets.FurnishingStatus.IsOpen.get -> bool
 Parquet.Parquets.FurnishingStatus.IsOpen.set -> void
 Parquet.Parquets.GatheringEffect
@@ -644,7 +644,7 @@ Parquet.Parquets.ParquetModel.AddsToRoom.get -> System.Collections.Generic.IRead
 Parquet.Parquets.ParquetModel.AddsToRoom.set -> void
 Parquet.Parquets.ParquetModel.ItemID.get -> Parquet.ModelID
 Parquet.Parquets.ParquetModel.ItemID.set -> void
-Parquet.Parquets.ParquetModel.ParquetModel(Parquet.Range<Parquet.ModelID> inBounds, Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null) -> void
+Parquet.Parquets.ParquetModel.ParquetModel(Parquet.Range<Parquet.ModelID> bounds, Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? itemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> addsToRoom = null) -> void
 Parquet.Parquets.ParquetModelPack
 Parquet.Parquets.ParquetModelPack.BlockID.get -> Parquet.ModelID
 Parquet.Parquets.ParquetModelPack.BlockID.set -> void
@@ -658,19 +658,19 @@ Parquet.Parquets.ParquetModelPack.FurnishingID.set -> void
 Parquet.Parquets.ParquetModelPack.IsEmpty.get -> bool
 Parquet.Parquets.ParquetModelPack.IsEnclosing.get -> bool
 Parquet.Parquets.ParquetModelPack.ParquetModelPack() -> void
-Parquet.Parquets.ParquetModelPack.ParquetModelPack(Parquet.ModelID inFloor, Parquet.ModelID inBlock, Parquet.ModelID inFurnishing, Parquet.ModelID inCollectible) -> void
+Parquet.Parquets.ParquetModelPack.ParquetModelPack(Parquet.ModelID floor, Parquet.ModelID block, Parquet.ModelID furnishing, Parquet.ModelID collectible) -> void
 Parquet.Parquets.ParquetModelPackGrid
 Parquet.Parquets.ParquetModelPackGrid.Columns.get -> int
 Parquet.Parquets.ParquetModelPackGrid.Count.get -> int
 Parquet.Parquets.ParquetModelPackGrid.DeepClone() -> Parquet.IGrid<Parquet.Parquets.ParquetModelPack>
 Parquet.Parquets.ParquetModelPackGrid.GetEnumerator() -> System.Collections.IEnumerator
 Parquet.Parquets.ParquetModelPackGrid.GetSubgrid() -> Parquet.IReadOnlyGrid<Parquet.Parquets.ParquetModelPack>
-Parquet.Parquets.ParquetModelPackGrid.GetSubgrid(Parquet.Point2D inUpperLeft, Parquet.Point2D inLowerRight) -> Parquet.IReadOnlyGrid<Parquet.Parquets.ParquetModelPack>
+Parquet.Parquets.ParquetModelPackGrid.GetSubgrid(Parquet.Point2D upperLeft, Parquet.Point2D lowerRight) -> Parquet.IReadOnlyGrid<Parquet.Parquets.ParquetModelPack>
 Parquet.Parquets.ParquetModelPackGrid.GridDelimiter.get -> string
-Parquet.Parquets.ParquetModelPackGrid.IsValidPosition(Parquet.Point2D inPosition) -> bool
+Parquet.Parquets.ParquetModelPackGrid.IsValidPosition(Parquet.Point2D position) -> bool
 Parquet.Parquets.ParquetModelPackGrid.ParquetModelPackGrid() -> void
-Parquet.Parquets.ParquetModelPackGrid.ParquetModelPackGrid(int inRowCount, int inColumnCount) -> void
-Parquet.Parquets.ParquetModelPackGrid.ParquetModelPackGrid(Parquet.Parquets.ParquetModelPack[,] inParquetPackArray) -> void
+Parquet.Parquets.ParquetModelPackGrid.ParquetModelPackGrid(int rowCount, int columnCount) -> void
+Parquet.Parquets.ParquetModelPackGrid.ParquetModelPackGrid(Parquet.Parquets.ParquetModelPack[,] parquetPackArray) -> void
 Parquet.Parquets.ParquetModelPackGrid.Rows.get -> int
 Parquet.Parquets.ParquetModelPackGrid.this[int y, int x].get -> Parquet.Parquets.ParquetModelPack
 Parquet.Parquets.ParquetStatus<T>
@@ -681,63 +681,63 @@ Parquet.Parquets.ParquetStatusPack.CurrentBlockStatus.set -> void
 Parquet.Parquets.ParquetStatusPack.CurrentFloorStatus.get -> Parquet.Parquets.FloorStatus
 Parquet.Parquets.ParquetStatusPack.CurrentFloorStatus.set -> void
 Parquet.Parquets.ParquetStatusPack.ParquetStatusPack() -> void
-Parquet.Parquets.ParquetStatusPack.ParquetStatusPack(Parquet.Parquets.FloorStatus inFloorStatus = null, Parquet.Parquets.BlockStatus inBlockStatus = null) -> void
-Parquet.Parquets.ParquetStatusPack.ParquetStatusPack(Parquet.Parquets.ParquetModelPack inParquetModelPack) -> void
+Parquet.Parquets.ParquetStatusPack.ParquetStatusPack(Parquet.Parquets.FloorStatus floorStatus = null, Parquet.Parquets.BlockStatus blockStatus = null) -> void
+Parquet.Parquets.ParquetStatusPack.ParquetStatusPack(Parquet.Parquets.ParquetModelPack parquetModelPack) -> void
 Parquet.Parquets.ParquetStatusPackGrid
 Parquet.Parquets.ParquetStatusPackGrid.Columns.get -> int
 Parquet.Parquets.ParquetStatusPackGrid.Count.get -> int
 Parquet.Parquets.ParquetStatusPackGrid.DeepClone() -> Parquet.IGrid<Parquet.Parquets.ParquetStatusPack>
 Parquet.Parquets.ParquetStatusPackGrid.GetEnumerator() -> System.Collections.IEnumerator
 Parquet.Parquets.ParquetStatusPackGrid.GridDelimiter.get -> string
-Parquet.Parquets.ParquetStatusPackGrid.IsValidPosition(Parquet.Point2D inPosition) -> bool
+Parquet.Parquets.ParquetStatusPackGrid.IsValidPosition(Parquet.Point2D position) -> bool
 Parquet.Parquets.ParquetStatusPackGrid.ParquetStatusPackGrid() -> void
-Parquet.Parquets.ParquetStatusPackGrid.ParquetStatusPackGrid(int inRowCount, int inColumnCount) -> void
-Parquet.Parquets.ParquetStatusPackGrid.ParquetStatusPackGrid(Parquet.Parquets.ParquetModelPackGrid inParquetModelPackGrid) -> void
+Parquet.Parquets.ParquetStatusPackGrid.ParquetStatusPackGrid(int rowCount, int columnCount) -> void
+Parquet.Parquets.ParquetStatusPackGrid.ParquetStatusPackGrid(Parquet.Parquets.ParquetModelPackGrid parquetModelPackGrid) -> void
 Parquet.Parquets.ParquetStatusPackGrid.Rows.get -> int
 Parquet.Parquets.ParquetStatusPackGrid.this[int y, int x].get -> Parquet.Parquets.ParquetStatusPack
 Parquet.Point2D
 Parquet.Point2D.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Point2D.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Point2D.Deconstruct(out int x, out int y) -> void
-Parquet.Point2D.Equals(Parquet.Point2D inPoint) -> bool
+Parquet.Point2D.Equals(Parquet.Point2D point) -> bool
 Parquet.Point2D.Magnitude.get -> int
-Parquet.Point2D.Point2D((int X, int Y) inCoordinates) -> void
+Parquet.Point2D.Point2D((int X, int Y) coordinates) -> void
 Parquet.Point2D.Point2D() -> void
-Parquet.Point2D.Point2D(int inX, int inY) -> void
+Parquet.Point2D.Point2D(int x, int y) -> void
 Parquet.Point2D.X.get -> int
 Parquet.Point2D.Y.get -> int
 Parquet.Precondition
 Parquet.Range<TElement>
-Parquet.Range<TElement>.ContainsRange(Parquet.Range<TElement> inRange) -> bool
+Parquet.Range<TElement>.ContainsRange(Parquet.Range<TElement> range) -> bool
 Parquet.Range<TElement>.ContainsValue(TElement value) -> bool
 Parquet.Range<TElement>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Range<TElement>.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Range<TElement>.Deconstruct(out TElement minimum, out TElement maximum) -> void
-Parquet.Range<TElement>.Equals(Parquet.Range<TElement> inRange) -> bool
+Parquet.Range<TElement>.Equals(Parquet.Range<TElement> range) -> bool
 Parquet.Range<TElement>.IsValid() -> bool
 Parquet.Range<TElement>.Maximum.get -> TElement
 Parquet.Range<TElement>.Minimum.get -> TElement
-Parquet.Range<TElement>.Range((TElement Minimum, TElement Maximum) inExtema) -> void
+Parquet.Range<TElement>.Range((TElement Minimum, TElement Maximum) extema) -> void
 Parquet.Range<TElement>.Range() -> void
-Parquet.Range<TElement>.Range(TElement inMinimum, TElement inMaximum) -> void
+Parquet.Range<TElement>.Range(TElement minimum, TElement maximum) -> void
 Parquet.RangeCollectionExtensions
 Parquet.RecipeElement
 Parquet.RecipeElement.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.RecipeElement.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.RecipeElement.ElementAmount.get -> int
 Parquet.RecipeElement.ElementTag.get -> Parquet.ModelTag
-Parquet.RecipeElement.Equals(Parquet.RecipeElement inElement) -> bool
+Parquet.RecipeElement.Equals(Parquet.RecipeElement element) -> bool
 Parquet.RecipeElement.RecipeElement() -> void
-Parquet.RecipeElement.RecipeElement(int inElementAmount, Parquet.ModelTag inElementTag) -> void
+Parquet.RecipeElement.RecipeElement(int elementAmount, Parquet.ModelTag elementTag) -> void
 Parquet.Regions.ChunkDetail
 Parquet.Regions.ChunkDetail.BaseComposition.get -> Parquet.ModelTag
 Parquet.Regions.ChunkDetail.BaseTopography.get -> Parquet.Regions.ChunkTopography
 Parquet.Regions.ChunkDetail.ChunkDetail() -> void
-Parquet.Regions.ChunkDetail.ChunkDetail(Parquet.Regions.ChunkTopography inBaseTopography, Parquet.ModelTag inBaseComposition, Parquet.Regions.ChunkTopography inModifierTopography, Parquet.ModelTag inModifierComposition) -> void
+Parquet.Regions.ChunkDetail.ChunkDetail(Parquet.Regions.ChunkTopography baseTopography, Parquet.ModelTag baseComposition, Parquet.Regions.ChunkTopography modifierTopography, Parquet.ModelTag modifierComposition) -> void
 Parquet.Regions.ChunkDetail.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 Parquet.Regions.ChunkDetail.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Regions.ChunkDetail.DeepClone() -> Parquet.Regions.ChunkDetail
-Parquet.Regions.ChunkDetail.Equals(Parquet.Regions.ChunkDetail inChunkType) -> bool
+Parquet.Regions.ChunkDetail.Equals(Parquet.Regions.ChunkDetail chunkType) -> bool
 Parquet.Regions.ChunkDetail.ModifierComposition.get -> Parquet.ModelTag
 Parquet.Regions.ChunkDetail.ModifierTopography.get -> Parquet.Regions.ChunkTopography
 Parquet.Regions.ChunkTopography
@@ -779,11 +779,11 @@ Parquet.Regions.MapChunk.DeepClone() -> Parquet.Regions.MapChunk
 Parquet.Regions.MapChunk.Details.get -> Parquet.Regions.ChunkDetail
 Parquet.Regions.MapChunk.Details.set -> void
 Parquet.Regions.MapChunk.DimensionsInParquets.get -> Parquet.Point2D
-Parquet.Regions.MapChunk.Equals(Parquet.Regions.MapChunk inChunk) -> bool
+Parquet.Regions.MapChunk.Equals(Parquet.Regions.MapChunk chunk) -> bool
 Parquet.Regions.MapChunk.Generate() -> Parquet.Regions.MapChunk
 Parquet.Regions.MapChunk.IsFilledOut.get -> bool
 Parquet.Regions.MapChunk.MapChunk() -> void
-Parquet.Regions.MapChunk.MapChunk(bool inIsFilledOut, Parquet.Regions.ChunkDetail inDetails = null, Parquet.IReadOnlyGrid<Parquet.Parquets.ParquetModelPack> inParquetDefinitions = null) -> void
+Parquet.Regions.MapChunk.MapChunk(bool isFilledOut, Parquet.Regions.ChunkDetail details = null, Parquet.IReadOnlyGrid<Parquet.Parquets.ParquetModelPack> parquetDefinitions = null) -> void
 Parquet.Regions.MapChunk.ParquetDefinitions.get -> Parquet.IReadOnlyGrid<Parquet.Parquets.ParquetModelPack>
 Parquet.Regions.MapChunk.ParquetDefinitions.set -> void
 Parquet.Regions.MapChunkArrayExtensions
@@ -793,10 +793,10 @@ Parquet.Regions.MapChunkGrid.Count.get -> int
 Parquet.Regions.MapChunkGrid.DeepClone() -> Parquet.IGrid<Parquet.Regions.MapChunk>
 Parquet.Regions.MapChunkGrid.GetEnumerator() -> System.Collections.IEnumerator
 Parquet.Regions.MapChunkGrid.GridDelimiter.get -> string
-Parquet.Regions.MapChunkGrid.IsValidPosition(Parquet.Point2D inPosition) -> bool
+Parquet.Regions.MapChunkGrid.IsValidPosition(Parquet.Point2D position) -> bool
 Parquet.Regions.MapChunkGrid.MapChunkGrid() -> void
-Parquet.Regions.MapChunkGrid.MapChunkGrid(int inRowCount, int inColumnCount) -> void
-Parquet.Regions.MapChunkGrid.MapChunkGrid(Parquet.Regions.MapChunk[,] inMapChunkArray) -> void
+Parquet.Regions.MapChunkGrid.MapChunkGrid(int rowCount, int columnCount) -> void
+Parquet.Regions.MapChunkGrid.MapChunkGrid(Parquet.Regions.MapChunk[,] mapChunkArray) -> void
 Parquet.Regions.MapChunkGrid.Rows.get -> int
 Parquet.Regions.MapChunkGrid.this[int y, int x].get -> Parquet.Regions.MapChunk
 Parquet.Regions.RegionModel
@@ -805,19 +805,19 @@ Parquet.Regions.RegionModel.ExitCount() -> int
 Parquet.Regions.RegionModel.MapChunks.get -> Parquet.Regions.MapChunkGrid
 Parquet.Regions.RegionModel.RegionAbove.get -> Parquet.ModelID
 Parquet.Regions.RegionModel.RegionBelow.get -> Parquet.ModelID
-Parquet.Regions.RegionModel.RegionModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, string inBackgroundColor = "#FFFFFFFF", Parquet.ModelID? inRegionToTheNorth = null, Parquet.ModelID? inRegionToTheEast = null, Parquet.ModelID? inRegionToTheSouth = null, Parquet.ModelID? inRegionToTheWest = null, Parquet.ModelID? inRegionAbove = null, Parquet.ModelID? inRegionBelow = null) -> void
+Parquet.Regions.RegionModel.RegionModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, string backgroundColor = "#FFFFFFFF", Parquet.ModelID? regionToTheNorth = null, Parquet.ModelID? regionToTheEast = null, Parquet.ModelID? regionToTheSouth = null, Parquet.ModelID? regionToTheWest = null, Parquet.ModelID? regionAbove = null, Parquet.ModelID? regionBelow = null) -> void
 Parquet.Regions.RegionModel.RegionToTheEast.get -> Parquet.ModelID
 Parquet.Regions.RegionModel.RegionToTheNorth.get -> Parquet.ModelID
 Parquet.Regions.RegionModel.RegionToTheSouth.get -> Parquet.ModelID
 Parquet.Regions.RegionModel.RegionToTheWest.get -> Parquet.ModelID
 Parquet.Regions.RegionStatus
 Parquet.Regions.RegionStatus.GetBiome() -> Parquet.ModelID
-Parquet.Regions.RegionStatus.IsValidPosition(Parquet.Point2D inPosition) -> bool
+Parquet.Regions.RegionStatus.IsValidPosition(Parquet.Point2D position) -> bool
 Parquet.Regions.RegionStatus.ParquetModels.get -> Parquet.Parquets.ParquetModelPackGrid
 Parquet.Regions.RegionStatus.ParquetStatuses.get -> Parquet.Parquets.ParquetStatusPackGrid
 Parquet.Regions.RegionStatus.RegionStatus() -> void
-Parquet.Regions.RegionStatus.RegionStatus(Parquet.Parquets.ParquetModelPackGrid inParquetModels, Parquet.Parquets.ParquetStatusPackGrid inParquetStatuses) -> void
-Parquet.Regions.RegionStatus.RegionStatus(Parquet.Regions.RegionModel inRegionModel) -> void
+Parquet.Regions.RegionStatus.RegionStatus(Parquet.Parquets.ParquetModelPackGrid parquetModels, Parquet.Parquets.ParquetStatusPackGrid parquetStatuses) -> void
+Parquet.Regions.RegionStatus.RegionStatus(Parquet.Regions.RegionModel regionModel) -> void
 Parquet.Regions.RegionStatus.Rooms.get -> System.Collections.Generic.IReadOnlyCollection<Parquet.Rooms.Room>
 Parquet.Regions.RegionStatus.UpdateRoomCollection() -> void
 Parquet.Rooms.IMutableRoomRecipe
@@ -829,12 +829,12 @@ Parquet.Rooms.IMutableRoomRecipe.OptionallyRequiredWalkableFloors.get -> System.
 Parquet.Rooms.MapSpace
 Parquet.Rooms.MapSpace.Content.get -> Parquet.Parquets.ParquetModelPack
 Parquet.Rooms.MapSpace.EastNeighbor() -> Parquet.Rooms.MapSpace
-Parquet.Rooms.MapSpace.Equals(Parquet.Rooms.MapSpace inSpace) -> bool
+Parquet.Rooms.MapSpace.Equals(Parquet.Rooms.MapSpace space) -> bool
 Parquet.Rooms.MapSpace.Grid.get -> Parquet.Parquets.ParquetModelPackGrid
 Parquet.Rooms.MapSpace.IsEmpty.get -> bool
 Parquet.Rooms.MapSpace.IsEnclosing.get -> bool
-Parquet.Rooms.MapSpace.MapSpace(int inX, int inY, Parquet.Parquets.ParquetModelPack inContent, Parquet.Parquets.ParquetModelPackGrid inGrid) -> void
-Parquet.Rooms.MapSpace.MapSpace(Parquet.Point2D inPosition, Parquet.Parquets.ParquetModelPack inContent, Parquet.Parquets.ParquetModelPackGrid inGrid) -> void
+Parquet.Rooms.MapSpace.MapSpace(int x, int y, Parquet.Parquets.ParquetModelPack content, Parquet.Parquets.ParquetModelPackGrid grid) -> void
+Parquet.Rooms.MapSpace.MapSpace(Parquet.Point2D position, Parquet.Parquets.ParquetModelPack content, Parquet.Parquets.ParquetModelPackGrid grid) -> void
 Parquet.Rooms.MapSpace.Neighbor(Parquet.Point2D inOffset) -> Parquet.Rooms.MapSpace
 Parquet.Rooms.MapSpace.Neighbors() -> System.Collections.Generic.IReadOnlyList<Parquet.Rooms.MapSpace>
 Parquet.Rooms.MapSpace.NorthNeighbor() -> Parquet.Rooms.MapSpace
@@ -844,23 +844,23 @@ Parquet.Rooms.MapSpace.WestNeighbor() -> Parquet.Rooms.MapSpace
 Parquet.Rooms.MapSpaceSetExtensions
 Parquet.Rooms.ReadOnlyRoomCollectionExtensions
 Parquet.Rooms.Room
-Parquet.Rooms.Room.ContainsPosition(Parquet.Point2D inPosition) -> bool
-Parquet.Rooms.Room.Equals(Parquet.Rooms.Room inRoom) -> bool
+Parquet.Rooms.Room.ContainsPosition(Parquet.Point2D position) -> bool
+Parquet.Rooms.Room.Equals(Parquet.Rooms.Room room) -> bool
 Parquet.Rooms.Room.FurnishingTags.get -> System.Collections.Generic.IEnumerable<Parquet.ModelTag>
 Parquet.Rooms.Room.Perimeter.get -> System.Collections.Generic.IReadOnlySet<Parquet.Rooms.MapSpace>
 Parquet.Rooms.Room.Position.get -> Parquet.Point2D
 Parquet.Rooms.Room.RecipeID.get -> Parquet.ModelID
-Parquet.Rooms.Room.Room(System.Collections.Generic.IReadOnlySet<Parquet.Rooms.MapSpace> inWalkableArea, System.Collections.Generic.IReadOnlySet<Parquet.Rooms.MapSpace> inPerimeter) -> void
+Parquet.Rooms.Room.Room(System.Collections.Generic.IReadOnlySet<Parquet.Rooms.MapSpace> walkableArea, System.Collections.Generic.IReadOnlySet<Parquet.Rooms.MapSpace> perimeter) -> void
 Parquet.Rooms.Room.WalkableArea.get -> System.Collections.Generic.IReadOnlySet<Parquet.Rooms.MapSpace>
 Parquet.Rooms.RoomConfiguration
 Parquet.Rooms.RoomRecipe
-Parquet.Rooms.RoomRecipe.Matches(Parquet.Rooms.Room inRoom) -> bool
+Parquet.Rooms.RoomRecipe.Matches(Parquet.Rooms.Room room) -> bool
 Parquet.Rooms.RoomRecipe.MinimumWalkableSpaces.get -> int
 Parquet.Rooms.RoomRecipe.OptionallyRequiredFurnishings.get -> System.Collections.Generic.IReadOnlyList<Parquet.RecipeElement>
 Parquet.Rooms.RoomRecipe.OptionallyRequiredPerimeterBlocks.get -> System.Collections.Generic.IReadOnlyList<Parquet.RecipeElement>
 Parquet.Rooms.RoomRecipe.OptionallyRequiredWalkableFloors.get -> System.Collections.Generic.IReadOnlyList<Parquet.RecipeElement>
 Parquet.Rooms.RoomRecipe.Priority.get -> int
-Parquet.Rooms.RoomRecipe.RoomRecipe(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, int? inMinimumWalkableSpaces = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredFurnishings = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredWalkableFloors = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredPerimeterBlocks = null) -> void
+Parquet.Rooms.RoomRecipe.RoomRecipe(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, int? minimumWalkableSpaces = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> optionallyRequiredFurnishings = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> optionallyRequiredWalkableFloors = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> optionallyRequiredPerimeterBlocks = null) -> void
 Parquet.Scripts.Commands
 Parquet.Scripts.IMutableInteractionModel
 Parquet.Scripts.IMutableInteractionModel.OutcomesIDs.get -> System.Collections.Generic.ICollection<Parquet.ModelID>
@@ -869,14 +869,14 @@ Parquet.Scripts.IMutableInteractionModel.StepsIDs.get -> System.Collections.Gene
 Parquet.Scripts.IMutableScriptModel
 Parquet.Scripts.IMutableScriptModel.Nodes.get -> System.Collections.Generic.ICollection<Parquet.Scripts.ScriptNode>
 Parquet.Scripts.InteractionModel
-Parquet.Scripts.InteractionModel.InteractionModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inPrerequisitesIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inStepsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inOutcomesIDs = null) -> void
+Parquet.Scripts.InteractionModel.InteractionModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> prerequisitesIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> stepsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> outcomesIDs = null) -> void
 Parquet.Scripts.InteractionModel.OutcomesIDs.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelID>
 Parquet.Scripts.InteractionModel.PrerequisitesIDs.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelID>
 Parquet.Scripts.InteractionModel.StepsIDs.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelID>
 Parquet.Scripts.InteractionStatus
 Parquet.Scripts.InteractionStatus.InteractionStatus() -> void
-Parquet.Scripts.InteractionStatus.InteractionStatus(Parquet.Scripts.InteractionModel inScript) -> void
-Parquet.Scripts.InteractionStatus.InteractionStatus(Parquet.Scripts.RunState inState, int inProgramCounter) -> void
+Parquet.Scripts.InteractionStatus.InteractionStatus(Parquet.Scripts.InteractionModel script) -> void
+Parquet.Scripts.InteractionStatus.InteractionStatus(Parquet.Scripts.RunState state, int programCounter) -> void
 Parquet.Scripts.InteractionStatus.State.get -> Parquet.Scripts.RunState
 Parquet.Scripts.InteractionStatus.State.set -> void
 Parquet.Scripts.InteractionStatus.StepCounter.get -> int
@@ -888,7 +888,7 @@ Parquet.Scripts.RunState.Unstarted = 0 -> Parquet.Scripts.RunState
 Parquet.Scripts.ScriptModel
 Parquet.Scripts.ScriptModel.GetActions() -> System.Collections.Generic.IEnumerable<System.Action>
 Parquet.Scripts.ScriptModel.Nodes.get -> System.Collections.Generic.IReadOnlyList<Parquet.Scripts.ScriptNode>
-Parquet.Scripts.ScriptModel.ScriptModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, System.Collections.Generic.IEnumerable<Parquet.Scripts.ScriptNode> inNodes = null) -> void
+Parquet.Scripts.ScriptModel.ScriptModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, System.Collections.Generic.IEnumerable<Parquet.Scripts.ScriptNode> nodes = null) -> void
 Parquet.Scripts.ScriptNode
 Parquet.Scripts.ScriptNode.CompareTo(Parquet.Scripts.ScriptNode tag) -> int
 Parquet.Scripts.ScriptNode.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
@@ -899,12 +899,12 @@ Parquet.Scripts.ScriptStatus
 Parquet.Scripts.ScriptStatus.ProgramCounter.get -> int
 Parquet.Scripts.ScriptStatus.ProgramCounter.set -> void
 Parquet.Scripts.ScriptStatus.ScriptStatus() -> void
-Parquet.Scripts.ScriptStatus.ScriptStatus(Parquet.Scripts.RunState inState, int inProgramCounter) -> void
-Parquet.Scripts.ScriptStatus.ScriptStatus(Parquet.Scripts.ScriptModel inScript) -> void
+Parquet.Scripts.ScriptStatus.ScriptStatus(Parquet.Scripts.RunState state, int programCounter) -> void
+Parquet.Scripts.ScriptStatus.ScriptStatus(Parquet.Scripts.ScriptModel script) -> void
 Parquet.Scripts.ScriptStatus.State.get -> Parquet.Scripts.RunState
 Parquet.Scripts.ScriptStatus.State.set -> void
 Parquet.SeriesConverter<TElement, TCollection>
-Parquet.SeriesConverter<TElement, TCollection>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData, string inDelimiter) -> object
+Parquet.SeriesConverter<TElement, TCollection>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData, string delimiter) -> object
 Parquet.SeriesConverter<TElement, TCollection>.SeriesConverter() -> void
 Parquet.Status<T>
 Parquet.Status<T>.DeepClone() -> Parquet.Status<T>
@@ -973,7 +973,7 @@ static Parquet.Crafts.CraftConfiguration.PutRecord() -> void
 static Parquet.Crafts.CraftingRecipe.NotCraftable.get -> Parquet.Crafts.CraftingRecipe
 static Parquet.Crafts.StrikePanel.operator !=(Parquet.Crafts.StrikePanel strikePanel1, Parquet.Crafts.StrikePanel strikePanel2) -> bool
 static Parquet.Crafts.StrikePanel.operator ==(Parquet.Crafts.StrikePanel strikePanel1, Parquet.Crafts.StrikePanel strikePanel2) -> bool
-static Parquet.Crafts.StrikePanelArrayExtensions.IsValidPosition(this Parquet.Crafts.StrikePanel[,] inStrikePanels, Parquet.Point2D inPosition) -> bool
+static Parquet.Crafts.StrikePanelArrayExtensions.IsValidPosition(this Parquet.Crafts.StrikePanel[,] strikePanels, Parquet.Point2D position) -> bool
 static Parquet.Crafts.StrikePanelGrid.Empty.get -> Parquet.Crafts.StrikePanelGrid
 static Parquet.Games.GameModel.Empty.get -> Parquet.Games.GameModel
 static Parquet.Games.GameStatus.Default.get -> Parquet.Games.GameStatus
@@ -995,26 +995,26 @@ static Parquet.Items.InventorySlot.operator ==(Parquet.Items.InventorySlot statu
 static Parquet.LibraryState.IsPlayMode.get -> bool
 static Parquet.LibraryState.IsPlayMode.set -> void
 static Parquet.Location.Nowhere.get -> Parquet.Location
-static Parquet.Location.operator !=(Parquet.Location inLocation1, Parquet.Location inLocation2) -> bool
-static Parquet.Location.operator ==(Parquet.Location inLocation1, Parquet.Location inLocation2) -> bool
-static Parquet.Logger.Log(Parquet.LogLevel inLogLevel, object inObject) -> void
-static Parquet.Logger.Log(Parquet.LogLevel inLogLevel, string inMessage = null, System.Exception inException = null) -> void
-static Parquet.Logger.SetLogger(Parquet.ILogger inLoggerToUse) -> void
-static Parquet.Model.operator !=(Parquet.Model inModel1, Parquet.Model inModel2) -> bool
-static Parquet.Model.operator ==(Parquet.Model inModel1, Parquet.Model inModel2) -> bool
+static Parquet.Location.operator !=(Parquet.Location location1, Parquet.Location location2) -> bool
+static Parquet.Location.operator ==(Parquet.Location location1, Parquet.Location location2) -> bool
+static Parquet.Logger.Log(Parquet.LogLevel logLevel, object objectToLog) -> void
+static Parquet.Logger.Log(Parquet.LogLevel logLevel, string message = null, System.Exception exception = null) -> void
+static Parquet.Logger.SetLogger(Parquet.ILogger loggerToUse) -> void
+static Parquet.Model.operator !=(Parquet.Model model1, Parquet.Model model2) -> bool
+static Parquet.Model.operator ==(Parquet.Model model1, Parquet.Model model2) -> bool
 static Parquet.ModelCollection.GetFilePath<TModel>() -> string
-static Parquet.ModelID.implicit operator int(Parquet.ModelID inIDentifier) -> int
+static Parquet.ModelID.implicit operator int(Parquet.ModelID id) -> int
 static Parquet.ModelID.implicit operator Parquet.ModelID(int value) -> Parquet.ModelID
-static Parquet.ModelID.operator !=(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
-static Parquet.ModelID.operator <(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
-static Parquet.ModelID.operator <=(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
-static Parquet.ModelID.operator ==(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
-static Parquet.ModelID.operator >(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
-static Parquet.ModelID.operator >=(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
+static Parquet.ModelID.operator !=(Parquet.ModelID id1, Parquet.ModelID id2) -> bool
+static Parquet.ModelID.operator <(Parquet.ModelID id1, Parquet.ModelID id2) -> bool
+static Parquet.ModelID.operator <=(Parquet.ModelID id1, Parquet.ModelID id2) -> bool
+static Parquet.ModelID.operator ==(Parquet.ModelID id1, Parquet.ModelID id2) -> bool
+static Parquet.ModelID.operator >(Parquet.ModelID id1, Parquet.ModelID id2) -> bool
+static Parquet.ModelID.operator >=(Parquet.ModelID id1, Parquet.ModelID id2) -> bool
 static Parquet.ModelIDGrid.Empty.get -> Parquet.ModelIDGrid
 static Parquet.ModelTag.implicit operator Parquet.ModelTag(string value) -> Parquet.ModelTag
 static Parquet.ModelTag.implicit operator string(Parquet.ModelTag tag) -> string
-static Parquet.PackArrayExtensions.IsValidPosition<T>(this Parquet.Pack<T>[,] inArray, Parquet.Point2D inPosition) -> bool
+static Parquet.PackArrayExtensions.IsValidPosition<T>(this Parquet.Pack<T>[,] array, Parquet.Point2D position) -> bool
 static Parquet.Parquets.BlockModel.Bounds.get -> Parquet.Range<Parquet.ModelID>
 static Parquet.Parquets.BlockStatus.Default.get -> Parquet.Parquets.BlockStatus
 static Parquet.Parquets.BlockStatus.operator !=(Parquet.Parquets.BlockStatus status1, Parquet.Parquets.BlockStatus status2) -> bool
@@ -1029,48 +1029,48 @@ static Parquet.Parquets.FurnishingStatus.Default.get -> Parquet.Parquets.Furnish
 static Parquet.Parquets.FurnishingStatus.operator !=(Parquet.Parquets.FurnishingStatus status1, Parquet.Parquets.FurnishingStatus status2) -> bool
 static Parquet.Parquets.FurnishingStatus.operator ==(Parquet.Parquets.FurnishingStatus status1, Parquet.Parquets.FurnishingStatus status2) -> bool
 static Parquet.Parquets.ParquetModelPack.Empty.get -> Parquet.Parquets.ParquetModelPack
-static Parquet.Parquets.ParquetModelPack.operator !=(Parquet.Parquets.ParquetModelPack inPack1, Parquet.Parquets.ParquetModelPack inPack2) -> bool
-static Parquet.Parquets.ParquetModelPack.operator ==(Parquet.Parquets.ParquetModelPack inPack1, Parquet.Parquets.ParquetModelPack inPack2) -> bool
+static Parquet.Parquets.ParquetModelPack.operator !=(Parquet.Parquets.ParquetModelPack pack1, Parquet.Parquets.ParquetModelPack pack2) -> bool
+static Parquet.Parquets.ParquetModelPack.operator ==(Parquet.Parquets.ParquetModelPack pack1, Parquet.Parquets.ParquetModelPack pack2) -> bool
 static Parquet.Parquets.ParquetModelPackGrid.Empty.get -> Parquet.Parquets.ParquetModelPackGrid
 static Parquet.Parquets.ParquetStatusPack.Default.get -> Parquet.Parquets.ParquetStatusPack
-static Parquet.Parquets.ParquetStatusPack.operator !=(Parquet.Parquets.ParquetStatusPack inPack1, Parquet.Parquets.ParquetStatusPack inPack2) -> bool
-static Parquet.Parquets.ParquetStatusPack.operator ==(Parquet.Parquets.ParquetStatusPack inPack1, Parquet.Parquets.ParquetStatusPack inPack2) -> bool
+static Parquet.Parquets.ParquetStatusPack.operator !=(Parquet.Parquets.ParquetStatusPack pack1, Parquet.Parquets.ParquetStatusPack pack2) -> bool
+static Parquet.Parquets.ParquetStatusPack.operator ==(Parquet.Parquets.ParquetStatusPack pack1, Parquet.Parquets.ParquetStatusPack pack2) -> bool
 static Parquet.Parquets.ParquetStatusPackGrid.Empty.get -> Parquet.Parquets.ParquetStatusPackGrid
-static Parquet.Point2D.operator !=(Parquet.Point2D inPoint1, Parquet.Point2D inPoint2) -> bool
-static Parquet.Point2D.operator *(int inScalar, Parquet.Point2D inPoint) -> Parquet.Point2D
-static Parquet.Point2D.operator +(Parquet.Point2D inPoint1, Parquet.Point2D inPoint2) -> Parquet.Point2D
-static Parquet.Point2D.operator -(Parquet.Point2D inPoint1, Parquet.Point2D inPoint2) -> Parquet.Point2D
-static Parquet.Point2D.operator ==(Parquet.Point2D inPoint1, Parquet.Point2D inPoint2) -> bool
-static Parquet.Precondition.AreInRange(System.Collections.Generic.IEnumerable<Parquet.ModelID> inEnumerable, Parquet.Range<Parquet.ModelID> inBounds, string inArgumentName) -> void
-static Parquet.Precondition.AreInRange(System.Collections.Generic.IEnumerable<Parquet.ModelID> inEnumerable, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBoundsCollection, string inArgumentName) -> void
-static Parquet.Precondition.IsInRange(int inInt, Parquet.Range<int> inBounds, string inArgumentName) -> void
-static Parquet.Precondition.IsInRange(Parquet.ModelID id, Parquet.Range<Parquet.ModelID> inBounds, string inArgumentName) -> void
-static Parquet.Precondition.IsInRange(Parquet.ModelID id, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBoundsCollection, string inArgumentName) -> void
-static Parquet.Precondition.IsInRange(Parquet.Range<Parquet.ModelID> inInnerBounds, Parquet.Range<Parquet.ModelID> inOuterBounds, string inArgumentName) -> void
-static Parquet.Precondition.IsInRange(Parquet.Range<Parquet.ModelID> inInnerBounds, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBoundsCollection, string inArgumentName) -> void
-static Parquet.Precondition.IsNotNone(Parquet.ModelID id, string inArgumentName = "Argument") -> void
-static Parquet.Precondition.IsNotNull(object inReference, string inArgumentName = "Argument") -> void
-static Parquet.Precondition.IsNotNullOrEmpty(string inString, string inArgumentName) -> void
-static Parquet.Precondition.IsNotNullOrEmpty<TElement>(System.Collections.Generic.IEnumerable<TElement> inEnumerable, string inArgumentName) -> void
-static Parquet.Precondition.IsOfType<TToCheck, TTarget>(string inArgumentName = "Argument") -> void
-static Parquet.Precondition.MustBeNonNegative(int inNumber, string inArgumentName = "Argument") -> void
-static Parquet.Precondition.MustBePositive(int inNumber, string inArgumentName = "Argument") -> void
-static Parquet.Range<TElement>.operator !=(Parquet.Range<TElement> inRange1, Parquet.Range<TElement> inRange2) -> bool
-static Parquet.Range<TElement>.operator ==(Parquet.Range<TElement> inRange1, Parquet.Range<TElement> inRange2) -> bool
-static Parquet.RangeCollectionExtensions.ContainsRange<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> inRangeCollection, Parquet.Range<TElement> inRange) -> bool
-static Parquet.RangeCollectionExtensions.ContainsValue<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> inRangeCollection, TElement value) -> bool
-static Parquet.RangeCollectionExtensions.IsValid<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> inRangeCollection) -> bool
-static Parquet.RecipeElement.operator !=(Parquet.RecipeElement inElement1, Parquet.RecipeElement inElement2) -> bool
-static Parquet.RecipeElement.operator ==(Parquet.RecipeElement inElement1, Parquet.RecipeElement inElement2) -> bool
-static Parquet.Regions.ChunkDetail.operator !=(Parquet.Regions.ChunkDetail inChunkType1, Parquet.Regions.ChunkDetail inChunkType2) -> bool
-static Parquet.Regions.ChunkDetail.operator ==(Parquet.Regions.ChunkDetail inChunkType1, Parquet.Regions.ChunkDetail inChunkType2) -> bool
+static Parquet.Point2D.operator !=(Parquet.Point2D point1, Parquet.Point2D point2) -> bool
+static Parquet.Point2D.operator *(int scalar, Parquet.Point2D point) -> Parquet.Point2D
+static Parquet.Point2D.operator +(Parquet.Point2D point1, Parquet.Point2D point2) -> Parquet.Point2D
+static Parquet.Point2D.operator -(Parquet.Point2D point1, Parquet.Point2D point2) -> Parquet.Point2D
+static Parquet.Point2D.operator ==(Parquet.Point2D point1, Parquet.Point2D point2) -> bool
+static Parquet.Precondition.AreInRange(System.Collections.Generic.IEnumerable<Parquet.ModelID> enumerable, Parquet.Range<Parquet.ModelID> bounds, string argumentName) -> void
+static Parquet.Precondition.AreInRange(System.Collections.Generic.IEnumerable<Parquet.ModelID> enumerable, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> boundsCollection, string argumentName) -> void
+static Parquet.Precondition.IsInRange(int integerToTest, Parquet.Range<int> bounds, string argumentName) -> void
+static Parquet.Precondition.IsInRange(Parquet.ModelID id, Parquet.Range<Parquet.ModelID> bounds, string argumentName) -> void
+static Parquet.Precondition.IsInRange(Parquet.ModelID id, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> boundsCollection, string argumentName) -> void
+static Parquet.Precondition.IsInRange(Parquet.Range<Parquet.ModelID> innerBounds, Parquet.Range<Parquet.ModelID> outerBounds, string argumentName) -> void
+static Parquet.Precondition.IsInRange(Parquet.Range<Parquet.ModelID> innerBounds, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> boundsCollection, string argumentName) -> void
+static Parquet.Precondition.IsNotNone(Parquet.ModelID id, string argumentName = "Argument") -> void
+static Parquet.Precondition.IsNotNull(object reference, string argumentName = "Argument") -> void
+static Parquet.Precondition.IsNotNullOrEmpty(string stringToTest, string argumentName) -> void
+static Parquet.Precondition.IsNotNullOrEmpty<TElement>(System.Collections.Generic.IEnumerable<TElement> enumerable, string argumentName) -> void
+static Parquet.Precondition.IsOfType<TToCheck, TTarget>(string argumentName = "Argument") -> void
+static Parquet.Precondition.MustBeNonNegative(int number, string argumentName = "Argument") -> void
+static Parquet.Precondition.MustBePositive(int number, string argumentName = "Argument") -> void
+static Parquet.Range<TElement>.operator !=(Parquet.Range<TElement> range1, Parquet.Range<TElement> range2) -> bool
+static Parquet.Range<TElement>.operator ==(Parquet.Range<TElement> range1, Parquet.Range<TElement> range2) -> bool
+static Parquet.RangeCollectionExtensions.ContainsRange<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> rangeCollection, Parquet.Range<TElement> rangeSought) -> bool
+static Parquet.RangeCollectionExtensions.ContainsValue<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> rangeCollection, TElement value) -> bool
+static Parquet.RangeCollectionExtensions.IsValid<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> rangeCollection) -> bool
+static Parquet.RecipeElement.operator !=(Parquet.RecipeElement element1, Parquet.RecipeElement element2) -> bool
+static Parquet.RecipeElement.operator ==(Parquet.RecipeElement element1, Parquet.RecipeElement element2) -> bool
+static Parquet.Regions.ChunkDetail.operator !=(Parquet.Regions.ChunkDetail chunkType1, Parquet.Regions.ChunkDetail chunkType2) -> bool
+static Parquet.Regions.ChunkDetail.operator ==(Parquet.Regions.ChunkDetail chunkType1, Parquet.Regions.ChunkDetail chunkType2) -> bool
 static Parquet.Regions.MapChunk.Empty.get -> Parquet.Regions.MapChunk
-static Parquet.Regions.MapChunk.operator !=(Parquet.Regions.MapChunk inChunk1, Parquet.Regions.MapChunk inChunk2) -> bool
-static Parquet.Regions.MapChunk.operator ==(Parquet.Regions.MapChunk inChunk1, Parquet.Regions.MapChunk inChunk2) -> bool
-static Parquet.Regions.MapChunkArrayExtensions.IsValidPosition(this Parquet.Regions.MapChunk[,] inArray, Parquet.Point2D inPosition) -> bool
+static Parquet.Regions.MapChunk.operator !=(Parquet.Regions.MapChunk chunk1, Parquet.Regions.MapChunk chunk2) -> bool
+static Parquet.Regions.MapChunk.operator ==(Parquet.Regions.MapChunk chunk1, Parquet.Regions.MapChunk chunk2) -> bool
+static Parquet.Regions.MapChunkArrayExtensions.IsValidPosition(this Parquet.Regions.MapChunk[,] array, Parquet.Point2D position) -> bool
 static Parquet.Regions.MapChunkGrid.Empty.get -> Parquet.Regions.MapChunkGrid
 static Parquet.Regions.RegionModel.Bounds.get -> Parquet.Range<Parquet.ModelID>
-static Parquet.Regions.RegionModel.CheckExitConsistency(Parquet.ModelID inRegionID) -> System.Collections.Generic.ICollection<string>
+static Parquet.Regions.RegionModel.CheckExitConsistency(Parquet.ModelID regionID) -> System.Collections.Generic.ICollection<string>
 static Parquet.Regions.RegionModel.DimensionsInChunks.get -> Parquet.Point2D
 static Parquet.Regions.RegionStatus.DimensionsInParquets.get -> Parquet.Point2D
 static Parquet.Regions.RegionStatus.FilePath.get -> string
@@ -1079,17 +1079,17 @@ static Parquet.Regions.RegionStatus.operator !=(Parquet.Regions.RegionStatus sta
 static Parquet.Regions.RegionStatus.operator ==(Parquet.Regions.RegionStatus status1, Parquet.Regions.RegionStatus status2) -> bool
 static Parquet.Regions.RegionStatus.PutRecords(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Parquet.ModelID, Parquet.Regions.RegionStatus>> inRegionStatuses) -> void
 static Parquet.Regions.RegionStatus.Unused.get -> Parquet.Regions.RegionStatus
-static Parquet.Rooms.MapSpace.operator !=(Parquet.Rooms.MapSpace inSpace1, Parquet.Rooms.MapSpace inSpace2) -> bool
-static Parquet.Rooms.MapSpace.operator ==(Parquet.Rooms.MapSpace inSpace1, Parquet.Rooms.MapSpace inSpace2) -> bool
-static Parquet.Rooms.ReadOnlyRoomCollectionExtensions.GetRoomAtOrNull(this System.Collections.Generic.IReadOnlyCollection<Parquet.Rooms.Room> inRooms, Parquet.Point2D inPosition) -> Parquet.Rooms.Room
-static Parquet.Rooms.ReadOnlyRoomCollectionExtensions.ToString(this System.Collections.Generic.IReadOnlyCollection<Parquet.Rooms.Room> inRooms) -> string
-static Parquet.Rooms.Room.operator !=(Parquet.Rooms.Room inRoom1, Parquet.Rooms.Room inRoom2) -> bool
-static Parquet.Rooms.Room.operator ==(Parquet.Rooms.Room inRoom1, Parquet.Rooms.Room inRoom2) -> bool
+static Parquet.Rooms.MapSpace.operator !=(Parquet.Rooms.MapSpace space1, Parquet.Rooms.MapSpace space2) -> bool
+static Parquet.Rooms.MapSpace.operator ==(Parquet.Rooms.MapSpace space1, Parquet.Rooms.MapSpace space2) -> bool
+static Parquet.Rooms.ReadOnlyRoomCollectionExtensions.GetRoomAtOrNull(this System.Collections.Generic.IReadOnlyCollection<Parquet.Rooms.Room> rooms, Parquet.Point2D position) -> Parquet.Rooms.Room
+static Parquet.Rooms.ReadOnlyRoomCollectionExtensions.ToString(this System.Collections.Generic.IReadOnlyCollection<Parquet.Rooms.Room> rooms) -> string
+static Parquet.Rooms.Room.operator !=(Parquet.Rooms.Room room1, Parquet.Rooms.Room room2) -> bool
+static Parquet.Rooms.Room.operator ==(Parquet.Rooms.Room room1, Parquet.Rooms.Room room2) -> bool
 static Parquet.Rooms.RoomConfiguration.FilePath.get -> string
 static Parquet.Rooms.RoomConfiguration.GetRecord() -> void
 static Parquet.Rooms.RoomConfiguration.MaxWalkableSpaces.get -> int
 static Parquet.Rooms.RoomConfiguration.MaxWalkableSpaces.set -> void
-static Parquet.Rooms.RoomConfiguration.MinPerimeterSpaces.get -> int
+static Parquet.Rooms.RoomConfiguration.MperimeterSpaces.get -> int
 static Parquet.Rooms.RoomConfiguration.MinWalkableSpaces.get -> int
 static Parquet.Rooms.RoomConfiguration.MinWalkableSpaces.set -> void
 static Parquet.Rooms.RoomConfiguration.PutRecord() -> void
@@ -1097,11 +1097,11 @@ static Parquet.Scripts.InteractionStatus.operator !=(Parquet.Scripts.Interaction
 static Parquet.Scripts.InteractionStatus.operator ==(Parquet.Scripts.InteractionStatus status1, Parquet.Scripts.InteractionStatus status2) -> bool
 static Parquet.Scripts.InteractionStatus.Unstarted.get -> Parquet.Scripts.InteractionStatus
 static Parquet.Scripts.ScriptNode.implicit operator Parquet.Scripts.ScriptNode(string value) -> Parquet.Scripts.ScriptNode
-static Parquet.Scripts.ScriptNode.implicit operator string(Parquet.Scripts.ScriptNode inNode) -> string
+static Parquet.Scripts.ScriptNode.implicit operator string(Parquet.Scripts.ScriptNode node) -> string
 static Parquet.Scripts.ScriptStatus.operator !=(Parquet.Scripts.ScriptStatus status1, Parquet.Scripts.ScriptStatus status2) -> bool
 static Parquet.Scripts.ScriptStatus.operator ==(Parquet.Scripts.ScriptStatus status1, Parquet.Scripts.ScriptStatus status2) -> bool
 static Parquet.Scripts.ScriptStatus.Unstarted.get -> Parquet.Scripts.ScriptStatus
-static Parquet.StatusArrayExtensions.IsValidPosition<T>(this Parquet.Status<T>[,] inArray, Parquet.Point2D inPosition) -> bool
+static Parquet.StatusArrayExtensions.IsValidPosition<T>(this Parquet.Status<T>[,] array, Parquet.Point2D position) -> bool
 static readonly Parquet.All.AllDefinedIDs -> System.Collections.Generic.IReadOnlyList<Parquet.Range<Parquet.ModelID>>
 static readonly Parquet.All.BeingIDs -> System.Collections.Generic.IReadOnlyList<Parquet.Range<Parquet.ModelID>>
 static readonly Parquet.All.BiomeRecipeIDs -> Parquet.Range<Parquet.ModelID>

--- a/ParquetClassLibrary/PublicAPI.Unshipped.txt
+++ b/ParquetClassLibrary/PublicAPI.Unshipped.txt
@@ -1,11 +1,11 @@
-abstract Parquet.Pack<T>.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-abstract Parquet.Pack<T>.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+abstract Parquet.Pack<T>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+abstract Parquet.Pack<T>.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 abstract Parquet.Pack<T>.DeepClone<TDerived>() -> TDerived
 abstract Parquet.Pack<T>.Equals<TDerived>(TDerived inPack) -> bool
-abstract Parquet.Status<T>.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-abstract Parquet.Status<T>.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+abstract Parquet.Status<T>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+abstract Parquet.Status<T>.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 abstract Parquet.Status<T>.DeepClone<TDerived>() -> TDerived
-abstract Parquet.Status<T>.Equals<TDerived>(TDerived inStatus) -> bool
+abstract Parquet.Status<T>.Equals<TDerived>(TDerived status) -> bool
 const Parquet.Beings.PronounGroup.DefaultKey = "they/them" -> string
 const Parquet.Beings.PronounGroup.DeterminerTag = "|their|" -> string
 const Parquet.Beings.PronounGroup.ObjectiveTag = "|them|" -> string
@@ -52,18 +52,18 @@ override abstract Parquet.Pack<T>.Equals(object obj) -> bool
 override abstract Parquet.Pack<T>.GetHashCode() -> int
 override abstract Parquet.Status<T>.Equals(object obj) -> bool
 override abstract Parquet.Status<T>.GetHashCode() -> int
-override Parquet.Beings.CharacterStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Beings.CharacterStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Beings.CharacterStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Beings.CharacterStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Beings.CharacterStatus.DeepClone<T>() -> T
 override Parquet.Beings.CharacterStatus.Equals(object obj) -> bool
-override Parquet.Beings.CharacterStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Beings.CharacterStatus.Equals<T>(T status) -> bool
 override Parquet.Beings.CharacterStatus.GetHashCode() -> int
 override Parquet.Beings.CharacterStatus.ToString() -> string
-override Parquet.Beings.CritterStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Beings.CritterStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Beings.CritterStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Beings.CritterStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Beings.CritterStatus.DeepClone<T>() -> T
 override Parquet.Beings.CritterStatus.Equals(object obj) -> bool
-override Parquet.Beings.CritterStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Beings.CritterStatus.Equals<T>(T status) -> bool
 override Parquet.Beings.CritterStatus.GetHashCode() -> int
 override Parquet.Beings.CritterStatus.ToString() -> string
 override Parquet.Beings.PronounGroup.ToString() -> string
@@ -71,23 +71,23 @@ override Parquet.Biomes.BiomeRecipe.GetAllTags() -> System.Collections.Generic.I
 override Parquet.Crafts.StrikePanel.Equals(object obj) -> bool
 override Parquet.Crafts.StrikePanel.GetHashCode() -> int
 override Parquet.Crafts.StrikePanel.ToString() -> string
-override Parquet.EmptyTolerantEnumConverter.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
+override Parquet.EmptyTolerantEnumConverter.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
 override Parquet.Games.GameModel.ToString() -> string
-override Parquet.Games.GameStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Games.GameStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Games.GameStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Games.GameStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Games.GameStatus.DeepClone<T>() -> T
 override Parquet.Games.GameStatus.Equals(object obj) -> bool
-override Parquet.Games.GameStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Games.GameStatus.Equals<T>(T status) -> bool
 override Parquet.Games.GameStatus.GetHashCode() -> int
 override Parquet.Games.GameStatus.ToString() -> string
-override Parquet.GridConverter<TElement, TGrid>.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.GridConverter<TElement, TGrid>.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.GridConverter<TElement, TGrid>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.GridConverter<TElement, TGrid>.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Items.InventoryCollection.ToString() -> string
-override Parquet.Items.InventorySlot.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Items.InventorySlot.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Items.InventorySlot.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Items.InventorySlot.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Items.InventorySlot.DeepClone<T>() -> T
 override Parquet.Items.InventorySlot.Equals(object obj) -> bool
-override Parquet.Items.InventorySlot.Equals<T>(T inStatus) -> bool
+override Parquet.Items.InventorySlot.Equals<T>(T status) -> bool
 override Parquet.Items.InventorySlot.GetHashCode() -> int
 override Parquet.Items.InventorySlot.ToString() -> string
 override Parquet.Items.ItemModel.GetAllTags() -> System.Collections.Generic.IEnumerable<Parquet.ModelTag>
@@ -102,38 +102,38 @@ override Parquet.ModelID.Equals(object obj) -> bool
 override Parquet.ModelID.GetHashCode() -> int
 override Parquet.ModelID.ToString() -> string
 override Parquet.ModelTag.ToString() -> string
-override Parquet.Parquets.BlockStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Parquets.BlockStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Parquets.BlockStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Parquets.BlockStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Parquets.BlockStatus.DeepClone<T>() -> T
 override Parquet.Parquets.BlockStatus.Equals(object obj) -> bool
-override Parquet.Parquets.BlockStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Parquets.BlockStatus.Equals<T>(T status) -> bool
 override Parquet.Parquets.BlockStatus.GetHashCode() -> int
 override Parquet.Parquets.BlockStatus.ToString() -> string
-override Parquet.Parquets.FloorStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Parquets.FloorStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Parquets.FloorStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Parquets.FloorStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Parquets.FloorStatus.DeepClone<T>() -> T
 override Parquet.Parquets.FloorStatus.Equals(object obj) -> bool
-override Parquet.Parquets.FloorStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Parquets.FloorStatus.Equals<T>(T status) -> bool
 override Parquet.Parquets.FloorStatus.GetHashCode() -> int
 override Parquet.Parquets.FloorStatus.ToString() -> string
-override Parquet.Parquets.FurnishingStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Parquets.FurnishingStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Parquets.FurnishingStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Parquets.FurnishingStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Parquets.FurnishingStatus.DeepClone<T>() -> T
 override Parquet.Parquets.FurnishingStatus.Equals(object obj) -> bool
-override Parquet.Parquets.FurnishingStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Parquets.FurnishingStatus.Equals<T>(T status) -> bool
 override Parquet.Parquets.FurnishingStatus.GetHashCode() -> int
 override Parquet.Parquets.FurnishingStatus.ToString() -> string
 override Parquet.Parquets.ParquetModel.GetAllTags() -> System.Collections.Generic.IEnumerable<Parquet.ModelTag>
-override Parquet.Parquets.ParquetModelPack.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Parquets.ParquetModelPack.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Parquets.ParquetModelPack.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Parquets.ParquetModelPack.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Parquets.ParquetModelPack.DeepClone() -> Parquet.Parquets.ParquetModelPack
 override Parquet.Parquets.ParquetModelPack.DeepClone<T>() -> T
 override Parquet.Parquets.ParquetModelPack.Equals(object obj) -> bool
 override Parquet.Parquets.ParquetModelPack.Equals<T>(T inPack) -> bool
 override Parquet.Parquets.ParquetModelPack.GetHashCode() -> int
 override Parquet.Parquets.ParquetModelPack.ToString() -> string
-override Parquet.Parquets.ParquetStatusPack.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Parquets.ParquetStatusPack.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Parquets.ParquetStatusPack.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Parquets.ParquetStatusPack.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Parquets.ParquetStatusPack.DeepClone() -> Parquet.Parquets.ParquetStatusPack
 override Parquet.Parquets.ParquetStatusPack.DeepClone<T>() -> T
 override Parquet.Parquets.ParquetStatusPack.Equals(object obj) -> bool
@@ -156,11 +156,11 @@ override Parquet.Regions.MapChunk.Equals(object obj) -> bool
 override Parquet.Regions.MapChunk.GetHashCode() -> int
 override Parquet.Regions.MapChunk.ToString() -> string
 override Parquet.Regions.RegionModel.ToString() -> string
-override Parquet.Regions.RegionStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Regions.RegionStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Regions.RegionStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Regions.RegionStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Regions.RegionStatus.DeepClone<T>() -> T
 override Parquet.Regions.RegionStatus.Equals(object obj) -> bool
-override Parquet.Regions.RegionStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Regions.RegionStatus.Equals<T>(T status) -> bool
 override Parquet.Regions.RegionStatus.GetHashCode() -> int
 override Parquet.Regions.RegionStatus.ToString() -> string
 override Parquet.Rooms.MapSpace.Equals(object obj) -> bool
@@ -168,29 +168,29 @@ override Parquet.Rooms.MapSpace.GetHashCode() -> int
 override Parquet.Rooms.MapSpace.ToString() -> string
 override Parquet.Rooms.Room.Equals(object obj) -> bool
 override Parquet.Rooms.Room.GetHashCode() -> int
-override Parquet.Scripts.InteractionStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Scripts.InteractionStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Scripts.InteractionStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Scripts.InteractionStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Scripts.InteractionStatus.DeepClone<T>() -> T
 override Parquet.Scripts.InteractionStatus.Equals(object obj) -> bool
-override Parquet.Scripts.InteractionStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Scripts.InteractionStatus.Equals<T>(T status) -> bool
 override Parquet.Scripts.InteractionStatus.GetHashCode() -> int
 override Parquet.Scripts.InteractionStatus.ToString() -> string
 override Parquet.Scripts.ScriptNode.ToString() -> string
-override Parquet.Scripts.ScriptStatus.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.Scripts.ScriptStatus.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.Scripts.ScriptStatus.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.Scripts.ScriptStatus.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 override Parquet.Scripts.ScriptStatus.DeepClone<T>() -> T
 override Parquet.Scripts.ScriptStatus.Equals(object obj) -> bool
-override Parquet.Scripts.ScriptStatus.Equals<T>(T inStatus) -> bool
+override Parquet.Scripts.ScriptStatus.Equals<T>(T status) -> bool
 override Parquet.Scripts.ScriptStatus.GetHashCode() -> int
 override Parquet.Scripts.ScriptStatus.ToString() -> string
-override Parquet.SeriesConverter<TElement, TCollection>.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-override Parquet.SeriesConverter<TElement, TCollection>.ConvertToString(object inCollection, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+override Parquet.SeriesConverter<TElement, TCollection>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+override Parquet.SeriesConverter<TElement, TCollection>.ConvertToString(object inCollection, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.All
 Parquet.AssemblyInfo
 Parquet.AssemblyInfo.AssemblyInfo() -> void
 Parquet.Beings.BeingModel
 Parquet.Beings.BeingModel.AvoidsIDs.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelID>
-Parquet.Beings.BeingModel.BeingModel(Parquet.Range<Parquet.ModelID> inBounds, Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.ModelID? inNativeBiomeID = null, Parquet.ModelID? inPrimaryBehaviorID = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inAvoidsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inSeeksIDs = null) -> void
+Parquet.Beings.BeingModel.BeingModel(Parquet.Range<Parquet.ModelID> bounds, Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? nativeBiomeID = null, Parquet.ModelID? primaryBehaviorID = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> avoidsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> seeksIDs = null) -> void
 Parquet.Beings.BeingModel.NativeBiomeID.get -> Parquet.ModelID
 Parquet.Beings.BeingModel.NativeBiomeID.set -> void
 Parquet.Beings.BeingModel.PrimaryBehaviorID.get -> Parquet.ModelID
@@ -199,7 +199,7 @@ Parquet.Beings.BeingModel.SeeksIDs.get -> System.Collections.Generic.IReadOnlyLi
 Parquet.Beings.BeingStatus<T>
 Parquet.Beings.BeingStatus<T>.BeingStatus() -> void
 Parquet.Beings.CharacterModel
-Parquet.Beings.CharacterModel.CharacterModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.ModelID? inNativeBiomeID = null, Parquet.ModelID? inPrimaryBehaviorID = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inAvoidsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inSeeksIDs = null, string inPronounKey = "they/them", string inStoryCharacterID = "", Parquet.Location? inStartingLocation = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inStartingQuestIDs = null, Parquet.ModelID? inStartingDialogueID = null, Parquet.Items.InventoryCollection inStartingInventory = null) -> void
+Parquet.Beings.CharacterModel.CharacterModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? nativeBiomeID = null, Parquet.ModelID? primaryBehaviorID = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> avoidsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> seeksIDs = null, string pronounKey = "they/them", string storyCharacterID = "", Parquet.Location? startingLocation = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> startingQuestIDs = null, Parquet.ModelID? startingDialogueID = null, Parquet.Items.InventoryCollection startingInventory = null) -> void
 Parquet.Beings.CharacterModel.FamilyName.get -> string
 Parquet.Beings.CharacterModel.PersonalName.get -> string
 Parquet.Beings.CharacterModel.PronounKey.get -> string
@@ -211,8 +211,8 @@ Parquet.Beings.CharacterModel.StoryCharacterID.get -> string
 Parquet.Beings.CharacterStatus
 Parquet.Beings.CharacterStatus.BiomeTimeRemaining.get -> int
 Parquet.Beings.CharacterStatus.BiomeTimeRemaining.set -> void
-Parquet.Beings.CharacterStatus.CharacterStatus(Parquet.Beings.CharacterModel inCharacterModel) -> void
-Parquet.Beings.CharacterStatus.CharacterStatus(Parquet.Location? inPosition = null, Parquet.Location? inSpawnAt = null, Parquet.Location? inRoomAssignment = null, Parquet.ModelID? inCurrentBehavior = null, int inBiomeTimeRemaining = 2147483647, System.Collections.Generic.ICollection<Parquet.ModelID> inKnownBeings = null, System.Collections.Generic.ICollection<Parquet.ModelID> inKnownParquets = null, System.Collections.Generic.ICollection<Parquet.ModelID> inKnownRoomRecipes = null, System.Collections.Generic.ICollection<Parquet.ModelID> inKnownCraftingRecipes = null, System.Collections.Generic.ICollection<Parquet.ModelID> inQuests = null, Parquet.Items.InventoryCollection inInventory = null) -> void
+Parquet.Beings.CharacterStatus.CharacterStatus(Parquet.Beings.CharacterModel characterModel) -> void
+Parquet.Beings.CharacterStatus.CharacterStatus(Parquet.Location? position = null, Parquet.Location? spawnAt = null, Parquet.Location? roomAssignment = null, Parquet.ModelID? currentBehavior = null, int biomeTimeRemaining = 2147483647, System.Collections.Generic.ICollection<Parquet.ModelID> knownBeings = null, System.Collections.Generic.ICollection<Parquet.ModelID> knownParquets = null, System.Collections.Generic.ICollection<Parquet.ModelID> knownRoomRecipes = null, System.Collections.Generic.ICollection<Parquet.ModelID> knownCraftingRecipes = null, System.Collections.Generic.ICollection<Parquet.ModelID> quests = null, Parquet.Items.InventoryCollection inventory = null) -> void
 Parquet.Beings.CharacterStatus.CurrentBehaviorID.get -> Parquet.ModelID
 Parquet.Beings.CharacterStatus.CurrentBehaviorID.set -> void
 Parquet.Beings.CharacterStatus.Inventory.get -> Parquet.Items.InventoryCollection
@@ -228,10 +228,10 @@ Parquet.Beings.CharacterStatus.RoomAssignment.set -> void
 Parquet.Beings.CharacterStatus.SpawnAt.get -> Parquet.Location
 Parquet.Beings.CharacterStatus.SpawnAt.set -> void
 Parquet.Beings.CritterModel
-Parquet.Beings.CritterModel.CritterModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.ModelID? inNativeBiomeID = null, Parquet.ModelID? inPrimaryBehaviorID = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inAvoidsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inSeeksIDs = null) -> void
+Parquet.Beings.CritterModel.CritterModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? nativeBiomeID = null, Parquet.ModelID? primaryBehaviorID = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> avoidsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> seeksIDs = null) -> void
 Parquet.Beings.CritterStatus
-Parquet.Beings.CritterStatus.CritterStatus(Parquet.Beings.CritterModel inCritterModel) -> void
-Parquet.Beings.CritterStatus.CritterStatus(Parquet.Location? inPosition = null, Parquet.ModelID? inCurrentBehavior = null) -> void
+Parquet.Beings.CritterStatus.CritterStatus(Parquet.Beings.CritterModel critterModel) -> void
+Parquet.Beings.CritterStatus.CritterStatus(Parquet.Location? position = null, Parquet.ModelID? currentBehavior = null) -> void
 Parquet.Beings.CritterStatus.CurrentBehaviorID.get -> Parquet.ModelID
 Parquet.Beings.CritterStatus.CurrentBehaviorID.set -> void
 Parquet.Beings.CritterStatus.Position.get -> Parquet.Location
@@ -272,17 +272,17 @@ Parquet.Beings.IMutablePronounGroup.Subjective.get -> string
 Parquet.Beings.IMutablePronounGroup.Subjective.set -> void
 Parquet.Beings.PronounGroup
 Parquet.Beings.PronounGroup.Determiner.get -> string
-Parquet.Beings.PronounGroup.FillInPronouns(string inText) -> System.Text.StringBuilder
-Parquet.Beings.PronounGroup.FillInPronouns(System.Text.StringBuilder inText) -> System.Text.StringBuilder
+Parquet.Beings.PronounGroup.FillInPronouns(string text) -> System.Text.StringBuilder
+Parquet.Beings.PronounGroup.FillInPronouns(System.Text.StringBuilder text) -> System.Text.StringBuilder
 Parquet.Beings.PronounGroup.Key.get -> string
 Parquet.Beings.PronounGroup.Objective.get -> string
 Parquet.Beings.PronounGroup.Possessive.get -> string
-Parquet.Beings.PronounGroup.PronounGroup(string inSubjective, string inObjective, string inDeterminer, string inPossessive, string inReflexive) -> void
+Parquet.Beings.PronounGroup.PronounGroup(string subjective, string objective, string determiner, string possessive, string reflexive) -> void
 Parquet.Beings.PronounGroup.Reflexive.get -> string
 Parquet.Beings.PronounGroup.Subjective.get -> string
 Parquet.Biomes.BiomeConfiguration
 Parquet.Biomes.BiomeRecipe
-Parquet.Biomes.BiomeRecipe.BiomeRecipe(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, int inTier = 0, bool inIsRoomBased = false, bool inIsLiquidBased = false, Parquet.ModelTag inParquetCriteria = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inEntryRequirements = null) -> void
+Parquet.Biomes.BiomeRecipe.BiomeRecipe(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, int tier = 0, bool isRoomBased = false, bool isLiquidBased = false, Parquet.ModelTag parquetCriteria = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> entryRequirements = null) -> void
 Parquet.Biomes.BiomeRecipe.EntryRequirements.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelTag>
 Parquet.Biomes.BiomeRecipe.IsLiquidBased.get -> bool
 Parquet.Biomes.BiomeRecipe.IsRoomBased.get -> bool
@@ -300,25 +300,25 @@ Parquet.Biomes.IMutableBiomeRecipe.Tier.get -> int
 Parquet.Biomes.IMutableBiomeRecipe.Tier.set -> void
 Parquet.Crafts.CraftConfiguration
 Parquet.Crafts.CraftingRecipe
-Parquet.Crafts.CraftingRecipe.CraftingRecipe(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inProducts = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inIngredients = null, Parquet.IReadOnlyGrid<Parquet.Crafts.StrikePanel> inPanelPattern = null) -> void
+Parquet.Crafts.CraftingRecipe.CraftingRecipe(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> products = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> ingredients = null, Parquet.IReadOnlyGrid<Parquet.Crafts.StrikePanel> panelPattern = null) -> void
 Parquet.Crafts.CraftingRecipe.Ingredients.get -> System.Collections.Generic.IReadOnlyList<Parquet.RecipeElement>
 Parquet.Crafts.CraftingRecipe.PanelPattern.get -> Parquet.IReadOnlyGrid<Parquet.Crafts.StrikePanel>
-Parquet.Crafts.CraftingRecipe.PanelPatternReplace(Parquet.IGrid<Parquet.Crafts.StrikePanel> inReplacement) -> void
+Parquet.Crafts.CraftingRecipe.PanelPatternReplace(Parquet.IGrid<Parquet.Crafts.StrikePanel> replacement) -> void
 Parquet.Crafts.CraftingRecipe.Products.get -> System.Collections.Generic.IReadOnlyList<Parquet.RecipeElement>
 Parquet.Crafts.IMutableCraftingRecipe
 Parquet.Crafts.IMutableCraftingRecipe.Ingredients.get -> System.Collections.Generic.ICollection<Parquet.RecipeElement>
 Parquet.Crafts.IMutableCraftingRecipe.PanelPattern.get -> Parquet.IGrid<Parquet.Crafts.StrikePanel>
-Parquet.Crafts.IMutableCraftingRecipe.PanelPatternReplace(Parquet.IGrid<Parquet.Crafts.StrikePanel> inReplacement) -> void
+Parquet.Crafts.IMutableCraftingRecipe.PanelPatternReplace(Parquet.IGrid<Parquet.Crafts.StrikePanel> replacement) -> void
 Parquet.Crafts.IMutableCraftingRecipe.Products.get -> System.Collections.Generic.ICollection<Parquet.RecipeElement>
 Parquet.Crafts.StrikePanel
-Parquet.Crafts.StrikePanel.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.Crafts.StrikePanel.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.Crafts.StrikePanel.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.Crafts.StrikePanel.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Crafts.StrikePanel.DeepClone() -> Parquet.Crafts.StrikePanel
-Parquet.Crafts.StrikePanel.Equals(Parquet.Crafts.StrikePanel inStrikePanel) -> bool
+Parquet.Crafts.StrikePanel.Equals(Parquet.Crafts.StrikePanel strikePanel) -> bool
 Parquet.Crafts.StrikePanel.IdealRange.get -> Parquet.Range<int>
 Parquet.Crafts.StrikePanel.IdealRange.set -> void
 Parquet.Crafts.StrikePanel.StrikePanel() -> void
-Parquet.Crafts.StrikePanel.StrikePanel(Parquet.Range<int> inWorkingRange, Parquet.Range<int> inIdealRange) -> void
+Parquet.Crafts.StrikePanel.StrikePanel(Parquet.Range<int> workingRange, Parquet.Range<int> idealRange) -> void
 Parquet.Crafts.StrikePanel.WorkingRange.get -> Parquet.Range<int>
 Parquet.Crafts.StrikePanel.WorkingRange.set -> void
 Parquet.Crafts.StrikePanelArrayExtensions
@@ -337,20 +337,20 @@ Parquet.Crafts.StrikePanelGrid.this[int y, int x].get -> Parquet.Crafts.StrikePa
 Parquet.DataChangedEventHandler
 Parquet.Delimiters
 Parquet.EmptyTolerantEnumConverter
-Parquet.EmptyTolerantEnumConverter.EmptyTolerantEnumConverter(System.Type inType) -> void
+Parquet.EmptyTolerantEnumConverter.EmptyTolerantEnumConverter(System.Type type) -> void
 Parquet.Games.GameModel
 Parquet.Games.GameModel.EpisodeNumber.get -> int
 Parquet.Games.GameModel.EpisodeTitle.get -> string
 Parquet.Games.GameModel.FirstScriptID.get -> Parquet.ModelID
-Parquet.Games.GameModel.GameModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, bool inIsEpisode = false, string inEpisodeTitle = "", int inEpisodeNumber = 0, Parquet.ModelID? inPlayerCharacterID = null, Parquet.ModelID? inFirstScriptID = null) -> void
+Parquet.Games.GameModel.GameModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, bool isEpisode = false, string episodeTitle = "", int episodeNumber = 0, Parquet.ModelID? playerCharacterID = null, Parquet.ModelID? firstScriptID = null) -> void
 Parquet.Games.GameModel.IsEpisode.get -> bool
 Parquet.Games.GameModel.PlayerCharacterID.get -> Parquet.ModelID
 Parquet.Games.GameStatus
 Parquet.Games.GameStatus.CurrentScriptID.get -> Parquet.ModelID
 Parquet.Games.GameStatus.CurrentScriptID.set -> void
 Parquet.Games.GameStatus.GameStatus() -> void
-Parquet.Games.GameStatus.GameStatus(Parquet.Games.GameModel inGameModel) -> void
-Parquet.Games.GameStatus.GameStatus(Parquet.ModelID? inPlayerCharacterID, Parquet.ModelID? inCurrentScriptID) -> void
+Parquet.Games.GameStatus.GameStatus(Parquet.Games.GameModel gameModel) -> void
+Parquet.Games.GameStatus.GameStatus(Parquet.ModelID? playerCharacterID, Parquet.ModelID? currentScriptID) -> void
 Parquet.Games.GameStatus.PlayerCharacterID.get -> Parquet.ModelID
 Parquet.Games.GameStatus.PlayerCharacterID.set -> void
 Parquet.Games.IMutableGameModel
@@ -375,7 +375,7 @@ Parquet.IGrid<TElement>.GridDelimiter.get -> string
 Parquet.IGrid<TElement>.Rows.get -> int
 Parquet.IGrid<TElement>.this[int y, int x].get -> TElement
 Parquet.ILogger
-Parquet.ILogger.Log(Parquet.LogLevel inLogLevel, string inMessage, System.Exception inException) -> void
+Parquet.ILogger.Log(Parquet.LogLevel logLevel, string message, System.Exception exception) -> void
 Parquet.IMutableModel
 Parquet.IMutableModel.Comment.get -> string
 Parquet.IMutableModel.Comment.set -> void
@@ -387,8 +387,8 @@ Parquet.IMutableModel.Name.get -> string
 Parquet.IMutableModel.Name.set -> void
 Parquet.IMutableModel.Tags.get -> System.Collections.Generic.ICollection<Parquet.ModelTag>
 Parquet.IMutableModelCollection<TModel>
-Parquet.IMutableModelCollection<TModel>.Remove(Parquet.ModelID inID) -> bool
-Parquet.IMutableModelCollection<TModel>.Replace(TModel inModel) -> void
+Parquet.IMutableModelCollection<TModel>.Remove(Parquet.ModelID id) -> bool
+Parquet.IMutableModelCollection<TModel>.Replace(TModel model) -> void
 Parquet.IReadOnlyGrid<TElement>
 Parquet.IReadOnlyGrid<TElement>.Columns.get -> int
 Parquet.IReadOnlyGrid<TElement>.Rows.get -> int
@@ -420,21 +420,21 @@ Parquet.Items.InventoryCollection.Add(Parquet.Items.InventorySlot inSlot) -> voi
 Parquet.Items.InventoryCollection.Capacity.get -> int
 Parquet.Items.InventoryCollection.Capacity.set -> void
 Parquet.Items.InventoryCollection.Clear() -> void
-Parquet.Items.InventoryCollection.Contains(Parquet.Items.InventorySlot inSlot) -> bool
-Parquet.Items.InventoryCollection.Contains(Parquet.ModelID inItemID) -> int
+Parquet.Items.InventoryCollection.Contains(Parquet.Items.InventorySlot slot) -> bool
+Parquet.Items.InventoryCollection.Contains(Parquet.ModelID itemID) -> int
 Parquet.Items.InventoryCollection.CopyTo(Parquet.Items.InventorySlot[] inArray, int inArrayIndex) -> void
 Parquet.Items.InventoryCollection.Count.get -> int
 Parquet.Items.InventoryCollection.DeepClone() -> Parquet.Items.InventoryCollection
 Parquet.Items.InventoryCollection.GetEnumerator() -> System.Collections.Generic.IEnumerator<Parquet.Items.InventorySlot>
 Parquet.Items.InventoryCollection.Give(Parquet.Items.InventorySlot inSlot) -> int
 Parquet.Items.InventoryCollection.Give(Parquet.ModelID inItemID, int inHowMany) -> int
-Parquet.Items.InventoryCollection.Has(Parquet.Items.InventorySlot inSlot) -> bool
-Parquet.Items.InventoryCollection.Has(Parquet.ModelID inItemID, int inHowMany = 1) -> bool
-Parquet.Items.InventoryCollection.Has(System.Collections.Generic.IEnumerable<(Parquet.ModelID, int)> inItems) -> bool
-Parquet.Items.InventoryCollection.Has(System.Collections.Generic.IEnumerable<Parquet.Items.InventorySlot> inSlots) -> bool
+Parquet.Items.InventoryCollection.Has(Parquet.Items.InventorySlot slot) -> bool
+Parquet.Items.InventoryCollection.Has(Parquet.ModelID itemID, int howMany = 1) -> bool
+Parquet.Items.InventoryCollection.Has(System.Collections.Generic.IEnumerable<(Parquet.ModelID, int)> items) -> bool
+Parquet.Items.InventoryCollection.Has(System.Collections.Generic.IEnumerable<Parquet.Items.InventorySlot> slots) -> bool
 Parquet.Items.InventoryCollection.InventoryCollection() -> void
-Parquet.Items.InventoryCollection.InventoryCollection(int inCapacity) -> void
-Parquet.Items.InventoryCollection.InventoryCollection(System.Collections.Generic.IEnumerable<Parquet.Items.InventorySlot> inSlots, int inCapacity) -> void
+Parquet.Items.InventoryCollection.InventoryCollection(int capacity) -> void
+Parquet.Items.InventoryCollection.InventoryCollection(System.Collections.Generic.IEnumerable<Parquet.Items.InventorySlot> slots, int capacity) -> void
 Parquet.Items.InventoryCollection.IsReadOnly.get -> bool
 Parquet.Items.InventoryCollection.ItemCount.get -> int
 Parquet.Items.InventoryCollection.Remove(Parquet.Items.InventorySlot inSlot) -> bool
@@ -443,15 +443,15 @@ Parquet.Items.InventoryCollection.Take(Parquet.ModelID inItemID, int inHowMany) 
 Parquet.Items.InventoryConfiguration
 Parquet.Items.InventorySlot
 Parquet.Items.InventorySlot.Count.get -> int
-Parquet.Items.InventorySlot.Give(int inHowMany = 1) -> int
+Parquet.Items.InventorySlot.Give(int howMany = 1) -> int
 Parquet.Items.InventorySlot.InventorySlot() -> void
-Parquet.Items.InventorySlot.InventorySlot(Parquet.ModelID inItemToStore, int inHowMany = 1) -> void
+Parquet.Items.InventorySlot.InventorySlot(Parquet.ModelID itemToStore, int howMany = 1) -> void
 Parquet.Items.InventorySlot.ItemID.get -> Parquet.ModelID
-Parquet.Items.InventorySlot.Take(int inHowMany = 1) -> int
+Parquet.Items.InventorySlot.Take(int howMany = 1) -> int
 Parquet.Items.ItemModel
 Parquet.Items.ItemModel.EffectWhenUsedID.get -> Parquet.ModelID
 Parquet.Items.ItemModel.EffectWhileHeldID.get -> Parquet.ModelID
-Parquet.Items.ItemModel.ItemModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.Items.ItemType inSubtype = Parquet.Items.ItemType.Other, int inWorth = 0, int inRarity = 0, int inStackMax = 999, Parquet.ModelID? inEffectWhileHeldID = null, Parquet.ModelID? inEffectWhenUsedID = null, Parquet.ModelID? inParquetID = null) -> void
+Parquet.Items.ItemModel.ItemModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.Items.ItemType subtype = Parquet.Items.ItemType.Other, int worth = 0, int rarity = 0, int stackMax = 999, Parquet.ModelID? effectWhileHeldID = null, Parquet.ModelID? effectWhenUsedID = null, Parquet.ModelID? parquetID = null) -> void
 Parquet.Items.ItemModel.ParquetID.get -> Parquet.ModelID
 Parquet.Items.ItemModel.Rarity.get -> int
 Parquet.Items.ItemModel.StackMax.get -> int
@@ -474,8 +474,8 @@ Parquet.IVisibleData
 Parquet.IVisibleData.VisibleDataChanged -> Parquet.DataChangedEventHandler
 Parquet.LibraryState
 Parquet.Location
-Parquet.Location.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.Location.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.Location.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.Location.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Location.Equals(Parquet.Location inLocation) -> bool
 Parquet.Location.Location() -> void
 Parquet.Location.Location(Parquet.ModelID? inRegionID = null, Parquet.Point2D? inPosition = null) -> void
@@ -494,7 +494,7 @@ Parquet.Model.Comment.get -> string
 Parquet.Model.Description.get -> string
 Parquet.Model.Equals(Parquet.Model inModel) -> bool
 Parquet.Model.ID.get -> Parquet.ModelID
-Parquet.Model.Model(Parquet.Range<Parquet.ModelID> inBounds, Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags) -> void
+Parquet.Model.Model(Parquet.Range<Parquet.ModelID> inBounds, Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags) -> void
 Parquet.Model.Name.get -> string
 Parquet.Model.Tags.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelTag>
 Parquet.Model.VisibleDataChanged -> Parquet.DataChangedEventHandler
@@ -502,10 +502,10 @@ Parquet.ModelCollection
 Parquet.ModelCollection<TModel>
 Parquet.ModelCollection<TModel>.Bounds.get -> System.Collections.Generic.IReadOnlyList<Parquet.Range<Parquet.ModelID>>
 Parquet.ModelCollection<TModel>.Contains(Parquet.Model inModel) -> bool
-Parquet.ModelCollection<TModel>.Contains(Parquet.ModelID inID) -> bool
+Parquet.ModelCollection<TModel>.Contains(Parquet.ModelID id) -> bool
 Parquet.ModelCollection<TModel>.Count.get -> int
 Parquet.ModelCollection<TModel>.GetEnumerator() -> System.Collections.Generic.IEnumerator<Parquet.Model>
-Parquet.ModelCollection<TModel>.GetOrNull<TTarget>(Parquet.ModelID inID) -> TTarget
+Parquet.ModelCollection<TModel>.GetOrNull<TTarget>(Parquet.ModelID id) -> TTarget
 Parquet.ModelCollection<TModel>.GetRecordsForType<TModelInner>(Parquet.Range<Parquet.ModelID> inBounds) -> Parquet.ModelCollection<TModel>
 Parquet.ModelCollection<TModel>.GetRecordsForType<TModelInner>(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBounds) -> Parquet.ModelCollection<TModel>
 Parquet.ModelCollection<TModel>.ModelCollection(Parquet.Range<Parquet.ModelID> inBounds, System.Collections.Generic.IEnumerable<Parquet.Model> inModels) -> void
@@ -514,8 +514,8 @@ Parquet.ModelCollection<TModel>.PutRecordsForType<TModelInner>() -> void
 Parquet.ModelCollection<TModel>.VisibleDataChanged -> Parquet.DataChangedEventHandler
 Parquet.ModelID
 Parquet.ModelID.CompareTo(Parquet.ModelID inIDentifier) -> int
-Parquet.ModelID.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.ModelID.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.ModelID.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.ModelID.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.ModelID.Equals(Parquet.ModelID inIDentifier) -> bool
 Parquet.ModelID.IsValidForRange(Parquet.Range<Parquet.ModelID> inRange) -> bool
 Parquet.ModelID.IsValidForRange(System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inRanges) -> bool
@@ -532,10 +532,10 @@ Parquet.ModelIDGrid.ModelIDGrid(int inRowCount, int inColumnCount) -> void
 Parquet.ModelIDGrid.Rows.get -> int
 Parquet.ModelIDGrid.this[int y, int x].get -> Parquet.ModelID
 Parquet.ModelTag
-Parquet.ModelTag.CompareTo(Parquet.ModelTag inTag) -> int
-Parquet.ModelTag.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.ModelTag.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
-Parquet.ModelTag.EqualsOrdinalIgnoreCase(Parquet.ModelTag inTag) -> bool
+Parquet.ModelTag.CompareTo(Parquet.ModelTag tag) -> int
+Parquet.ModelTag.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.ModelTag.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
+Parquet.ModelTag.EqualsOrdinalIgnoreCase(Parquet.ModelTag tag) -> bool
 Parquet.ModelTag.ModelTag() -> void
 Parquet.ModelTag.StartsWithOrdinalIgnoreCase(Parquet.ModelTag inPrefix) -> bool
 Parquet.Pack<T>
@@ -543,7 +543,7 @@ Parquet.Pack<T>.Equals(Parquet.Pack<T> inPack) -> bool
 Parquet.Pack<T>.Pack() -> void
 Parquet.PackArrayExtensions
 Parquet.Parquets.BlockModel
-Parquet.Parquets.BlockModel.BlockModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Items.GatheringTool inGatherTool = Parquet.Items.GatheringTool.None, Parquet.Parquets.GatheringEffect inGatherEffect = Parquet.Parquets.GatheringEffect.None, Parquet.ModelID? inCollectibleID = null, bool inIsFlammable = false, bool inIsLiquid = false, int inMaxToughness = 10) -> void
+Parquet.Parquets.BlockModel.BlockModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Items.GatheringTool inGatherTool = Parquet.Items.GatheringTool.None, Parquet.Parquets.GatheringEffect inGatherEffect = Parquet.Parquets.GatheringEffect.None, Parquet.ModelID? inCollectibleID = null, bool inIsFlammable = false, bool inIsLiquid = false, int inMaxToughness = 10) -> void
 Parquet.Parquets.BlockModel.CollectibleID.get -> Parquet.ModelID
 Parquet.Parquets.BlockModel.GatherEffect.get -> Parquet.Parquets.GatheringEffect
 Parquet.Parquets.BlockModel.GatherTool.get -> Parquet.Items.GatheringTool
@@ -557,7 +557,7 @@ Parquet.Parquets.BlockStatus.BlockStatus(Parquet.ModelID inBlockID) -> void
 Parquet.Parquets.BlockStatus.Toughness.get -> int
 Parquet.Parquets.BlockStatus.Toughness.set -> void
 Parquet.Parquets.CollectibleModel
-Parquet.Parquets.CollectibleModel.CollectibleModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Parquets.CollectingEffect inCollectionEffect = Parquet.Parquets.CollectingEffect.None, int inEffectAmount = 0) -> void
+Parquet.Parquets.CollectibleModel.CollectibleModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Parquets.CollectingEffect inCollectionEffect = Parquet.Parquets.CollectingEffect.None, int inEffectAmount = 0) -> void
 Parquet.Parquets.CollectibleModel.CollectionEffect.get -> Parquet.Parquets.CollectingEffect
 Parquet.Parquets.CollectibleModel.EffectAmount.get -> int
 Parquet.Parquets.CollectingEffect
@@ -571,7 +571,7 @@ Parquet.Parquets.EntryType.Room = 1 -> Parquet.Parquets.EntryType
 Parquet.Parquets.EntryType.Up = 2 -> Parquet.Parquets.EntryType
 Parquet.Parquets.FloorModel
 Parquet.Parquets.FloorModel.DefaultTrenchName.get -> string
-Parquet.Parquets.FloorModel.FloorModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Items.ModificationTool inModTool = Parquet.Items.ModificationTool.None, string inTrenchName = null) -> void
+Parquet.Parquets.FloorModel.FloorModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, Parquet.Items.ModificationTool inModTool = Parquet.Items.ModificationTool.None, string inTrenchName = null) -> void
 Parquet.Parquets.FloorModel.ModTool.get -> Parquet.Items.ModificationTool
 Parquet.Parquets.FloorModel.TrenchName.get -> string
 Parquet.Parquets.FloorStatus
@@ -582,7 +582,7 @@ Parquet.Parquets.FloorStatus.IsTrench.get -> bool
 Parquet.Parquets.FloorStatus.IsTrench.set -> void
 Parquet.Parquets.FurnishingModel
 Parquet.Parquets.FurnishingModel.Entry.get -> Parquet.Parquets.EntryType
-Parquet.Parquets.FurnishingModel.FurnishingModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, bool inIsWalkable = false, Parquet.Parquets.EntryType inEntry = Parquet.Parquets.EntryType.None, bool inIsEnclosing = false, bool inIsFlammable = false, bool inIsOpenable = false) -> void
+Parquet.Parquets.FurnishingModel.FurnishingModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null, bool inIsWalkable = false, Parquet.Parquets.EntryType inEntry = Parquet.Parquets.EntryType.None, bool inIsEnclosing = false, bool inIsFlammable = false, bool inIsOpenable = false) -> void
 Parquet.Parquets.FurnishingModel.IsEnclosing.get -> bool
 Parquet.Parquets.FurnishingModel.IsFlammable.get -> bool
 Parquet.Parquets.FurnishingModel.IsOpenable.get -> bool
@@ -643,7 +643,7 @@ Parquet.Parquets.ParquetModel.AddsToRoom.get -> System.Collections.Generic.IRead
 Parquet.Parquets.ParquetModel.AddsToRoom.set -> void
 Parquet.Parquets.ParquetModel.ItemID.get -> Parquet.ModelID
 Parquet.Parquets.ParquetModel.ItemID.set -> void
-Parquet.Parquets.ParquetModel.ParquetModel(Parquet.Range<Parquet.ModelID> inBounds, Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null) -> void
+Parquet.Parquets.ParquetModel.ParquetModel(Parquet.Range<Parquet.ModelID> inBounds, Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, Parquet.ModelID? inItemID = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToBiome = null, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inAddsToRoom = null) -> void
 Parquet.Parquets.ParquetModelPack
 Parquet.Parquets.ParquetModelPack.BlockID.get -> Parquet.ModelID
 Parquet.Parquets.ParquetModelPack.BlockID.set -> void
@@ -695,8 +695,8 @@ Parquet.Parquets.ParquetStatusPackGrid.ParquetStatusPackGrid(Parquet.Parquets.Pa
 Parquet.Parquets.ParquetStatusPackGrid.Rows.get -> int
 Parquet.Parquets.ParquetStatusPackGrid.this[int y, int x].get -> Parquet.Parquets.ParquetStatusPack
 Parquet.Point2D
-Parquet.Point2D.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.Point2D.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.Point2D.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.Point2D.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Point2D.Deconstruct(out int x, out int y) -> void
 Parquet.Point2D.Equals(Parquet.Point2D inPoint) -> bool
 Parquet.Point2D.Magnitude.get -> int
@@ -708,9 +708,9 @@ Parquet.Point2D.Y.get -> int
 Parquet.Precondition
 Parquet.Range<TElement>
 Parquet.Range<TElement>.ContainsRange(Parquet.Range<TElement> inRange) -> bool
-Parquet.Range<TElement>.ContainsValue(TElement inValue) -> bool
-Parquet.Range<TElement>.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.Range<TElement>.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.Range<TElement>.ContainsValue(TElement value) -> bool
+Parquet.Range<TElement>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.Range<TElement>.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Range<TElement>.Deconstruct(out TElement minimum, out TElement maximum) -> void
 Parquet.Range<TElement>.Equals(Parquet.Range<TElement> inRange) -> bool
 Parquet.Range<TElement>.IsValid() -> bool
@@ -721,8 +721,8 @@ Parquet.Range<TElement>.Range() -> void
 Parquet.Range<TElement>.Range(TElement inMinimum, TElement inMaximum) -> void
 Parquet.RangeCollectionExtensions
 Parquet.RecipeElement
-Parquet.RecipeElement.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.RecipeElement.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.RecipeElement.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.RecipeElement.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.RecipeElement.ElementAmount.get -> int
 Parquet.RecipeElement.ElementTag.get -> Parquet.ModelTag
 Parquet.RecipeElement.Equals(Parquet.RecipeElement inElement) -> bool
@@ -733,8 +733,8 @@ Parquet.Regions.ChunkDetail.BaseComposition.get -> Parquet.ModelTag
 Parquet.Regions.ChunkDetail.BaseTopography.get -> Parquet.Regions.ChunkTopography
 Parquet.Regions.ChunkDetail.ChunkDetail() -> void
 Parquet.Regions.ChunkDetail.ChunkDetail(Parquet.Regions.ChunkTopography inBaseTopography, Parquet.ModelTag inBaseComposition, Parquet.Regions.ChunkTopography inModifierTopography, Parquet.ModelTag inModifierComposition) -> void
-Parquet.Regions.ChunkDetail.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.Regions.ChunkDetail.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.Regions.ChunkDetail.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.Regions.ChunkDetail.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Regions.ChunkDetail.DeepClone() -> Parquet.Regions.ChunkDetail
 Parquet.Regions.ChunkDetail.Equals(Parquet.Regions.ChunkDetail inChunkType) -> bool
 Parquet.Regions.ChunkDetail.ModifierComposition.get -> Parquet.ModelTag
@@ -771,8 +771,8 @@ Parquet.Regions.IMutableRegionModel.RegionToTheSouthID.set -> void
 Parquet.Regions.IMutableRegionModel.RegionToTheWestID.get -> Parquet.ModelID
 Parquet.Regions.IMutableRegionModel.RegionToTheWestID.set -> void
 Parquet.Regions.MapChunk
-Parquet.Regions.MapChunk.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.Regions.MapChunk.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.Regions.MapChunk.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.Regions.MapChunk.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Regions.MapChunk.Count.get -> int
 Parquet.Regions.MapChunk.DeepClone() -> Parquet.Regions.MapChunk
 Parquet.Regions.MapChunk.Details.get -> Parquet.Regions.ChunkDetail
@@ -804,7 +804,7 @@ Parquet.Regions.RegionModel.ExitCount() -> int
 Parquet.Regions.RegionModel.MapChunks.get -> Parquet.Regions.MapChunkGrid
 Parquet.Regions.RegionModel.RegionAbove.get -> Parquet.ModelID
 Parquet.Regions.RegionModel.RegionBelow.get -> Parquet.ModelID
-Parquet.Regions.RegionModel.RegionModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, string inBackgroundColor = "#FFFFFFFF", Parquet.ModelID? inRegionToTheNorth = null, Parquet.ModelID? inRegionToTheEast = null, Parquet.ModelID? inRegionToTheSouth = null, Parquet.ModelID? inRegionToTheWest = null, Parquet.ModelID? inRegionAbove = null, Parquet.ModelID? inRegionBelow = null) -> void
+Parquet.Regions.RegionModel.RegionModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, string inBackgroundColor = "#FFFFFFFF", Parquet.ModelID? inRegionToTheNorth = null, Parquet.ModelID? inRegionToTheEast = null, Parquet.ModelID? inRegionToTheSouth = null, Parquet.ModelID? inRegionToTheWest = null, Parquet.ModelID? inRegionAbove = null, Parquet.ModelID? inRegionBelow = null) -> void
 Parquet.Regions.RegionModel.RegionToTheEast.get -> Parquet.ModelID
 Parquet.Regions.RegionModel.RegionToTheNorth.get -> Parquet.ModelID
 Parquet.Regions.RegionModel.RegionToTheSouth.get -> Parquet.ModelID
@@ -859,7 +859,7 @@ Parquet.Rooms.RoomRecipe.OptionallyRequiredFurnishings.get -> System.Collections
 Parquet.Rooms.RoomRecipe.OptionallyRequiredPerimeterBlocks.get -> System.Collections.Generic.IReadOnlyList<Parquet.RecipeElement>
 Parquet.Rooms.RoomRecipe.OptionallyRequiredWalkableFloors.get -> System.Collections.Generic.IReadOnlyList<Parquet.RecipeElement>
 Parquet.Rooms.RoomRecipe.Priority.get -> int
-Parquet.Rooms.RoomRecipe.RoomRecipe(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, int? inMinimumWalkableSpaces = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredFurnishings = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredWalkableFloors = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredPerimeterBlocks = null) -> void
+Parquet.Rooms.RoomRecipe.RoomRecipe(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, int? inMinimumWalkableSpaces = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredFurnishings = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredWalkableFloors = null, System.Collections.Generic.IEnumerable<Parquet.RecipeElement> inOptionallyRequiredPerimeterBlocks = null) -> void
 Parquet.Scripts.Commands
 Parquet.Scripts.IMutableInteractionModel
 Parquet.Scripts.IMutableInteractionModel.OutcomesIDs.get -> System.Collections.Generic.ICollection<Parquet.ModelID>
@@ -868,7 +868,7 @@ Parquet.Scripts.IMutableInteractionModel.StepsIDs.get -> System.Collections.Gene
 Parquet.Scripts.IMutableScriptModel
 Parquet.Scripts.IMutableScriptModel.Nodes.get -> System.Collections.Generic.ICollection<Parquet.Scripts.ScriptNode>
 Parquet.Scripts.InteractionModel
-Parquet.Scripts.InteractionModel.InteractionModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inPrerequisitesIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inStepsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inOutcomesIDs = null) -> void
+Parquet.Scripts.InteractionModel.InteractionModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inPrerequisitesIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inStepsIDs = null, System.Collections.Generic.IEnumerable<Parquet.ModelID> inOutcomesIDs = null) -> void
 Parquet.Scripts.InteractionModel.OutcomesIDs.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelID>
 Parquet.Scripts.InteractionModel.PrerequisitesIDs.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelID>
 Parquet.Scripts.InteractionModel.StepsIDs.get -> System.Collections.Generic.IReadOnlyList<Parquet.ModelID>
@@ -887,11 +887,11 @@ Parquet.Scripts.RunState.Unstarted = 0 -> Parquet.Scripts.RunState
 Parquet.Scripts.ScriptModel
 Parquet.Scripts.ScriptModel.GetActions() -> System.Collections.Generic.IEnumerable<System.Action>
 Parquet.Scripts.ScriptModel.Nodes.get -> System.Collections.Generic.IReadOnlyList<Parquet.Scripts.ScriptNode>
-Parquet.Scripts.ScriptModel.ScriptModel(Parquet.ModelID inID, string inName, string inDescription, string inComment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> inTags = null, System.Collections.Generic.IEnumerable<Parquet.Scripts.ScriptNode> inNodes = null) -> void
+Parquet.Scripts.ScriptModel.ScriptModel(Parquet.ModelID id, string name, string description, string comment, System.Collections.Generic.IEnumerable<Parquet.ModelTag> tags = null, System.Collections.Generic.IEnumerable<Parquet.Scripts.ScriptNode> inNodes = null) -> void
 Parquet.Scripts.ScriptNode
-Parquet.Scripts.ScriptNode.CompareTo(Parquet.Scripts.ScriptNode inTag) -> int
-Parquet.Scripts.ScriptNode.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> object
-Parquet.Scripts.ScriptNode.ConvertToString(object inValue, CsvHelper.IWriterRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData) -> string
+Parquet.Scripts.ScriptNode.CompareTo(Parquet.Scripts.ScriptNode tag) -> int
+Parquet.Scripts.ScriptNode.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> object
+Parquet.Scripts.ScriptNode.ConvertToString(object value, CsvHelper.IWriterRow row, CsvHelper.Configuration.MemberMapData memberMapData) -> string
 Parquet.Scripts.ScriptNode.GetAction() -> System.Action
 Parquet.Scripts.ScriptNode.ScriptNode() -> void
 Parquet.Scripts.ScriptStatus
@@ -903,11 +903,11 @@ Parquet.Scripts.ScriptStatus.ScriptStatus(Parquet.Scripts.ScriptModel inScript) 
 Parquet.Scripts.ScriptStatus.State.get -> Parquet.Scripts.RunState
 Parquet.Scripts.ScriptStatus.State.set -> void
 Parquet.SeriesConverter<TElement, TCollection>
-Parquet.SeriesConverter<TElement, TCollection>.ConvertFromString(string inText, CsvHelper.IReaderRow inRow, CsvHelper.Configuration.MemberMapData inMemberMapData, string inDelimiter) -> object
+Parquet.SeriesConverter<TElement, TCollection>.ConvertFromString(string text, CsvHelper.IReaderRow row, CsvHelper.Configuration.MemberMapData memberMapData, string inDelimiter) -> object
 Parquet.SeriesConverter<TElement, TCollection>.SeriesConverter() -> void
 Parquet.Status<T>
 Parquet.Status<T>.DeepClone() -> Parquet.Status<T>
-Parquet.Status<T>.Equals(Parquet.Status<T> inStatus) -> bool
+Parquet.Status<T>.Equals(Parquet.Status<T> status) -> bool
 Parquet.Status<T>.Status() -> void
 Parquet.StatusArrayExtensions
 static Parquet.All.Beings.get -> Parquet.ModelCollection<Parquet.Beings.BeingModel>
@@ -922,10 +922,10 @@ static Parquet.All.Critters.get -> Parquet.ModelCollection<Parquet.Beings.Critte
 static Parquet.All.Floors.get -> Parquet.ModelCollection<Parquet.Parquets.FloorModel>
 static Parquet.All.Furnishings.get -> Parquet.ModelCollection<Parquet.Parquets.FurnishingModel>
 static Parquet.All.Games.get -> Parquet.ModelCollection<Parquet.Games.GameModel>
-static Parquet.All.GetIDRangeForType(Parquet.Model inModel) -> Parquet.Range<Parquet.ModelID>
-static Parquet.All.GetIDRangeForType(Parquet.ModelID inID) -> Parquet.Range<Parquet.ModelID>
-static Parquet.All.GetIDRangeForType(System.Type inModelType) -> Parquet.Range<Parquet.ModelID>
-static Parquet.All.InitializeCollections(System.Collections.Generic.IEnumerable<Parquet.Beings.PronounGroup> inPronouns, System.Collections.Generic.IEnumerable<Parquet.Games.GameModel> inGames, System.Collections.Generic.IEnumerable<Parquet.Parquets.FloorModel> inFloors, System.Collections.Generic.IEnumerable<Parquet.Parquets.BlockModel> inBlocks, System.Collections.Generic.IEnumerable<Parquet.Parquets.FurnishingModel> inFurnishings, System.Collections.Generic.IEnumerable<Parquet.Parquets.CollectibleModel> inCollectibles, System.Collections.Generic.IEnumerable<Parquet.Beings.CritterModel> inCritters, System.Collections.Generic.IEnumerable<Parquet.Beings.CharacterModel> inCharacters, System.Collections.Generic.IEnumerable<Parquet.Biomes.BiomeRecipe> inBiomes, System.Collections.Generic.IEnumerable<Parquet.Crafts.CraftingRecipe> inCraftingRecipes, System.Collections.Generic.IEnumerable<Parquet.Rooms.RoomRecipe> inRoomRecipes, System.Collections.Generic.IEnumerable<Parquet.Regions.RegionModel> inRegions, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Parquet.ModelID, Parquet.Regions.RegionStatus>> inRegionStatuses, System.Collections.Generic.IEnumerable<Parquet.Scripts.ScriptModel> inScripts, System.Collections.Generic.IEnumerable<Parquet.Scripts.InteractionModel> inInteractions, System.Collections.Generic.IEnumerable<Parquet.Items.ItemModel> inItems) -> void
+static Parquet.All.GetIDRangeForType(Parquet.Model model) -> Parquet.Range<Parquet.ModelID>
+static Parquet.All.GetIDRangeForType(Parquet.ModelID id) -> Parquet.Range<Parquet.ModelID>
+static Parquet.All.GetIDRangeForType(System.Type modelType) -> Parquet.Range<Parquet.ModelID>
+static Parquet.All.InitializeCollections(System.Collections.Generic.IEnumerable<Parquet.Beings.PronounGroup> pronouns, System.Collections.Generic.IEnumerable<Parquet.Games.GameModel> games, System.Collections.Generic.IEnumerable<Parquet.Parquets.FloorModel> floors, System.Collections.Generic.IEnumerable<Parquet.Parquets.BlockModel> blocks, System.Collections.Generic.IEnumerable<Parquet.Parquets.FurnishingModel> furnishings, System.Collections.Generic.IEnumerable<Parquet.Parquets.CollectibleModel> collectibles, System.Collections.Generic.IEnumerable<Parquet.Beings.CritterModel> critters, System.Collections.Generic.IEnumerable<Parquet.Beings.CharacterModel> characters, System.Collections.Generic.IEnumerable<Parquet.Biomes.BiomeRecipe> biomes, System.Collections.Generic.IEnumerable<Parquet.Crafts.CraftingRecipe> craftingRecipes, System.Collections.Generic.IEnumerable<Parquet.Rooms.RoomRecipe> roomRecipes, System.Collections.Generic.IEnumerable<Parquet.Regions.RegionModel> regions, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Parquet.ModelID, Parquet.Regions.RegionStatus>> regionStatuses, System.Collections.Generic.IEnumerable<Parquet.Scripts.ScriptModel> scripts, System.Collections.Generic.IEnumerable<Parquet.Scripts.InteractionModel> interactions, System.Collections.Generic.IEnumerable<Parquet.Items.ItemModel> items) -> void
 static Parquet.All.Interactions.get -> Parquet.ModelCollection<Parquet.Scripts.InteractionModel>
 static Parquet.All.Items.get -> Parquet.ModelCollection<Parquet.Items.ItemModel>
 static Parquet.All.LoadFromCSVs() -> bool
@@ -939,16 +939,16 @@ static Parquet.All.RoomRecipes.get -> Parquet.ModelCollection<Parquet.Rooms.Room
 static Parquet.All.SaveToCSVs() -> bool
 static Parquet.All.Scripts.get -> Parquet.ModelCollection<Parquet.Scripts.ScriptModel>
 static Parquet.Beings.CharacterModel.Unused.get -> Parquet.Beings.CharacterModel
-static Parquet.Beings.CharacterStatus.operator !=(Parquet.Beings.CharacterStatus inStatus1, Parquet.Beings.CharacterStatus inStatus2) -> bool
-static Parquet.Beings.CharacterStatus.operator ==(Parquet.Beings.CharacterStatus inStatus1, Parquet.Beings.CharacterStatus inStatus2) -> bool
+static Parquet.Beings.CharacterStatus.operator !=(Parquet.Beings.CharacterStatus status1, Parquet.Beings.CharacterStatus status2) -> bool
+static Parquet.Beings.CharacterStatus.operator ==(Parquet.Beings.CharacterStatus status1, Parquet.Beings.CharacterStatus status2) -> bool
 static Parquet.Beings.CharacterStatus.Unused.get -> Parquet.Beings.CharacterStatus
 static Parquet.Beings.CritterModel.Unused.get -> Parquet.Beings.CritterModel
-static Parquet.Beings.CritterStatus.operator !=(Parquet.Beings.CritterStatus inStatus1, Parquet.Beings.CritterStatus inStatus2) -> bool
-static Parquet.Beings.CritterStatus.operator ==(Parquet.Beings.CritterStatus inStatus1, Parquet.Beings.CritterStatus inStatus2) -> bool
+static Parquet.Beings.CritterStatus.operator !=(Parquet.Beings.CritterStatus status1, Parquet.Beings.CritterStatus status2) -> bool
+static Parquet.Beings.CritterStatus.operator ==(Parquet.Beings.CritterStatus status1, Parquet.Beings.CritterStatus status2) -> bool
 static Parquet.Beings.CritterStatus.Unused.get -> Parquet.Beings.CritterStatus
 static Parquet.Beings.PronounGroup.FilePath.get -> string
 static Parquet.Beings.PronounGroup.GetRecords() -> System.Collections.Generic.HashSet<Parquet.Beings.PronounGroup>
-static Parquet.Beings.PronounGroup.PutRecords(System.Collections.Generic.IEnumerable<Parquet.Beings.PronounGroup> inGroups) -> void
+static Parquet.Beings.PronounGroup.PutRecords(System.Collections.Generic.IEnumerable<Parquet.Beings.PronounGroup> groups) -> void
 static Parquet.Biomes.BiomeConfiguration.FilePath.get -> string
 static Parquet.Biomes.BiomeConfiguration.GetRecord() -> void
 static Parquet.Biomes.BiomeConfiguration.LandThreshold.get -> int
@@ -970,15 +970,15 @@ static Parquet.Crafts.CraftConfiguration.ProductCount.get -> Parquet.Range<int>
 static Parquet.Crafts.CraftConfiguration.ProductCount.set -> void
 static Parquet.Crafts.CraftConfiguration.PutRecord() -> void
 static Parquet.Crafts.CraftingRecipe.NotCraftable.get -> Parquet.Crafts.CraftingRecipe
-static Parquet.Crafts.StrikePanel.operator !=(Parquet.Crafts.StrikePanel inStrikePanel1, Parquet.Crafts.StrikePanel inStrikePanel2) -> bool
-static Parquet.Crafts.StrikePanel.operator ==(Parquet.Crafts.StrikePanel inStrikePanel1, Parquet.Crafts.StrikePanel inStrikePanel2) -> bool
+static Parquet.Crafts.StrikePanel.operator !=(Parquet.Crafts.StrikePanel strikePanel1, Parquet.Crafts.StrikePanel strikePanel2) -> bool
+static Parquet.Crafts.StrikePanel.operator ==(Parquet.Crafts.StrikePanel strikePanel1, Parquet.Crafts.StrikePanel strikePanel2) -> bool
 static Parquet.Crafts.StrikePanelArrayExtensions.IsValidPosition(this Parquet.Crafts.StrikePanel[,] inStrikePanels, Parquet.Point2D inPosition) -> bool
 static Parquet.Crafts.StrikePanelGrid.Empty.get -> Parquet.Crafts.StrikePanelGrid
 static Parquet.Games.GameModel.Empty.get -> Parquet.Games.GameModel
 static Parquet.Games.GameStatus.Default.get -> Parquet.Games.GameStatus
-static Parquet.Games.GameStatus.operator !=(Parquet.Games.GameStatus inStatus1, Parquet.Games.GameStatus inStatus2) -> bool
-static Parquet.Games.GameStatus.operator ==(Parquet.Games.GameStatus inStatus1, Parquet.Games.GameStatus inStatus2) -> bool
-static Parquet.IReadOnlyListOfTagsExtensions.ContainsOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyList<Parquet.ModelTag> inList, Parquet.ModelTag inTag) -> bool
+static Parquet.Games.GameStatus.operator !=(Parquet.Games.GameStatus status1, Parquet.Games.GameStatus status2) -> bool
+static Parquet.Games.GameStatus.operator ==(Parquet.Games.GameStatus status1, Parquet.Games.GameStatus status2) -> bool
+static Parquet.IReadOnlyListOfTagsExtensions.ContainsOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyList<Parquet.ModelTag> inList, Parquet.ModelTag tag) -> bool
 static Parquet.IReadOnlyListOfTagsExtensions.ContainsPrefixOrdinalIgnoreCase(this System.Collections.Generic.IReadOnlyList<Parquet.ModelTag> inList, Parquet.ModelTag inPrefix) -> bool
 static Parquet.Items.InventoryCollection.Empty.get -> Parquet.Items.InventoryCollection
 static Parquet.Items.InventoryConfiguration.DefaultCapacity.get -> int
@@ -987,8 +987,8 @@ static Parquet.Items.InventoryConfiguration.FilePath.get -> string
 static Parquet.Items.InventoryConfiguration.GetRecord() -> void
 static Parquet.Items.InventoryConfiguration.PutRecord() -> void
 static Parquet.Items.InventorySlot.Empty.get -> Parquet.Items.InventorySlot
-static Parquet.Items.InventorySlot.operator !=(Parquet.Items.InventorySlot inStatus1, Parquet.Items.InventorySlot inStatus2) -> bool
-static Parquet.Items.InventorySlot.operator ==(Parquet.Items.InventorySlot inStatus1, Parquet.Items.InventorySlot inStatus2) -> bool
+static Parquet.Items.InventorySlot.operator !=(Parquet.Items.InventorySlot status1, Parquet.Items.InventorySlot status2) -> bool
+static Parquet.Items.InventorySlot.operator ==(Parquet.Items.InventorySlot status1, Parquet.Items.InventorySlot status2) -> bool
 static Parquet.LibraryState.IsPlayMode.get -> bool
 static Parquet.LibraryState.IsPlayMode.set -> void
 static Parquet.Location.Nowhere.get -> Parquet.Location
@@ -1001,7 +1001,7 @@ static Parquet.Model.operator !=(Parquet.Model inModel1, Parquet.Model inModel2)
 static Parquet.Model.operator ==(Parquet.Model inModel1, Parquet.Model inModel2) -> bool
 static Parquet.ModelCollection.GetFilePath<TModel>() -> string
 static Parquet.ModelID.implicit operator int(Parquet.ModelID inIDentifier) -> int
-static Parquet.ModelID.implicit operator Parquet.ModelID(int inValue) -> Parquet.ModelID
+static Parquet.ModelID.implicit operator Parquet.ModelID(int value) -> Parquet.ModelID
 static Parquet.ModelID.operator !=(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
 static Parquet.ModelID.operator <(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
 static Parquet.ModelID.operator <=(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
@@ -1009,22 +1009,22 @@ static Parquet.ModelID.operator ==(Parquet.ModelID inIDentifier1, Parquet.ModelI
 static Parquet.ModelID.operator >(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
 static Parquet.ModelID.operator >=(Parquet.ModelID inIDentifier1, Parquet.ModelID inIDentifier2) -> bool
 static Parquet.ModelIDGrid.Empty.get -> Parquet.ModelIDGrid
-static Parquet.ModelTag.implicit operator Parquet.ModelTag(string inValue) -> Parquet.ModelTag
-static Parquet.ModelTag.implicit operator string(Parquet.ModelTag inTag) -> string
+static Parquet.ModelTag.implicit operator Parquet.ModelTag(string value) -> Parquet.ModelTag
+static Parquet.ModelTag.implicit operator string(Parquet.ModelTag tag) -> string
 static Parquet.PackArrayExtensions.IsValidPosition<T>(this Parquet.Pack<T>[,] inArray, Parquet.Point2D inPosition) -> bool
 static Parquet.Parquets.BlockModel.Bounds.get -> Parquet.Range<Parquet.ModelID>
 static Parquet.Parquets.BlockStatus.Default.get -> Parquet.Parquets.BlockStatus
-static Parquet.Parquets.BlockStatus.operator !=(Parquet.Parquets.BlockStatus inStatus1, Parquet.Parquets.BlockStatus inStatus2) -> bool
-static Parquet.Parquets.BlockStatus.operator ==(Parquet.Parquets.BlockStatus inStatus1, Parquet.Parquets.BlockStatus inStatus2) -> bool
+static Parquet.Parquets.BlockStatus.operator !=(Parquet.Parquets.BlockStatus status1, Parquet.Parquets.BlockStatus status2) -> bool
+static Parquet.Parquets.BlockStatus.operator ==(Parquet.Parquets.BlockStatus status1, Parquet.Parquets.BlockStatus status2) -> bool
 static Parquet.Parquets.CollectibleModel.Bounds.get -> Parquet.Range<Parquet.ModelID>
 static Parquet.Parquets.FloorModel.Bounds.get -> Parquet.Range<Parquet.ModelID>
 static Parquet.Parquets.FloorStatus.Default.get -> Parquet.Parquets.FloorStatus
-static Parquet.Parquets.FloorStatus.operator !=(Parquet.Parquets.FloorStatus inStatus1, Parquet.Parquets.FloorStatus inStatus2) -> bool
-static Parquet.Parquets.FloorStatus.operator ==(Parquet.Parquets.FloorStatus inStatus1, Parquet.Parquets.FloorStatus inStatus2) -> bool
+static Parquet.Parquets.FloorStatus.operator !=(Parquet.Parquets.FloorStatus status1, Parquet.Parquets.FloorStatus status2) -> bool
+static Parquet.Parquets.FloorStatus.operator ==(Parquet.Parquets.FloorStatus status1, Parquet.Parquets.FloorStatus status2) -> bool
 static Parquet.Parquets.FurnishingModel.Bounds.get -> Parquet.Range<Parquet.ModelID>
 static Parquet.Parquets.FurnishingStatus.Default.get -> Parquet.Parquets.FurnishingStatus
-static Parquet.Parquets.FurnishingStatus.operator !=(Parquet.Parquets.FurnishingStatus inStatus1, Parquet.Parquets.FurnishingStatus inStatus2) -> bool
-static Parquet.Parquets.FurnishingStatus.operator ==(Parquet.Parquets.FurnishingStatus inStatus1, Parquet.Parquets.FurnishingStatus inStatus2) -> bool
+static Parquet.Parquets.FurnishingStatus.operator !=(Parquet.Parquets.FurnishingStatus status1, Parquet.Parquets.FurnishingStatus status2) -> bool
+static Parquet.Parquets.FurnishingStatus.operator ==(Parquet.Parquets.FurnishingStatus status1, Parquet.Parquets.FurnishingStatus status2) -> bool
 static Parquet.Parquets.ParquetModelPack.Empty.get -> Parquet.Parquets.ParquetModelPack
 static Parquet.Parquets.ParquetModelPack.operator !=(Parquet.Parquets.ParquetModelPack inPack1, Parquet.Parquets.ParquetModelPack inPack2) -> bool
 static Parquet.Parquets.ParquetModelPack.operator ==(Parquet.Parquets.ParquetModelPack inPack1, Parquet.Parquets.ParquetModelPack inPack2) -> bool
@@ -1041,11 +1041,11 @@ static Parquet.Point2D.operator ==(Parquet.Point2D inPoint1, Parquet.Point2D inP
 static Parquet.Precondition.AreInRange(System.Collections.Generic.IEnumerable<Parquet.ModelID> inEnumerable, Parquet.Range<Parquet.ModelID> inBounds, string inArgumentName) -> void
 static Parquet.Precondition.AreInRange(System.Collections.Generic.IEnumerable<Parquet.ModelID> inEnumerable, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBoundsCollection, string inArgumentName) -> void
 static Parquet.Precondition.IsInRange(int inInt, Parquet.Range<int> inBounds, string inArgumentName) -> void
-static Parquet.Precondition.IsInRange(Parquet.ModelID inID, Parquet.Range<Parquet.ModelID> inBounds, string inArgumentName) -> void
-static Parquet.Precondition.IsInRange(Parquet.ModelID inID, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBoundsCollection, string inArgumentName) -> void
+static Parquet.Precondition.IsInRange(Parquet.ModelID id, Parquet.Range<Parquet.ModelID> inBounds, string inArgumentName) -> void
+static Parquet.Precondition.IsInRange(Parquet.ModelID id, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBoundsCollection, string inArgumentName) -> void
 static Parquet.Precondition.IsInRange(Parquet.Range<Parquet.ModelID> inInnerBounds, Parquet.Range<Parquet.ModelID> inOuterBounds, string inArgumentName) -> void
 static Parquet.Precondition.IsInRange(Parquet.Range<Parquet.ModelID> inInnerBounds, System.Collections.Generic.IEnumerable<Parquet.Range<Parquet.ModelID>> inBoundsCollection, string inArgumentName) -> void
-static Parquet.Precondition.IsNotNone(Parquet.ModelID inID, string inArgumentName = "Argument") -> void
+static Parquet.Precondition.IsNotNone(Parquet.ModelID id, string inArgumentName = "Argument") -> void
 static Parquet.Precondition.IsNotNull(object inReference, string inArgumentName = "Argument") -> void
 static Parquet.Precondition.IsNotNullOrEmpty(string inString, string inArgumentName) -> void
 static Parquet.Precondition.IsNotNullOrEmpty<TElement>(System.Collections.Generic.IEnumerable<TElement> inEnumerable, string inArgumentName) -> void
@@ -1055,7 +1055,7 @@ static Parquet.Precondition.MustBePositive(int inNumber, string inArgumentName =
 static Parquet.Range<TElement>.operator !=(Parquet.Range<TElement> inRange1, Parquet.Range<TElement> inRange2) -> bool
 static Parquet.Range<TElement>.operator ==(Parquet.Range<TElement> inRange1, Parquet.Range<TElement> inRange2) -> bool
 static Parquet.RangeCollectionExtensions.ContainsRange<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> inRangeCollection, Parquet.Range<TElement> inRange) -> bool
-static Parquet.RangeCollectionExtensions.ContainsValue<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> inRangeCollection, TElement inValue) -> bool
+static Parquet.RangeCollectionExtensions.ContainsValue<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> inRangeCollection, TElement value) -> bool
 static Parquet.RangeCollectionExtensions.IsValid<TElement>(this System.Collections.Generic.IEnumerable<Parquet.Range<TElement>> inRangeCollection) -> bool
 static Parquet.RecipeElement.operator !=(Parquet.RecipeElement inElement1, Parquet.RecipeElement inElement2) -> bool
 static Parquet.RecipeElement.operator ==(Parquet.RecipeElement inElement1, Parquet.RecipeElement inElement2) -> bool
@@ -1072,8 +1072,8 @@ static Parquet.Regions.RegionModel.DimensionsInChunks.get -> Parquet.Point2D
 static Parquet.Regions.RegionStatus.DimensionsInParquets.get -> Parquet.Point2D
 static Parquet.Regions.RegionStatus.FilePath.get -> string
 static Parquet.Regions.RegionStatus.GetRecords() -> System.Collections.Generic.Dictionary<Parquet.ModelID, Parquet.Regions.RegionStatus>
-static Parquet.Regions.RegionStatus.operator !=(Parquet.Regions.RegionStatus inStatus1, Parquet.Regions.RegionStatus inStatus2) -> bool
-static Parquet.Regions.RegionStatus.operator ==(Parquet.Regions.RegionStatus inStatus1, Parquet.Regions.RegionStatus inStatus2) -> bool
+static Parquet.Regions.RegionStatus.operator !=(Parquet.Regions.RegionStatus status1, Parquet.Regions.RegionStatus status2) -> bool
+static Parquet.Regions.RegionStatus.operator ==(Parquet.Regions.RegionStatus status1, Parquet.Regions.RegionStatus status2) -> bool
 static Parquet.Regions.RegionStatus.PutRecords(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Parquet.ModelID, Parquet.Regions.RegionStatus>> inRegionStatuses) -> void
 static Parquet.Regions.RegionStatus.Unused.get -> Parquet.Regions.RegionStatus
 static Parquet.Rooms.MapSpace.operator !=(Parquet.Rooms.MapSpace inSpace1, Parquet.Rooms.MapSpace inSpace2) -> bool
@@ -1090,13 +1090,13 @@ static Parquet.Rooms.RoomConfiguration.MinPerimeterSpaces.get -> int
 static Parquet.Rooms.RoomConfiguration.MinWalkableSpaces.get -> int
 static Parquet.Rooms.RoomConfiguration.MinWalkableSpaces.set -> void
 static Parquet.Rooms.RoomConfiguration.PutRecord() -> void
-static Parquet.Scripts.InteractionStatus.operator !=(Parquet.Scripts.InteractionStatus inStatus1, Parquet.Scripts.InteractionStatus inStatus2) -> bool
-static Parquet.Scripts.InteractionStatus.operator ==(Parquet.Scripts.InteractionStatus inStatus1, Parquet.Scripts.InteractionStatus inStatus2) -> bool
+static Parquet.Scripts.InteractionStatus.operator !=(Parquet.Scripts.InteractionStatus status1, Parquet.Scripts.InteractionStatus status2) -> bool
+static Parquet.Scripts.InteractionStatus.operator ==(Parquet.Scripts.InteractionStatus status1, Parquet.Scripts.InteractionStatus status2) -> bool
 static Parquet.Scripts.InteractionStatus.Unstarted.get -> Parquet.Scripts.InteractionStatus
-static Parquet.Scripts.ScriptNode.implicit operator Parquet.Scripts.ScriptNode(string inValue) -> Parquet.Scripts.ScriptNode
+static Parquet.Scripts.ScriptNode.implicit operator Parquet.Scripts.ScriptNode(string value) -> Parquet.Scripts.ScriptNode
 static Parquet.Scripts.ScriptNode.implicit operator string(Parquet.Scripts.ScriptNode inNode) -> string
-static Parquet.Scripts.ScriptStatus.operator !=(Parquet.Scripts.ScriptStatus inStatus1, Parquet.Scripts.ScriptStatus inStatus2) -> bool
-static Parquet.Scripts.ScriptStatus.operator ==(Parquet.Scripts.ScriptStatus inStatus1, Parquet.Scripts.ScriptStatus inStatus2) -> bool
+static Parquet.Scripts.ScriptStatus.operator !=(Parquet.Scripts.ScriptStatus status1, Parquet.Scripts.ScriptStatus status2) -> bool
+static Parquet.Scripts.ScriptStatus.operator ==(Parquet.Scripts.ScriptStatus status1, Parquet.Scripts.ScriptStatus status2) -> bool
 static Parquet.Scripts.ScriptStatus.Unstarted.get -> Parquet.Scripts.ScriptStatus
 static Parquet.StatusArrayExtensions.IsValidPosition<T>(this Parquet.Status<T>[,] inArray, Parquet.Point2D inPosition) -> bool
 static readonly Parquet.All.AllDefinedIDs -> System.Collections.Generic.IReadOnlyList<Parquet.Range<Parquet.ModelID>>
@@ -1136,5 +1136,5 @@ static readonly Parquet.Rooms.MapSpace.Empty -> Parquet.Rooms.MapSpace
 static readonly Parquet.Scripts.ScriptNode.None -> Parquet.Scripts.ScriptNode
 virtual Parquet.Model.GetAllTags() -> System.Collections.Generic.IEnumerable<Parquet.ModelTag>
 virtual Parquet.Model.OnVisibleDataChanged() -> bool
-virtual Parquet.ModelCollection<TModel>.OnVisibleDataChanged(object inSender = null, System.EventArgs inEventData = null) -> bool
+virtual Parquet.ModelCollection<TModel>.OnVisibleDataChanged(object sender = null, System.EventArgs eventData = null) -> bool
 virtual Parquet.Pack<T>.DeepClone() -> Parquet.Pack<T>

--- a/ParquetClassLibrary/Range.cs
+++ b/ParquetClassLibrary/Range.cs
@@ -34,17 +34,17 @@ namespace Parquet
         /// <summary>
         /// Initializes a new instance of the <see cref="Range{TElement}"/> struct.
         /// </summary>
-        /// <param name="inMinimum">The lower end of the range.</param>
-        /// <param name="inMaximum">The upper end of the range.</param>
-        public Range(TElement inMinimum, TElement inMaximum)
+        /// <param name="minimum">The lower end of the range.</param>
+        /// <param name="maximum">The upper end of the range.</param>
+        public Range(TElement minimum, TElement maximum)
         {
-            Minimum = inMinimum;
-            Maximum = inMaximum;
+            Minimum = minimum;
+            Maximum = maximum;
 
             if (!IsValid())
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfOrderLTE,
-                                                           nameof(inMinimum), inMinimum, nameof(inMaximum)));
+                                                           nameof(minimum), minimum, nameof(maximum)));
                 // Swap the two values so that execution can continue.
                 (Minimum, Maximum) = (Maximum, Minimum);
             }
@@ -53,9 +53,9 @@ namespace Parquet
         /// <summary>
         /// Initializes a new instance of the <see cref="Range{TElement}"/> struct.
         /// </summary>
-        /// <param name="inExtema">The extremes of the Range.</param>
-        public Range((TElement Minimum, TElement Maximum) inExtema)
-            : this(inExtema.Minimum, inExtema.Maximum)
+        /// <param name="extema">The extremes of the Range.</param>
+        public Range((TElement Minimum, TElement Maximum) extema)
+            : this(extema.Minimum, extema.Maximum)
         { }
         #endregion
 
@@ -68,10 +68,10 @@ namespace Parquet
             => Minimum.CompareTo(Maximum) <= 0;
 
         /// <summary>Determines if the given <see cref="Range{TElement}"/> is equal to or entirely contained within the current Range.</summary>
-        /// <param name="inRange">The <see cref="Range{TElement}"/> to test.</param>
+        /// <param name="range">The <see cref="Range{TElement}"/> to test.</param>
         /// <returns><c>true</c>, if the given range is within the current range, <c>false</c> otherwise.</returns>
-        public bool ContainsRange(Range<TElement> inRange)
-            => ContainsValue(inRange.Minimum) && ContainsValue(inRange.Maximum);
+        public bool ContainsRange(Range<TElement> range)
+            => ContainsValue(range.Minimum) && ContainsValue(range.Maximum);
 
         /// <summary>Determines if the given value is within the range, inclusive.</summary>
         /// <param name="value">The value to test.</param>
@@ -130,8 +130,8 @@ namespace Parquet
 
             // Determines if the given variable may be deserialized as an integer.
             // Returns true if TElement may be deserialized via Int32Converter.
-            static bool IsIntConvertible(TElement inElement)
-                => inElement switch
+            static bool IsIntConvertible(TElement element)
+                => element switch
                 {
                     sbyte _ => true,
                     short _ => true,
@@ -142,8 +142,8 @@ namespace Parquet
 
             // Determines if the given variable may be deserialized as a single-precision floating point number.
             // Returns true if TElement may be deserialized via SingleConverter.
-            static bool IsSingleConvertible(TElement inElement)
-                => inElement switch
+            static bool IsSingleConvertible(TElement element)
+                => element switch
                 {
                     float _ => true,
                     _ => false
@@ -164,11 +164,11 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Range{TElement}"/> is equal to the current <see cref="Range{TElement}"/>.
         /// </summary>
-        /// <param name="inRange">The <see cref="Range{TElement}"/> to compare with the current.</param>
+        /// <param name="range">The <see cref="Range{TElement}"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Range<TElement> inRange)
-            => Minimum.Equals(inRange.Minimum)
-            && Maximum.Equals(inRange.Maximum);
+        public bool Equals(Range<TElement> range)
+            => Minimum.Equals(range.Minimum)
+            && Maximum.Equals(range.Maximum);
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Range{TElement}"/>.
@@ -182,21 +182,21 @@ namespace Parquet
         /// Determines whether a specified instance of <see cref="Range{TElement}"/>
         /// is equal to another specified instance of <see cref="Range{TElement}"/>.
         /// </summary>
-        /// <param name="inRange1">The first <see cref="Range{TElement}"/> to compare.</param>
-        /// <param name="inRange2">The second <see cref="Range{TElement}"/> to compare.</param>
+        /// <param name="range1">The first <see cref="Range{TElement}"/> to compare.</param>
+        /// <param name="range2">The second <see cref="Range{TElement}"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(Range<TElement> inRange1, Range<TElement> inRange2)
-            => inRange1.Equals(inRange2);
+        public static bool operator ==(Range<TElement> range1, Range<TElement> range2)
+            => range1.Equals(range2);
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="Range{TElement}"/>
         /// is not equal to another specified instance of <see cref="Range{TElement}"/>.
         /// </summary>
-        /// <param name="inRange1">The first <see cref="Range{TElement}"/> to compare.</param>
-        /// <param name="inRange2">The second <see cref="Range{TElement}"/> to compare.</param>
+        /// <param name="range1">The first <see cref="Range{TElement}"/> to compare.</param>
+        /// <param name="range2">The second <see cref="Range{TElement}"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(Range<TElement> inRange1, Range<TElement> inRange2)
-            => !inRange1.Equals(inRange2);
+        public static bool operator !=(Range<TElement> range1, Range<TElement> range2)
+            => !range1.Equals(range2);
         #endregion
 
         #region Utilities
@@ -227,13 +227,13 @@ namespace Parquet
         /// that is, if Minima are less than or equal to Maxima.
         /// </summary>
         /// <returns><c>true</c>, if the range is valid, <c>false</c> otherwise.</returns>
-        public static bool IsValid<TElement>(this IEnumerable<Range<TElement>> inRangeCollection)
+        public static bool IsValid<TElement>(this IEnumerable<Range<TElement>> rangeCollection)
             where TElement : IComparable<TElement>, IEquatable<TElement>
         {
-            Precondition.IsNotNull(inRangeCollection, nameof(inRangeCollection));
+            Precondition.IsNotNull(rangeCollection, nameof(rangeCollection));
 
             var isValid = true;
-            foreach (var range in inRangeCollection ?? Enumerable.Empty<Range<TElement>>())
+            foreach (var range in rangeCollection ?? Enumerable.Empty<Range<TElement>>())
             {
                 isValid &= range.IsValid();
             }
@@ -244,20 +244,20 @@ namespace Parquet
         /// Determines if the given <paramref name="value"/> is contained by any of the <see cref="Range{TElement}"/>s
         /// in the current <see cref="IEnumerable{Range}"/>.
         /// </summary>
-        /// <param name="inRangeCollection">The range collection in which to search.</param>
+        /// <param name="rangeCollection">The range collection in which to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <typeparam name="TElement">The type over which the Ranges are defined.</typeparam>
         /// <returns>
-        /// <c>true</c>, if <paramref name="inRangeCollection"/> contains the <paramref name="value"/>,
+        /// <c>true</c>, if <paramref name="rangeCollection"/> contains the <paramref name="value"/>,
         /// <c>false</c> otherwise.
         /// </returns>
-        public static bool ContainsValue<TElement>(this IEnumerable<Range<TElement>> inRangeCollection, TElement value)
+        public static bool ContainsValue<TElement>(this IEnumerable<Range<TElement>> rangeCollection, TElement value)
             where TElement : IComparable<TElement>, IEquatable<TElement>
         {
-            Precondition.IsNotNull(inRangeCollection, nameof(inRangeCollection));
+            Precondition.IsNotNull(rangeCollection, nameof(rangeCollection));
 
             var foundRange = false;
-            foreach (var range in inRangeCollection ?? Enumerable.Empty<Range<TElement>>())
+            foreach (var range in rangeCollection ?? Enumerable.Empty<Range<TElement>>())
             {
                 if (range.ContainsValue(value))
                 {
@@ -272,19 +272,19 @@ namespace Parquet
         /// Determines if the given <see cref="Range{TElement}"/> is contained by any of the ranges
         /// in the current <see cref="IEnumerable{Range}"/>.
         /// </summary>
-        /// <param name="inRangeCollection">The range collection in which to search.</param>
-        /// <param name="inRange">The range to search for.</param>
+        /// <param name="rangeCollection">The range collection in which to search.</param>
+        /// <param name="rangeSought">The range to search for.</param>
         /// <typeparam name="TElement">The type over which the Ranges are defined.</typeparam>
         /// <returns><c>true</c>, if the list contains the given range, <c>false</c> otherwise.</returns>
-        public static bool ContainsRange<TElement>(this IEnumerable<Range<TElement>> inRangeCollection, Range<TElement> inRange)
+        public static bool ContainsRange<TElement>(this IEnumerable<Range<TElement>> rangeCollection, Range<TElement> rangeSought)
             where TElement : IComparable<TElement>, IEquatable<TElement>
         {
-            Precondition.IsNotNull(inRangeCollection, nameof(inRangeCollection));
+            Precondition.IsNotNull(rangeCollection, nameof(rangeCollection));
 
             var foundRange = false;
-            foreach (var range in inRangeCollection ?? Enumerable.Empty<Range<TElement>>())
+            foreach (var range in rangeCollection ?? Enumerable.Empty<Range<TElement>>())
             {
-                if (range.ContainsRange(inRange))
+                if (range.ContainsRange(rangeSought))
                 {
                     foundRange = true;
                     break;

--- a/ParquetClassLibrary/Range.cs
+++ b/ParquetClassLibrary/Range.cs
@@ -203,10 +203,10 @@ namespace Parquet
         /// <summary>
         /// Deconstructs the current <see cref="Range{TElement}"/> into its constituent extrema.
         /// </summary>
-        /// <param name="outMinimum">The minimum.</param>
-        /// <param name="outMaximum">The maximum.</param>
-        public void Deconstruct(out TElement outMinimum, out TElement outMaximum)
-            => (outMinimum, outMaximum) = (Minimum, Maximum);
+        /// <param name="minimum">The minimum.</param>
+        /// <param name="maximum">The maximum.</param>
+        public void Deconstruct(out TElement minimum, out TElement maximum)
+            => (minimum, maximum) = (Minimum, Maximum);
 
         /// <summary>
         /// Returns a <see cref="string"/> that represents the current <see cref="Range{TElement}"/>.

--- a/ParquetClassLibrary/Range.cs
+++ b/ParquetClassLibrary/Range.cs
@@ -164,11 +164,11 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Range{TElement}"/> is equal to the current <see cref="Range{TElement}"/>.
         /// </summary>
-        /// <param name="range">The <see cref="Range{TElement}"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="Range{TElement}"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Range<TElement> range)
-            => Minimum.Equals(range.Minimum)
-            && Maximum.Equals(range.Maximum);
+        public bool Equals(Range<TElement> other)
+            => Minimum.Equals(other.Minimum)
+            && Maximum.Equals(other.Maximum);
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Range{TElement}"/>.

--- a/ParquetClassLibrary/Range.cs
+++ b/ParquetClassLibrary/Range.cs
@@ -74,10 +74,10 @@ namespace Parquet
             => ContainsValue(inRange.Minimum) && ContainsValue(inRange.Maximum);
 
         /// <summary>Determines if the given value is within the range, inclusive.</summary>
-        /// <param name="inValue">The value to test.</param>
+        /// <param name="value">The value to test.</param>
         /// <returns><c>true</c>, if the value is in range, <c>false</c> otherwise.</returns>
-        public bool ContainsValue(TElement inValue)
-            => Minimum.CompareTo(inValue) <= 0 && Maximum.CompareTo(inValue) >= 0;
+        public bool ContainsValue(TElement value)
+            => Minimum.CompareTo(value) <= 0 && Maximum.CompareTo(value) >= 0;
         #endregion
 
         #region ITypeConverter Implementation
@@ -93,39 +93,39 @@ namespace Parquet
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is Range<TElement> range
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is Range<TElement> range
                 ? $"{range.Minimum}{Delimiters.ElementDelimiter}" +
                   $"{range.Maximum}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(Range<TElement>),
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(Range<TElement>),
                                                $"{default(TElement)}{Delimiters.ElementDelimiter}{default(TElement)}");
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText))
+            if (string.IsNullOrEmpty(text))
             {
-                return Logger.DefaultWithConvertLog(inText, nameof(Range<TElement>), None);
+                return Logger.DefaultWithConvertLog(text, nameof(Range<TElement>), None);
             }
 
-            var parameterText = inText.Split(Delimiters.ElementDelimiter);
+            var parameterText = text.Split(Delimiters.ElementDelimiter);
 
             return IsIntConvertible(default)
-                ? new Range<TElement>((TElement)Int32ConverterFactory.ConvertFromString(parameterText[0], inRow, inMemberMapData),
-                                      (TElement)Int32ConverterFactory.ConvertFromString(parameterText[1], inRow, inMemberMapData))
+                ? new Range<TElement>((TElement)Int32ConverterFactory.ConvertFromString(parameterText[0], row, memberMapData),
+                                      (TElement)Int32ConverterFactory.ConvertFromString(parameterText[1], row, memberMapData))
                 : IsSingleConvertible(default)
-                    ? new Range<TElement>((TElement)SingleConverterFactory.ConvertFromString(parameterText[0], inRow, inMemberMapData),
-                                          (TElement)SingleConverterFactory.ConvertFromString(parameterText[1], inRow, inMemberMapData))
+                    ? new Range<TElement>((TElement)SingleConverterFactory.ConvertFromString(parameterText[0], row, memberMapData),
+                                          (TElement)SingleConverterFactory.ConvertFromString(parameterText[1], row, memberMapData))
                     : Logger.DefaultWithUnsupportedSerializationLog(nameof(Range<TElement>), None);
 
             // Determines if the given variable may be deserialized as an integer.
@@ -241,17 +241,17 @@ namespace Parquet
         }
 
         /// <summary>
-        /// Determines if the given <paramref name="inValue"/> is contained by any of the <see cref="Range{TElement}"/>s
+        /// Determines if the given <paramref name="value"/> is contained by any of the <see cref="Range{TElement}"/>s
         /// in the current <see cref="IEnumerable{Range}"/>.
         /// </summary>
         /// <param name="inRangeCollection">The range collection in which to search.</param>
-        /// <param name="inValue">The value to search for.</param>
+        /// <param name="value">The value to search for.</param>
         /// <typeparam name="TElement">The type over which the Ranges are defined.</typeparam>
         /// <returns>
-        /// <c>true</c>, if <paramref name="inRangeCollection"/> contains the <paramref name="inValue"/>,
+        /// <c>true</c>, if <paramref name="inRangeCollection"/> contains the <paramref name="value"/>,
         /// <c>false</c> otherwise.
         /// </returns>
-        public static bool ContainsValue<TElement>(this IEnumerable<Range<TElement>> inRangeCollection, TElement inValue)
+        public static bool ContainsValue<TElement>(this IEnumerable<Range<TElement>> inRangeCollection, TElement value)
             where TElement : IComparable<TElement>, IEquatable<TElement>
         {
             Precondition.IsNotNull(inRangeCollection, nameof(inRangeCollection));
@@ -259,7 +259,7 @@ namespace Parquet
             var foundRange = false;
             foreach (var range in inRangeCollection ?? Enumerable.Empty<Range<TElement>>())
             {
-                if (range.ContainsValue(inValue))
+                if (range.ContainsValue(value))
                 {
                     foundRange = true;
                     break;

--- a/ParquetClassLibrary/RecipeElement.cs
+++ b/ParquetClassLibrary/RecipeElement.cs
@@ -45,14 +45,14 @@ namespace Parquet
         /// <summary>
         /// Initializes a new instance of the <see cref="RecipeElement"/> class.
         /// </summary>
-        /// <param name="inElementAmount">The amount of the element.  Must be positive.</param>
-        /// <param name="inElementTag">A <see cref="ModelTag"/> describing the element.</param>
-        public RecipeElement(int inElementAmount, ModelTag inElementTag)
+        /// <param name="elementAmount">The amount of the element.  Must be positive.</param>
+        /// <param name="elementTag">A <see cref="ModelTag"/> describing the element.</param>
+        public RecipeElement(int elementAmount, ModelTag elementTag)
         {
-            Precondition.MustBePositive(inElementAmount, nameof(inElementAmount));
+            Precondition.MustBePositive(elementAmount, nameof(elementAmount));
 
-            ElementAmount = inElementAmount;
-            ElementTag = inElementTag;
+            ElementAmount = elementAmount;
+            ElementTag = elementTag;
         }
         #endregion
 
@@ -69,11 +69,11 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="RecipeElement"/> is equal to the current <see cref="RecipeElement"/>.
         /// </summary>
-        /// <param name="inElement">The <see cref="RecipeElement"/> to compare with the current.</param>
+        /// <param name="element">The <see cref="RecipeElement"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(RecipeElement inElement)
-            => inElement?.ElementTag == ElementTag
-            && inElement?.ElementAmount == ElementAmount;
+        public bool Equals(RecipeElement element)
+            => element?.ElementTag == ElementTag
+            && element?.ElementAmount == ElementAmount;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="RecipeElement"/>.
@@ -87,20 +87,20 @@ namespace Parquet
         /// <summary>
         /// Determines whether a specified instance of <see cref="RecipeElement"/> is equal to another specified instance of <see cref="RecipeElement"/>.
         /// </summary>
-        /// <param name="inElement1">The first <see cref="RecipeElement"/> to compare.</param>
-        /// <param name="inElement2">The second <see cref="RecipeElement"/> to compare.</param>
+        /// <param name="element1">The first <see cref="RecipeElement"/> to compare.</param>
+        /// <param name="element2">The second <see cref="RecipeElement"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(RecipeElement inElement1, RecipeElement inElement2)
-            => inElement1?.Equals(inElement2) ?? inElement2?.Equals(inElement1) ?? true;
+        public static bool operator ==(RecipeElement element1, RecipeElement element2)
+            => element1?.Equals(element2) ?? element2?.Equals(element1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="RecipeElement"/> is not equal to another specified instance of <see cref="RecipeElement"/>.
         /// </summary>
-        /// <param name="inElement1">The first <see cref="RecipeElement"/> to compare.</param>
-        /// <param name="inElement2">The second <see cref="RecipeElement"/> to compare.</param>
+        /// <param name="element1">The first <see cref="RecipeElement"/> to compare.</param>
+        /// <param name="element2">The second <see cref="RecipeElement"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(RecipeElement inElement1, RecipeElement inElement2)
-            => !(inElement1 == inElement2);
+        public static bool operator !=(RecipeElement element1, RecipeElement element2)
+            => !(element1 == element2);
         #endregion
 
         #region ITypeConverter Implementation

--- a/ParquetClassLibrary/RecipeElement.cs
+++ b/ParquetClassLibrary/RecipeElement.cs
@@ -110,19 +110,19 @@ namespace Parquet
         /// <summary>
         /// Converts the given record column to <see cref="RecipeElement"/>.
         /// </summary>
-        /// <param name="inText">The record column to convert to an object.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The record column to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <returns>The <see cref="ModelTag"/> created from the record column.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(None), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(None), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return None;
             }
 
-            var elementSplitText = inText.Split(Delimiters.InternalDelimiter);
+            var elementSplitText = text.Split(Delimiters.InternalDelimiter);
 
             var elementAmountText = elementSplitText[0];
             var elementTagText = elementSplitText[1];
@@ -130,7 +130,7 @@ namespace Parquet
             var amount = int.TryParse(elementAmountText, All.SerializedNumberStyle, CultureInfo.InvariantCulture, out var temp)
                 ? temp
                 : Logger.DefaultWithParseLog(elementAmountText, nameof(ElementAmount), 0);
-            var tag = (ModelTag)ModelTag.None.ConvertFromString(elementTagText, inRow, inMemberMapData);
+            var tag = (ModelTag)ModelTag.None.ConvertFromString(elementTagText, row, memberMapData);
 
             return new RecipeElement(amount, tag);
         }
@@ -138,17 +138,17 @@ namespace Parquet
         /// <summary>
         /// Converts the given <see cref="RecipeElement"/> to a record column.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
         /// <returns>The <see cref="RecipeElement"/> as a CSV record.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is RecipeElement recipeElement
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is RecipeElement recipeElement
                 ? recipeElement == None
                     ? nameof(None)
                     : $"{recipeElement.ElementAmount}{Delimiters.InternalDelimiter}" +
                       $"{recipeElement.ElementTag}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(RecipeElement), nameof(None));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(RecipeElement), nameof(None));
         #endregion
 
         #region Utilities

--- a/ParquetClassLibrary/RecipeElement.cs
+++ b/ParquetClassLibrary/RecipeElement.cs
@@ -69,11 +69,11 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="RecipeElement"/> is equal to the current <see cref="RecipeElement"/>.
         /// </summary>
-        /// <param name="element">The <see cref="RecipeElement"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="RecipeElement"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(RecipeElement element)
-            => element?.ElementTag == ElementTag
-            && element?.ElementAmount == ElementAmount;
+        public bool Equals(RecipeElement other)
+            => other?.ElementTag == ElementTag
+            && other?.ElementAmount == ElementAmount;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="RecipeElement"/>.

--- a/ParquetClassLibrary/Regions/ChunkDetail.cs
+++ b/ParquetClassLibrary/Regions/ChunkDetail.cs
@@ -130,46 +130,46 @@ namespace Parquet.Regions
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is ChunkDetail chunk
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is ChunkDetail chunk
                 ? chunk == None
                     ? nameof(None)
                     : $"{chunk.BaseTopography}{Delimiters.InternalDelimiter}" +
                       $"{chunk.BaseComposition}{Delimiters.InternalDelimiter}" +
                       $"{chunk.ModifierTopography}{Delimiters.InternalDelimiter}" +
                       $"{chunk.ModifierComposition}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(ChunkDetail), nameof(None));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(ChunkDetail), nameof(None));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(None), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(None), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return None;
             }
             else
             {
-                var parameterText = inText.Split(Delimiters.InternalDelimiter);
+                var parameterText = text.Split(Delimiters.InternalDelimiter);
 
                 var baseTopography = Enum.TryParse(typeof(ChunkTopography), parameterText[0], true, out var temp1)
                     ? (ChunkTopography)temp1
                     : Logger.DefaultWithParseLog(parameterText[0], nameof(BaseTopography), ChunkTopography.Empty);
-                var baseComposition = (ModelTag)ModelTag.ConverterFactory.ConvertFromString(parameterText[1], inRow, inMemberMapData);
+                var baseComposition = (ModelTag)ModelTag.ConverterFactory.ConvertFromString(parameterText[1], row, memberMapData);
                 var modifierTopography = Enum.TryParse(typeof(ChunkTopography), parameterText[2], true, out var temp2)
                     ? (ChunkTopography)temp2
                     : Logger.DefaultWithParseLog(parameterText[2], nameof(ModifierTopography), ChunkTopography.Empty);
-                var modifierComposition = (ModelTag)ModelTag.ConverterFactory.ConvertFromString(parameterText[3], inRow, inMemberMapData);
+                var modifierComposition = (ModelTag)ModelTag.ConverterFactory.ConvertFromString(parameterText[3], row, memberMapData);
 
                 return new ChunkDetail(baseTopography, baseComposition, modifierTopography, modifierComposition);
             }

--- a/ParquetClassLibrary/Regions/ChunkDetail.cs
+++ b/ParquetClassLibrary/Regions/ChunkDetail.cs
@@ -85,13 +85,13 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines whether the specified <see cref="ChunkDetail"/> is equal to the current <see cref="ChunkDetail"/>.
         /// </summary>
-        /// <param name="chunkType">The <see cref="ChunkDetail"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="ChunkDetail"/> to compare with the current.</param>
         /// <returns><c>true</c> if the <see cref="ChunkDetail"/>s are equal.</returns>
-        public bool Equals(ChunkDetail chunkType)
-            => BaseTopography == chunkType?.BaseTopography
-            && BaseComposition == chunkType.BaseComposition
-            && ModifierTopography == chunkType.ModifierTopography
-            && ModifierComposition == chunkType.ModifierComposition;
+        public bool Equals(ChunkDetail other)
+            => BaseTopography == other?.BaseTopography
+            && BaseComposition == other.BaseComposition
+            && ModifierTopography == other.ModifierTopography
+            && ModifierComposition == other.ModifierComposition;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="ChunkDetail"/>.

--- a/ParquetClassLibrary/Regions/ChunkDetail.cs
+++ b/ParquetClassLibrary/Regions/ChunkDetail.cs
@@ -60,17 +60,17 @@ namespace Parquet.Regions
         /// <summary>
         /// Initializes a new instance of the <see cref="ChunkDetail"/> class.
         /// </summary>
-        /// <param name="inBaseTopography">The basic form that the <see cref="MapChunk"/> of parquets takes.</param>
-        /// <param name="inBaseComposition">Indicates the overall type of parquets in the <see cref="MapChunk"/>.</param>
-        /// <param name="inModifierTopography">Indicates a modifier on the <see cref="MapChunk"/> of parquets.</param>
-        /// <param name="inModifierComposition">Indicates the type of parquets modifying the <see cref="MapChunk"/>.</param>
-        public ChunkDetail(ChunkTopography inBaseTopography, ModelTag inBaseComposition,
-                                ChunkTopography inModifierTopography, ModelTag inModifierComposition)
+        /// <param name="baseTopography">The basic form that the <see cref="MapChunk"/> of parquets takes.</param>
+        /// <param name="baseComposition">Indicates the overall type of parquets in the <see cref="MapChunk"/>.</param>
+        /// <param name="modifierTopography">Indicates a modifier on the <see cref="MapChunk"/> of parquets.</param>
+        /// <param name="modifierComposition">Indicates the type of parquets modifying the <see cref="MapChunk"/>.</param>
+        public ChunkDetail(ChunkTopography baseTopography, ModelTag baseComposition,
+                                ChunkTopography modifierTopography, ModelTag modifierComposition)
         {
-            BaseTopography = inBaseTopography;
-            BaseComposition = inBaseComposition ?? ModelTag.None;
-            ModifierTopography = inModifierTopography;
-            ModifierComposition = inModifierComposition ?? ModelTag.None;
+            BaseTopography = baseTopography;
+            BaseComposition = baseComposition ?? ModelTag.None;
+            ModifierTopography = modifierTopography;
+            ModifierComposition = modifierComposition ?? ModelTag.None;
         }
         #endregion
 
@@ -85,13 +85,13 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines whether the specified <see cref="ChunkDetail"/> is equal to the current <see cref="ChunkDetail"/>.
         /// </summary>
-        /// <param name="inChunkType">The <see cref="ChunkDetail"/> to compare with the current.</param>
+        /// <param name="chunkType">The <see cref="ChunkDetail"/> to compare with the current.</param>
         /// <returns><c>true</c> if the <see cref="ChunkDetail"/>s are equal.</returns>
-        public bool Equals(ChunkDetail inChunkType)
-            => BaseTopography == inChunkType?.BaseTopography
-            && BaseComposition == inChunkType.BaseComposition
-            && ModifierTopography == inChunkType.ModifierTopography
-            && ModifierComposition == inChunkType.ModifierComposition;
+        public bool Equals(ChunkDetail chunkType)
+            => BaseTopography == chunkType?.BaseTopography
+            && BaseComposition == chunkType.BaseComposition
+            && ModifierTopography == chunkType.ModifierTopography
+            && ModifierComposition == chunkType.ModifierComposition;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="ChunkDetail"/>.
@@ -106,21 +106,21 @@ namespace Parquet.Regions
         /// Determines whether a specified instance of <see cref="ChunkDetail"/> is equal to
         /// another specified instance of <see cref="ChunkDetail"/>.
         /// </summary>
-        /// <param name="inChunkType1">The first <see cref="ChunkDetail"/> to compare.</param>
-        /// <param name="inChunkType2">The second <see cref="ChunkDetail"/> to compare.</param>
+        /// <param name="chunkType1">The first <see cref="ChunkDetail"/> to compare.</param>
+        /// <param name="chunkType2">The second <see cref="ChunkDetail"/> to compare.</param>
         /// <returns><c>true</c> if the two <see cref="ChunkDetail"/>s are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(ChunkDetail inChunkType1, ChunkDetail inChunkType2)
-            => inChunkType1?.Equals(inChunkType2) ?? inChunkType2?.Equals(inChunkType1) ?? true;
+        public static bool operator ==(ChunkDetail chunkType1, ChunkDetail chunkType2)
+            => chunkType1?.Equals(chunkType2) ?? chunkType2?.Equals(chunkType1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ChunkDetail"/> is unequal to
         /// another specified instance of <see cref="ChunkDetail"/>.
         /// </summary>
-        /// <param name="inChunkType1">The first <see cref="ChunkDetail"/> to compare.</param>
-        /// <param name="inChunkType2">The second <see cref="ChunkDetail"/> to compare.</param>
+        /// <param name="chunkType1">The first <see cref="ChunkDetail"/> to compare.</param>
+        /// <param name="chunkType2">The second <see cref="ChunkDetail"/> to compare.</param>
         /// <returns><c>true</c> if the two <see cref="ChunkDetail"/>s are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(ChunkDetail inChunkType1, ChunkDetail inChunkType2)
-            => !(inChunkType1 == inChunkType2);
+        public static bool operator !=(ChunkDetail chunkType1, ChunkDetail chunkType2)
+            => !(chunkType1 == chunkType2);
         #endregion
 
         #region ITypeConverter Implementation

--- a/ParquetClassLibrary/Regions/MapChunk.cs
+++ b/ParquetClassLibrary/Regions/MapChunk.cs
@@ -133,13 +133,13 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines whether the specified <see cref="MapChunk"/> is equal to the current <see cref="MapChunk"/>.
         /// </summary>
-        /// <param name="chunk">The <see cref="MapChunk"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="MapChunk"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(MapChunk chunk)
-            => chunk is MapChunk mapChunk
-            && IsFilledOut == mapChunk.IsFilledOut
-            && Details == mapChunk.Details
-            && ParquetDefinitions == mapChunk.ParquetDefinitions;
+        public bool Equals(MapChunk other)
+            => other is MapChunk chunk
+            && IsFilledOut == chunk.IsFilledOut
+            && Details == chunk.Details
+            && ParquetDefinitions == chunk.ParquetDefinitions;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="MapChunk"/>.

--- a/ParquetClassLibrary/Regions/MapChunk.cs
+++ b/ParquetClassLibrary/Regions/MapChunk.cs
@@ -48,25 +48,24 @@ namespace Parquet.Regions
         /// <summary>
         /// Initializes an instance of the <see cref="MapChunk"/> class.
         /// </summary>
-        /// <param name="inIsFilledOut">
+        /// <param name="isFilledOut">
         /// If <c>true</c>, the <see cref="MapChunk"/> was either created at design time or
         /// has already been procedurally generated on load in-game.
         /// </param>
-        /// <param name="inDetails">Cues to the generation routines if generated at runtime.</param>
-        /// <param name="inParquetDefinitions">The definitions of the collected parquets if designed by hand.</param>        
-        public MapChunk(bool inIsFilledOut, ChunkDetail inDetails = null,
-                        IReadOnlyGrid<ParquetModelPack> inParquetDefinitions = null)
+        /// <param name="details">Cues to the generation routines if generated at runtime.</param>
+        /// <param name="parquetDefinitions">The definitions of the collected parquets if designed by hand.</param>        
+        public MapChunk(bool isFilledOut, ChunkDetail details = null, IReadOnlyGrid<ParquetModelPack> parquetDefinitions = null)
         {
-            IsFilledOut = inIsFilledOut;
+            IsFilledOut = isFilledOut;
 
             if (IsFilledOut)
             {
                 Details = ChunkDetail.None;
-                ParquetDefinitions = inParquetDefinitions ?? new ParquetModelPackGrid(ParquetsPerChunkDimension, ParquetsPerChunkDimension);
+                ParquetDefinitions = parquetDefinitions ?? new ParquetModelPackGrid(ParquetsPerChunkDimension, ParquetsPerChunkDimension);
             }
             else
             {
-                Details = inDetails ?? ChunkDetail.None;
+                Details = details ?? ChunkDetail.None;
                 ParquetDefinitions = ParquetModelPackGrid.Empty;
             }
         }
@@ -134,13 +133,13 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines whether the specified <see cref="MapChunk"/> is equal to the current <see cref="MapChunk"/>.
         /// </summary>
-        /// <param name="inChunk">The <see cref="MapChunk"/> to compare with the current.</param>
+        /// <param name="chunk">The <see cref="MapChunk"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(MapChunk inChunk)
-            => inChunk is MapChunk chunk
-            && IsFilledOut == chunk.IsFilledOut
-            && Details == chunk.Details
-            && ParquetDefinitions == chunk.ParquetDefinitions;
+        public bool Equals(MapChunk chunk)
+            => chunk is MapChunk mapChunk
+            && IsFilledOut == mapChunk.IsFilledOut
+            && Details == mapChunk.Details
+            && ParquetDefinitions == mapChunk.ParquetDefinitions;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="MapChunk"/>.
@@ -154,20 +153,20 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines whether a specified instance of <see cref="MapChunk"/> is equal to another specified instance of <see cref="MapChunk"/>.
         /// </summary>
-        /// <param name="inChunk1">The first <see cref="MapChunk"/> to compare.</param>
-        /// <param name="inChunk2">The second <see cref="MapChunk"/> to compare.</param>
+        /// <param name="chunk1">The first <see cref="MapChunk"/> to compare.</param>
+        /// <param name="chunk2">The second <see cref="MapChunk"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(MapChunk inChunk1, MapChunk inChunk2)
-            => inChunk1?.Equals(inChunk2) ?? inChunk2?.Equals(inChunk1) ?? true;
+        public static bool operator ==(MapChunk chunk1, MapChunk chunk2)
+            => chunk1?.Equals(chunk2) ?? chunk2?.Equals(chunk1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="MapChunk"/> is not equal to another specified instance of <see cref="MapChunk"/>.
         /// </summary>
-        /// <param name="inChunk1">The first <see cref="MapChunk"/> to compare.</param>
-        /// <param name="inChunk2">The second <see cref="MapChunk"/> to compare.</param>
+        /// <param name="chunk1">The first <see cref="MapChunk"/> to compare.</param>
+        /// <param name="chunk2">The second <see cref="MapChunk"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(MapChunk inChunk1, MapChunk inChunk2)
-            => !(inChunk1 == inChunk2);
+        public static bool operator !=(MapChunk chunk1, MapChunk chunk2)
+            => !(chunk1 == chunk2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -254,14 +253,14 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines if the given position corresponds to a point within the current array.
         /// </summary>
-        /// <param name="inArray">The <see cref="Pack{T}"/> array to validate against.</param>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="array">The <see cref="Pack{T}"/> array to validate against.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public static bool IsValidPosition(this MapChunk[,] inArray, Point2D inPosition)
-            => inArray is not null
-            && inPosition.X > -1
-            && inPosition.Y > -1
-            && inPosition.X < inArray.GetLength(1)
-            && inPosition.Y < inArray.GetLength(0);
+        public static bool IsValidPosition(this MapChunk[,] array, Point2D position)
+            => array is not null
+            && position.X > -1
+            && position.Y > -1
+            && position.X < array.GetLength(1)
+            && position.Y < array.GetLength(0);
     }
 }

--- a/ParquetClassLibrary/Regions/MapChunk.cs
+++ b/ParquetClassLibrary/Regions/MapChunk.cs
@@ -177,40 +177,40 @@ namespace Parquet.Regions
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is MapChunk chunk
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is MapChunk chunk
                 ? $"{IsFilledOut}{Delimiters.MapChunkDelimiter}" +
-                  $"{chunk.Details.ConvertToString(Details, inRow, inMemberMapData)}{Delimiters.MapChunkDelimiter}" +
-                  $"{GridConverter<ParquetModelPack, ParquetModelPackGrid>.ConverterFactory.ConvertToString(ParquetDefinitions, inRow, inMemberMapData)}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(MapChunk), nameof(Empty));
+                  $"{chunk.Details.ConvertToString(Details, row, memberMapData)}{Delimiters.MapChunkDelimiter}" +
+                  $"{GridConverter<ParquetModelPack, ParquetModelPackGrid>.ConverterFactory.ConvertToString(ParquetDefinitions, row, memberMapData)}"
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(MapChunk), nameof(Empty));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Empty), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Empty), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Empty;
             }
 
-            var parameterText = inText.Split(Delimiters.MapChunkDelimiter);
+            var parameterText = text.Split(Delimiters.MapChunkDelimiter);
             var parsedIsFilledOut = bool.TryParse(parameterText[0], out var tempIsFilledOut)
                 ? tempIsFilledOut
                 : Logger.DefaultWithParseLog(parameterText[0], nameof(IsFilledOut), false);
-            var parsedDetails = (ChunkDetail)ChunkDetail.ConverterFactory.ConvertFromString(parameterText[1], inRow, inMemberMapData);
+            var parsedDetails = (ChunkDetail)ChunkDetail.ConverterFactory.ConvertFromString(parameterText[1], row, memberMapData);
             var parsedParquetDefinitions = (ParquetModelPackGrid)GridConverter<ParquetModelPack, ParquetModelPackGrid>
                 .ConverterFactory
-                .ConvertFromString(parameterText[2], inRow, inMemberMapData);
+                .ConvertFromString(parameterText[2], row, memberMapData);
 
             return new MapChunk(parsedIsFilledOut, parsedDetails, parsedParquetDefinitions);
         }

--- a/ParquetClassLibrary/Regions/MapChunkGrid.cs
+++ b/ParquetClassLibrary/Regions/MapChunkGrid.cs
@@ -31,14 +31,14 @@ namespace Parquet.Regions
         /// <summary>
         /// Initializes a new empty <see cref="MapChunkGrid"/>.
         /// </summary>
-        /// <param name="inRowCount">The length of the Y dimension of the collection.</param>
-        /// <param name="inColumnCount">The length of the X dimension of the collection.</param>
-        public MapChunkGrid(int inRowCount, int inColumnCount)
+        /// <param name="rowCount">The length of the Y dimension of the collection.</param>
+        /// <param name="columnCount">The length of the X dimension of the collection.</param>
+        public MapChunkGrid(int rowCount, int columnCount)
         {
-            MapChunks = new MapChunk[inRowCount, inColumnCount];
-            for (var y = 0; y < inRowCount; y++)
+            MapChunks = new MapChunk[rowCount, columnCount];
+            for (var y = 0; y < rowCount; y++)
             {
-                for (var x = 0; x < inColumnCount; x++)
+                for (var x = 0; x < columnCount; x++)
                 {
                     MapChunks[y, x] = new MapChunk();
                 }
@@ -48,9 +48,9 @@ namespace Parquet.Regions
         /// <summary>
         /// Initializes a new <see cref="MapChunkGrid"/> from the given 2D <see cref="MapChunk"/> array.
         /// </summary>
-        /// <param name="inMapChunkArray">An existing array of MapChunks.</param>
-        public MapChunkGrid(MapChunk[,] inMapChunkArray)
-            => MapChunks = inMapChunkArray;
+        /// <param name="mapChunkArray">An existing array of MapChunks.</param>
+        public MapChunkGrid(MapChunk[,] mapChunkArray)
+            => MapChunks = mapChunkArray;
         #endregion
 
         #region IGrid Implementation
@@ -139,10 +139,10 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines if the given position corresponds to a point within the collection.
         /// </summary>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public bool IsValidPosition(Point2D inPosition)
-            => MapChunks.IsValidPosition(inPosition);
+        public bool IsValidPosition(Point2D position)
+            => MapChunks.IsValidPosition(position);
         #endregion
     }
 }

--- a/ParquetClassLibrary/Regions/RegionModel.cs
+++ b/ParquetClassLibrary/Regions/RegionModel.cs
@@ -83,39 +83,39 @@ namespace Parquet.Regions
         /// <param name="description">Player-friendly description of the <see cref="RegionModel"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="RegionModel"/>.</param>
         /// <param name="tags">Any additional information about the <see cref="RegionModel"/>.</param>
-        /// <param name="inBackgroundColor">A color to show in the <see cref="RegionModel"/> when no parquets are present at a location.</param>
-        /// <param name="inRegionToTheNorth">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the north of this one.</param>
-        /// <param name="inRegionToTheEast">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the east of this one.</param>
-        /// <param name="inRegionToTheSouth">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the south of this one.</param>
-        /// <param name="inRegionToTheWest">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the west of this one.</param>
-        /// <param name="inRegionAbove">The <see cref="ModelID"/> of the <see cref="RegionModel"/> above this one.</param>
-        /// <param name="inRegionBelow">The <see cref="ModelID"/> of the <see cref="RegionModel"/> below this one.</param>
+        /// <param name="backgroundColor">A color to show in the <see cref="RegionModel"/> when no parquets are present at a location.</param>
+        /// <param name="regionToTheNorth">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the north of this one.</param>
+        /// <param name="regionToTheEast">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the east of this one.</param>
+        /// <param name="regionToTheSouth">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the south of this one.</param>
+        /// <param name="regionToTheWest">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the west of this one.</param>
+        /// <param name="regionAbove">The <see cref="ModelID"/> of the <see cref="RegionModel"/> above this one.</param>
+        /// <param name="regionBelow">The <see cref="ModelID"/> of the <see cref="RegionModel"/> below this one.</param>
         public RegionModel(ModelID id, string name, string description, string comment,
                            IEnumerable<ModelTag> tags = null,
-                           string inBackgroundColor = DefaultColor,
-                           ModelID? inRegionToTheNorth = null,
-                           ModelID? inRegionToTheEast = null,
-                           ModelID? inRegionToTheSouth = null,
-                           ModelID? inRegionToTheWest = null,
-                           ModelID? inRegionAbove = null,
-                           ModelID? inRegionBelow = null)
+                           string backgroundColor = DefaultColor,
+                           ModelID? regionToTheNorth = null,
+                           ModelID? regionToTheEast = null,
+                           ModelID? regionToTheSouth = null,
+                           ModelID? regionToTheWest = null,
+                           ModelID? regionAbove = null,
+                           ModelID? regionBelow = null)
             : base(Bounds, id, name, description, comment, tags)
         {
-            var nonNullRegionToTheNorth = inRegionToTheNorth ?? ModelID.None;
-            var nonNullRegionToTheEast = inRegionToTheEast ?? ModelID.None;
-            var nonNullRegionToTheSouth = inRegionToTheSouth ?? ModelID.None;
-            var nonNullRegionToTheWest = inRegionToTheWest ?? ModelID.None;
-            var nonNullRegionAbove = inRegionAbove ?? ModelID.None;
-            var nonNullRegionBelow = inRegionBelow ?? ModelID.None;
+            var nonNullRegionToTheNorth = regionToTheNorth ?? ModelID.None;
+            var nonNullRegionToTheEast = regionToTheEast ?? ModelID.None;
+            var nonNullRegionToTheSouth = regionToTheSouth ?? ModelID.None;
+            var nonNullRegionToTheWest = regionToTheWest ?? ModelID.None;
+            var nonNullRegionAbove = regionAbove ?? ModelID.None;
+            var nonNullRegionBelow = regionBelow ?? ModelID.None;
 
-            Precondition.IsInRange(nonNullRegionToTheNorth, Bounds, nameof(inRegionToTheNorth));
-            Precondition.IsInRange(nonNullRegionToTheEast, Bounds, nameof(inRegionToTheEast));
-            Precondition.IsInRange(nonNullRegionToTheSouth, Bounds, nameof(inRegionToTheSouth));
-            Precondition.IsInRange(nonNullRegionToTheWest, Bounds, nameof(inRegionToTheWest));
-            Precondition.IsInRange(nonNullRegionAbove, Bounds, nameof(inRegionAbove));
-            Precondition.IsInRange(nonNullRegionBelow, Bounds, nameof(inRegionBelow));
+            Precondition.IsInRange(nonNullRegionToTheNorth, Bounds, nameof(regionToTheNorth));
+            Precondition.IsInRange(nonNullRegionToTheEast, Bounds, nameof(regionToTheEast));
+            Precondition.IsInRange(nonNullRegionToTheSouth, Bounds, nameof(regionToTheSouth));
+            Precondition.IsInRange(nonNullRegionToTheWest, Bounds, nameof(regionToTheWest));
+            Precondition.IsInRange(nonNullRegionAbove, Bounds, nameof(regionAbove));
+            Precondition.IsInRange(nonNullRegionBelow, Bounds, nameof(regionBelow));
 
-            BackgroundColor = inBackgroundColor;
+            BackgroundColor = backgroundColor;
             RegionToTheNorth = nonNullRegionToTheNorth;
             RegionToTheEast = nonNullRegionToTheEast;
             RegionToTheSouth = nonNullRegionToTheSouth;
@@ -163,7 +163,7 @@ namespace Parquet.Regions
         /// <summary>
         /// Takes a <see cref="RegionModel"/> and returns the <see cref="ModelID" /> of an adjacent RegionModel.
         /// </summary>
-        private delegate ModelID IDByDirection(RegionModel inRegion);
+        private delegate ModelID IDByDirection(RegionModel region);
 
         /// <summary>
         /// A database of directions and their opposites, together with the properties needed to inspect both.
@@ -194,20 +194,20 @@ namespace Parquet.Regions
         /// That is, if the player leaves Region 1 by going North and cannot then return to Region 1 by going south,
         /// that is considered inconsistent and will be reported.
         /// </summary>
-        /// <param name="inRegionID">The <see cref="ModelID"/> of the origination and destination map.</param>
+        /// <param name="regionID">The <see cref="ModelID"/> of the origination and destination map.</param>
         /// <returns>A report of all exit directions leading to regions whose own exits are inconsistent.</returns>
         [SuppressMessage("Style", "IDE0042:Deconstruct variable declaration",
             Justification = "In this instance it makes the code less readable.")]
-        public static ICollection<string> CheckExitConsistency(ModelID inRegionID)
+        public static ICollection<string> CheckExitConsistency(ModelID regionID)
         {
             var inconsistentExitDirections = new List<string>();
 
-            if (inRegionID == ModelID.None)
+            if (regionID == ModelID.None)
             {
                 return inconsistentExitDirections;
             }
 
-            var currentRegion = All.Regions.GetOrNull<RegionModel>(inRegionID);
+            var currentRegion = All.Regions.GetOrNull<RegionModel>(regionID);
 
             if (currentRegion is null)
             {
@@ -228,7 +228,7 @@ namespace Parquet.Regions
                     continue;
                 }
 
-                if (directionPair.GetReturningRegionID(adjacentRegion) != inRegionID)
+                if (directionPair.GetReturningRegionID(adjacentRegion) != regionID)
                 {
                     inconsistentExitDirections.Add(
                         $"{adjacentRegion.Name} is {directionPair.LeavingDirection} of {currentRegion.Name} but " +

--- a/ParquetClassLibrary/Regions/RegionModel.cs
+++ b/ParquetClassLibrary/Regions/RegionModel.cs
@@ -78,11 +78,11 @@ namespace Parquet.Regions
         /// <summary>
         /// Constructs a new instance of the <see cref="RegionModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="RegionModel"/>.  Cannot be null.</param>
-        /// <param name="inName">The player-facing name of the <see cref="RegionModel"/>.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="RegionModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="RegionModel"/>.</param>
-        /// <param name="inTags">Any additional information about the <see cref="RegionModel"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="RegionModel"/>.  Cannot be null.</param>
+        /// <param name="name">The player-facing name of the <see cref="RegionModel"/>.</param>
+        /// <param name="description">Player-friendly description of the <see cref="RegionModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="RegionModel"/>.</param>
+        /// <param name="tags">Any additional information about the <see cref="RegionModel"/>.</param>
         /// <param name="inBackgroundColor">A color to show in the <see cref="RegionModel"/> when no parquets are present at a location.</param>
         /// <param name="inRegionToTheNorth">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the north of this one.</param>
         /// <param name="inRegionToTheEast">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the east of this one.</param>
@@ -90,8 +90,8 @@ namespace Parquet.Regions
         /// <param name="inRegionToTheWest">The <see cref="ModelID"/> of the <see cref="RegionModel"/> to the west of this one.</param>
         /// <param name="inRegionAbove">The <see cref="ModelID"/> of the <see cref="RegionModel"/> above this one.</param>
         /// <param name="inRegionBelow">The <see cref="ModelID"/> of the <see cref="RegionModel"/> below this one.</param>
-        public RegionModel(ModelID inID, string inName, string inDescription, string inComment,
-                           IEnumerable<ModelTag> inTags = null,
+        public RegionModel(ModelID id, string name, string description, string comment,
+                           IEnumerable<ModelTag> tags = null,
                            string inBackgroundColor = DefaultColor,
                            ModelID? inRegionToTheNorth = null,
                            ModelID? inRegionToTheEast = null,
@@ -99,7 +99,7 @@ namespace Parquet.Regions
                            ModelID? inRegionToTheWest = null,
                            ModelID? inRegionAbove = null,
                            ModelID? inRegionBelow = null)
-            : base(Bounds, inID, inName, inDescription, inComment, inTags)
+            : base(Bounds, id, name, description, comment, tags)
         {
             var nonNullRegionToTheNorth = inRegionToTheNorth ?? ModelID.None;
             var nonNullRegionToTheEast = inRegionToTheEast ?? ModelID.None;

--- a/ParquetClassLibrary/Regions/RegionStatus.cs
+++ b/ParquetClassLibrary/Regions/RegionStatus.cs
@@ -363,10 +363,10 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines whether the specified <see cref="RegionStatus"/> is equal to the current <see cref="RegionStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="RegionStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="RegionStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is RegionStatus regionStatus
+        public override bool Equals<T>(T status)
+            => status is RegionStatus regionStatus
             && ParquetModels == regionStatus.ParquetModels
             && ParquetStatuses == regionStatus.ParquetStatuses;
 
@@ -382,20 +382,20 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines whether a specified instance of <see cref="RegionStatus"/> is equal to another specified instance of <see cref="RegionStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="RegionStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="RegionStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="RegionStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="RegionStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(RegionStatus inStatus1, RegionStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(RegionStatus status1, RegionStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="RegionStatus"/> is not equal to another specified instance of <see cref="RegionStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="RegionStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="RegionStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="RegionStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="RegionStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(RegionStatus inStatus1, RegionStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(RegionStatus status1, RegionStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -405,39 +405,39 @@ namespace Parquet.Regions
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is RegionStatus status
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is RegionStatus status
                 // NOTE Tertiary delimiter is used here to separate ParquetModelPackGrid from ParquetStatusPackGrid.
-                ? $"{GridConverter<ParquetModelPack, ParquetModelPackGrid>.ConverterFactory.ConvertToString(ParquetModels, inRow, inMemberMapData)}{Delimiters.TertiaryDelimiter}" +
-                  $"{GridConverter<ParquetStatusPack, ParquetStatusPackGrid>.ConverterFactory.ConvertToString(ParquetStatuses, inRow, inMemberMapData)}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(MapChunk), nameof(Unused));
+                ? $"{GridConverter<ParquetModelPack, ParquetModelPackGrid>.ConverterFactory.ConvertToString(ParquetModels, row, memberMapData)}{Delimiters.TertiaryDelimiter}" +
+                  $"{GridConverter<ParquetStatusPack, ParquetStatusPackGrid>.ConverterFactory.ConvertToString(ParquetStatuses, row, memberMapData)}"
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(MapChunk), nameof(Unused));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Unused), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Unused), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Unused.DeepClone();
             }
 
-            var parameterText = inText.Split(Delimiters.TertiaryDelimiter);
+            var parameterText = text.Split(Delimiters.TertiaryDelimiter);
             var parsedParquetModels = (ParquetModelPackGrid)GridConverter<ParquetModelPack, ParquetModelPackGrid>
                 .ConverterFactory
-                .ConvertFromString(parameterText[0], inRow, inMemberMapData);
+                .ConvertFromString(parameterText[0], row, memberMapData);
             var parsedParquetStatuses = (ParquetStatusPackGrid)GridConverter<ParquetStatusPack, ParquetStatusPackGrid>
                 .ConverterFactory
-                .ConvertFromString(parameterText[1], inRow, inMemberMapData);
+                .ConvertFromString(parameterText[1], row, memberMapData);
 
             return new RegionStatus(parsedParquetModels, parsedParquetStatuses);
         }

--- a/ParquetClassLibrary/Regions/RegionStatus.cs
+++ b/ParquetClassLibrary/Regions/RegionStatus.cs
@@ -60,12 +60,12 @@ namespace Parquet.Regions
         /// <summary>
         /// Initializes a new instance of the <see cref="RegionStatus"/> class.
         /// </summary>
-        /// <param name="inParquetModels">The definitions of parquets that make up the region.</param>
-        /// <param name="inParquetStatuses">The statuses of parquets that make up the region.</param>
-        public RegionStatus(ParquetModelPackGrid inParquetModels, ParquetStatusPackGrid inParquetStatuses)
+        /// <param name="parquetModels">The definitions of parquets that make up the region.</param>
+        /// <param name="parquetStatuses">The statuses of parquets that make up the region.</param>
+        public RegionStatus(ParquetModelPackGrid parquetModels, ParquetStatusPackGrid parquetStatuses)
         {
-            var nonNullParquetModels = inParquetModels ?? ParquetModelPackGrid.Empty;
-            var nonNullParquetStatuses = inParquetStatuses ?? ParquetStatusPackGrid.Empty;
+            var nonNullParquetModels = parquetModels ?? ParquetModelPackGrid.Empty;
+            var nonNullParquetStatuses = parquetStatuses ?? ParquetStatusPackGrid.Empty;
 
             // Ensure grid dimensions are equal.
             if (nonNullParquetModels.Columns != nonNullParquetStatuses.Columns
@@ -86,14 +86,14 @@ namespace Parquet.Regions
         /// based on a given <see cref="RegionModel"/> instance.
         /// </summary>
         /// <remarks>This is the entry point for map procedural generation.</remarks>
-        /// <param name="inRegionModel">The region definition whose status is being tracked.</param>
+        /// <param name="regionModel">The region definition whose status is being tracked.</param>
         // TODO [PROC GEN] Review and update this entire routine.
-        public RegionStatus(RegionModel inRegionModel)
+        public RegionStatus(RegionModel regionModel)
         {
-            Precondition.IsNotNull(inRegionModel);
-            var nonNullRegionModel = inRegionModel is null
+            Precondition.IsNotNull(regionModel);
+            var nonNullRegionModel = regionModel is null
                 ? RegionModel.Empty
-                : inRegionModel;
+                : regionModel;
 
             Debug.Assert(nonNullRegionModel.MapChunks.Rows == RegionModel.ChunksPerRegionDimension, "Row size mismatch.");
             Debug.Assert(nonNullRegionModel.MapChunks.Columns == RegionModel.ChunksPerRegionDimension, "Column size mismatch.");
@@ -157,40 +157,40 @@ namespace Parquet.Regions
 
             #region Local Helper Methods
             // Determines if the given BiomeRecipe matches the given Region.
-            //     inRegion -> The MapRegionModel to test.
+            //     region -> The MapRegionModel to test.
             //     inBiome -> The BiomeRecipe to test against.
             // Returns the given BiomeRecipe's ModelID if they match, otherwise returns the ModelID for the default biome.
-            static ModelID FindBiomeByTag(RegionStatus inRegion, BiomeRecipe inBiome)
+            static ModelID FindBiomeByTag(RegionStatus region, BiomeRecipe inBiome)
                 // Prioritization of biome categories is hard-coded in the following way:
                 //    1 Room-based Biomes supersede
                 //    2 Liquid-based Biomes, which supersede
                 //    3 Land-based Biomes, which supersede
                 //    4 the default Biome.
                 => (inBiome.IsRoomBased
-                    && GetParquetsInRooms(inRegion) >= BiomeConfiguration.RoomThreshold
-                    && ConstitutesBiome(inRegion, inBiome, BiomeConfiguration.RoomThreshold))
+                    && GetParquetsInRooms(region) >= BiomeConfiguration.RoomThreshold
+                    && ConstitutesBiome(region, inBiome, BiomeConfiguration.RoomThreshold))
                 || (inBiome.IsLiquidBased
-                    && ConstitutesBiome(inRegion, inBiome, BiomeConfiguration.LiquidThreshold))
-                || ConstitutesBiome(inRegion, inBiome, BiomeConfiguration.LandThreshold)
+                    && ConstitutesBiome(region, inBiome, BiomeConfiguration.LiquidThreshold))
+                || ConstitutesBiome(region, inBiome, BiomeConfiguration.LandThreshold)
                     ? inBiome.ID
                     : BiomeRecipe.None.ID;
 
             // Determines the number of individual parquets that are present inside Rooms in the given MapRegionModel.
-            //     inRegion -> The region to consider.
+            //     region -> The region to consider.
             // Returns the number of parquets that are part of a known Room.
-            static ModelID GetParquetsInRooms(RegionStatus inRegion)
+            static ModelID GetParquetsInRooms(RegionStatus region)
             {
                 var parquetsInRoom = 0;
 
                 // TODO [OPTIMIZATION] This might be a good place to optimize.
-                for (var y = 0; y < inRegion.ParquetModels.Rows; y++)
+                for (var y = 0; y < region.ParquetModels.Rows; y++)
                 {
-                    for (var x = 0; x < inRegion.ParquetModels.Columns; x++)
+                    for (var x = 0; x < region.ParquetModels.Columns; x++)
                     {
-                        if (inRegion.Rooms.Any(room => room.ContainsPosition(new Point2D(x, y))))
+                        if (region.Rooms.Any(room => room.ContainsPosition(new Point2D(x, y))))
                         {
                             // NOTE that we are counting every parquet, including collectibles.
-                            parquetsInRoom += inRegion.ParquetModels[y, x].Count;
+                            parquetsInRoom += region.ParquetModels[y, x].Count;
                         }
                     }
                 }
@@ -199,26 +199,26 @@ namespace Parquet.Regions
             }
 
             // Determines if the given region has enough parquets contributing to the given biome to exceed the given threshold.
-            //     inRegion -> The region to test.
+            //     region -> The region to test.
             //     inBiome -> The biome to test against.
             //     inThreshold -> A total number of parquets that must be met for the region to qualify.
             // Returns true if enough parquets contribute to the biome, false otherwise.
-            static bool ConstitutesBiome(RegionStatus inRegion, BiomeRecipe inBiome, int inThreshold)
-                => CountMeetsOrExceedsThreshold(inRegion,
+            static bool ConstitutesBiome(RegionStatus region, BiomeRecipe inBiome, int inThreshold)
+                => CountMeetsOrExceedsThreshold(region,
                                                 parquet => parquet?.AddsToBiome.Contains(inBiome.ParquetCriteria) ?? false,
                                                 inThreshold);
 
             // Determines if the region has enough parquets satisfying the given predicate to meet or exceed the given threshold.
-            //     inRegion -> The region to test.
+            //     region -> The region to test.
             //     inPredicate -> A predicate indicating if the parquet should be counted.
             //                    The predicate must accommodate a null argument.
             //     inThreshold -> A total number of parquets that must be met for the region to qualify.
             // Returns true if enough parquets satisfy the conditions given, false otherwise.
-            static bool CountMeetsOrExceedsThreshold(RegionStatus inRegion, Predicate<ParquetModel> inPredicate, int inThreshold)
+            static bool CountMeetsOrExceedsThreshold(RegionStatus region, Predicate<ParquetModel> inPredicate, int inThreshold)
             {
                 var count = 0;
 
-                foreach (ParquetModelPack pack in inRegion.ParquetModels)
+                foreach (ParquetModelPack pack in region.ParquetModels)
                 {
                     if (inPredicate(All.Floors.GetOrNull<FloorModel>(pack.FloorID)))
                     {
@@ -259,17 +259,17 @@ namespace Parquet.Regions
         /// For a complete explanation of the algorithm implemented here, see:
         /// <a href="https://github.com/mxashlynn/Parquet/blob/master/Documentation/4.-Room_Detection_and_Type_Assignment.md"/>
         /// </remarks>
-        /// <param name="inGrid">The current collection of parquets to search for <see cref="Room"/>s.</param>
+        /// <param name="grid">The current collection of parquets to search for <see cref="Room"/>s.</param>
         /// <returns>An initialized collection of rooms.</returns>
-        private static IReadOnlyCollection<Room> FindRoomsInParquetGrid(ParquetModelPackGrid inGrid)
+        private static IReadOnlyCollection<Room> FindRoomsInParquetGrid(ParquetModelPackGrid grid)
         {
-            Precondition.IsNotNull(inGrid, nameof(inGrid));
-            if (inGrid is null)
+            Precondition.IsNotNull(grid, nameof(grid));
+            if (grid is null)
             {
                 return new List<Room>();
             }
 
-            var walkableAreas = GetWalkableAreas(inGrid);
+            var walkableAreas = GetWalkableAreas(grid);
             var perimeter = MapSpaceSetExtensions.Empty;
             var rooms =
                 walkableAreas
@@ -285,27 +285,27 @@ namespace Parquet.Regions
         /// <summary>
         /// Finds all valid Walkable Areas in a given <see cref="ParquetModelPackGrid"/>.
         /// </summary>
-        /// <param name="inGrid">The grid to search.</param>
+        /// <param name="grid">The grid to search.</param>
         /// <returns>The list of valid Walkable Areas.</returns>
-        private static IReadOnlyList<IReadOnlySet<MapSpace>> GetWalkableAreas(ParquetModelPackGrid inGrid)
+        private static IReadOnlyList<IReadOnlySet<MapSpace>> GetWalkableAreas(ParquetModelPackGrid grid)
         {
             var PWAs = new List<HashSet<MapSpace>>();
-            var subgridRows = inGrid.Rows;
-            var subgridCols = inGrid.Columns;
+            var subgridRows = grid.Rows;
+            var subgridCols = grid.Columns;
 
             for (var y = 0; y < subgridRows; y++)
             {
                 for (var x = 0; x < subgridCols; x++)
                 {
-                    if (inGrid[y, x].IsWalkable)
+                    if (grid[y, x].IsWalkable)
                     {
-                        var currentSpace = new MapSpace(x, y, inGrid[y, x], inGrid);
+                        var currentSpace = new MapSpace(x, y, grid[y, x], grid);
 
-                        var northSpace = y > 0 && inGrid[y - 1, x].IsWalkable
-                            ? new MapSpace(x, y - 1, inGrid[y - 1, x], inGrid)
+                        var northSpace = y > 0 && grid[y - 1, x].IsWalkable
+                            ? new MapSpace(x, y - 1, grid[y - 1, x], grid)
                             : MapSpace.Empty;
-                        var westSpace = x > 0 && inGrid[y, x - 1].IsWalkable
-                            ? new MapSpace(x - 1, y, inGrid[y, x - 1], inGrid)
+                        var westSpace = x > 0 && grid[y, x - 1].IsWalkable
+                            ? new MapSpace(x - 1, y, grid[y, x - 1], grid)
                             : MapSpace.Empty;
 
                         if (MapSpace.Empty == northSpace && MapSpace.Empty == westSpace)
@@ -509,11 +509,11 @@ namespace Parquet.Regions
         /// <summary>
         /// Determines if the given position corresponds to a point in the region.
         /// </summary>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public bool IsValidPosition(Point2D inPosition)
-            => ParquetModels.IsValidPosition(inPosition)
-            && ParquetStatuses.IsValidPosition(inPosition);
+        public bool IsValidPosition(Point2D position)
+            => ParquetModels.IsValidPosition(position)
+            && ParquetStatuses.IsValidPosition(position);
 
         /// <summary>
         /// Returns a <see cref="string"/> that represents the current <see cref="RegionStatus"/>.

--- a/ParquetClassLibrary/Rooms/MapSpace.cs
+++ b/ParquetClassLibrary/Rooms/MapSpace.cs
@@ -173,11 +173,11 @@ namespace Parquet.Rooms
         /// <summary>
         /// Determines whether the specified <see cref="MapSpace"/> is equal to the current <see cref="MapSpace"/>.
         /// </summary>
-        /// <param name="space">The <see cref="MapSpace"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="MapSpace"/> to compare with the current.</param>
         /// <returns><c>true</c> if the <see cref="MapSpace"/>s are equal.</returns>
-        public bool Equals(MapSpace space)
-            => Position == space?.Position
-            && Content == space.Content;
+        public bool Equals(MapSpace other)
+            => Position == other?.Position
+            && Content == other.Content;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="MapSpace"/>.

--- a/ParquetClassLibrary/Rooms/MapSpace.cs
+++ b/ParquetClassLibrary/Rooms/MapSpace.cs
@@ -31,25 +31,25 @@ namespace Parquet.Rooms
         /// <summary>
         /// Initializes a new instance of the <see cref="MapSpace"/> class.
         /// </summary>
-        /// <param name="inPosition">Where this <see cref="MapSpace"/> is.</param>
-        /// <param name="inContent">All parquets occupying this <see cref="MapSpace"/>.</param>
-        /// <param name="inGrid">The <see cref="ParquetModelPackGrid"/> within which this <see cref="MapSpace"/> occurs.</param>
-        public MapSpace(Point2D inPosition, ParquetModelPack inContent, ParquetModelPackGrid inGrid)
+        /// <param name="position">Where this <see cref="MapSpace"/> is.</param>
+        /// <param name="content">All parquets occupying this <see cref="MapSpace"/>.</param>
+        /// <param name="grid">The <see cref="ParquetModelPackGrid"/> within which this <see cref="MapSpace"/> occurs.</param>
+        public MapSpace(Point2D position, ParquetModelPack content, ParquetModelPackGrid grid)
         {
-            Position = inPosition;
-            Content = inContent;
-            Grid = inGrid;
+            Position = position;
+            Content = content;
+            Grid = grid;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MapSpace"/> class.
         /// </summary>
-        /// <param name="inX">X-coordinate of this <see cref="MapSpace"/>.</param>
-        /// <param name="inY">Y-coordinate of this <see cref="MapSpace"/>.</param>
-        /// <param name="inContent">All parquets occupying this <see cref="MapSpace"/>.</param>
-        /// <param name="inGrid">The grid in which this <see cref="MapSpace"/> occurs. </param>
-        public MapSpace(int inX, int inY, ParquetModelPack inContent, ParquetModelPackGrid inGrid)
-            : this(new Point2D(inX, inY), inContent, inGrid) { }
+        /// <param name="x">X-coordinate of this <see cref="MapSpace"/>.</param>
+        /// <param name="y">Y-coordinate of this <see cref="MapSpace"/>.</param>
+        /// <param name="content">All parquets occupying this <see cref="MapSpace"/>.</param>
+        /// <param name="grid">The grid in which this <see cref="MapSpace"/> occurs. </param>
+        public MapSpace(int x, int y, ParquetModelPack content, ParquetModelPackGrid grid)
+            : this(new Point2D(x, y), content, grid) { }
         #endregion
 
         #region Position Offsets
@@ -151,14 +151,14 @@ namespace Parquet.Rooms
         /// third, has one walkable neighbor that is within the given <see cref="IReadOnlySet{MapSpace}"/>; and
         /// fourth, has one walkable neighbor that is NOT within the given <see cref="IReadOnlySet{MapSpace}"/>.
         /// </summary>
-        /// <param name="inWalkableArea">The <see cref="IReadOnlySet{MapSpace}"/> used to define this <see cref="MapSpace"/>.</param>
+        /// <param name="walkableArea">The <see cref="IReadOnlySet{MapSpace}"/> used to define this <see cref="MapSpace"/>.</param>
         /// <returns><c>true</c>, if this <see cref="MapSpace"/> may be used as an enclosing entry by a <see cref="Room"/>, <c>false</c> otherwise.</returns>
-        internal bool IsEnclosingEntry(IReadOnlySet<MapSpace> inWalkableArea)
+        internal bool IsEnclosingEntry(IReadOnlySet<MapSpace> walkableArea)
             => ModelID.None != Content.FurnishingID
             && (All.Furnishings.GetOrNull<FurnishingModel>(Content.FurnishingID)?.Entry ?? EntryType.None) != EntryType.None
             && Content.IsEnclosing
-            && Neighbors().Any(neighbor1 => inWalkableArea.Contains(neighbor1))
-            && Neighbors().Any(neighbor2 => !inWalkableArea.Contains(neighbor2)
+            && Neighbors().Any(neighbor1 => walkableArea.Contains(neighbor1))
+            && Neighbors().Any(neighbor2 => !walkableArea.Contains(neighbor2)
                                          && neighbor2.Content.IsWalkable);
         #endregion
 
@@ -173,11 +173,11 @@ namespace Parquet.Rooms
         /// <summary>
         /// Determines whether the specified <see cref="MapSpace"/> is equal to the current <see cref="MapSpace"/>.
         /// </summary>
-        /// <param name="inSpace">The <see cref="MapSpace"/> to compare with the current.</param>
+        /// <param name="space">The <see cref="MapSpace"/> to compare with the current.</param>
         /// <returns><c>true</c> if the <see cref="MapSpace"/>s are equal.</returns>
-        public bool Equals(MapSpace inSpace)
-            => Position == inSpace?.Position
-            && Content == inSpace.Content;
+        public bool Equals(MapSpace space)
+            => Position == space?.Position
+            && Content == space.Content;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="MapSpace"/>.
@@ -192,21 +192,21 @@ namespace Parquet.Rooms
         /// Determines whether a specified instance of <see cref="MapSpace"/> is equal to
         /// another specified instance of <see cref="MapSpace"/>.
         /// </summary>
-        /// <param name="inSpace1">The first <see cref="MapSpace"/> to compare.</param>
-        /// <param name="inSpace2">The second <see cref="MapSpace"/> to compare.</param>
+        /// <param name="space1">The first <see cref="MapSpace"/> to compare.</param>
+        /// <param name="space2">The second <see cref="MapSpace"/> to compare.</param>
         /// <returns><c>true</c> if the two <see cref="MapSpace"/>s are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(MapSpace inSpace1, MapSpace inSpace2)
-            => inSpace1?.Equals(inSpace2) ?? inSpace2?.Equals(inSpace1) ?? true;
+        public static bool operator ==(MapSpace space1, MapSpace space2)
+            => space1?.Equals(space2) ?? space2?.Equals(space1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="MapSpace"/> is unequal to
         /// another specified instance of <see cref="MapSpace"/>.
         /// </summary>
-        /// <param name="inSpace1">The first <see cref="MapSpace"/> to compare.</param>
-        /// <param name="inSpace2">The second <see cref="MapSpace"/> to compare.</param>
+        /// <param name="space1">The first <see cref="MapSpace"/> to compare.</param>
+        /// <param name="space2">The second <see cref="MapSpace"/> to compare.</param>
         /// <returns><c>true</c> if the two <see cref="MapSpace"/>s are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(MapSpace inSpace1, MapSpace inSpace2)
-            => !(inSpace1 == inSpace2);
+        public static bool operator !=(MapSpace space1, MapSpace space2)
+            => !(space1 == space2);
         #endregion
 
         #region Utilities

--- a/ParquetClassLibrary/Rooms/MapSpaceSetExtensions.cs
+++ b/ParquetClassLibrary/Rooms/MapSpaceSetExtensions.cs
@@ -86,10 +86,10 @@ namespace Parquet.Rooms
                                  string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfOrderLTE,
                                                nameof(potentialPerimeter.Count), potentialPerimeter.Count,
                                                (subgrid.Rows * subgrid.Columns) - RoomConfiguration.MinWalkableSpaces));
-                    Debug.Assert(potentialPerimeter.Count >= RoomConfiguration.MinPerimeterSpaces,
+                    Debug.Assert(potentialPerimeter.Count >= RoomConfiguration.MperimeterSpaces,
                                  string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfOrderGTE,
                                                nameof(potentialPerimeter.Count),
-                                               potentialPerimeter.Count, RoomConfiguration.MinPerimeterSpaces));
+                                               potentialPerimeter.Count, RoomConfiguration.MperimeterSpaces));
 
                     // Validate the perimeter.
                     resultPerimeter = potentialPerimeter.AllSpacesAreReachableAndCycleExists(space => space.Content.IsEnclosing)
@@ -99,7 +99,7 @@ namespace Parquet.Rooms
                 }
             }
 
-            return resultPerimeter.Count >= RoomConfiguration.MinPerimeterSpaces;
+            return resultPerimeter.Count >= RoomConfiguration.MperimeterSpaces;
 
             #region Algorithm Helper Methods
             // Returns true if it finds a MapSpace that can be used to search for the perimeter.
@@ -169,26 +169,26 @@ namespace Parquet.Rooms
         /// whose <see cref="MapSpace.Content"/> conforms to the given predicate using only
         /// 4-connected movements, beginning at an arbitrary <see cref="MapSpace"/>.
         /// </summary>
-        /// <param name="inSpaces">The group of spaces under consideration.</param>
-        /// <param name="inIsApplicable">Determines if a <see cref="MapSpace"/> is a target MapSpace.</param>
+        /// <param name="spaces">The group of spaces under consideration.</param>
+        /// <param name="isApplicable">Determines if a <see cref="MapSpace"/> is a target MapSpace.</param>
         /// <returns><c>true</c> if all members of the given set are reachable from all other members of the given set.</returns>
-        internal static bool AllSpacesAreReachable(this HashSet<MapSpace> inSpaces, Predicate<MapSpace> inIsApplicable)
-            => ((IReadOnlySet<MapSpace>)inSpaces).Search(inSpaces.First(), inIsApplicable, space => false)
-               .Visited.Count == inSpaces.Count;
+        internal static bool AllSpacesAreReachable(this HashSet<MapSpace> spaces, Predicate<MapSpace> isApplicable)
+            => ((IReadOnlySet<MapSpace>)spaces).Search(spaces.First(), isApplicable, space => false)
+               .Visited.Count == spaces.Count;
 
         /// <summary>
         /// Determines if it is possible to reach every <see cref="MapSpace"/> in the given subgrid
         /// whose <see cref="MapSpace.Content"/> conforms to the given predicate using only 4-connected
         /// movements, beginning at an arbitrary <see cref="MapSpace"/>, while encountering at least one cycle.
         /// </summary>
-        /// <param name="inSpaces">The group of spaces under consideration.</param>
-        /// <param name="inIsApplicable">Determines if a <see cref="MapSpace"/> is a target MapSpace.</param>
+        /// <param name="spaces">The group of spaces under consideration.</param>
+        /// <param name="isApplicable">Determines if a <see cref="MapSpace"/> is a target MapSpace.</param>
         /// <returns><c>true</c> if all members of the given set are reachable from all other members of the given set.</returns>
-        internal static bool AllSpacesAreReachableAndCycleExists(this IReadOnlySet<MapSpace> inSpaces, Predicate<MapSpace> inIsApplicable)
+        internal static bool AllSpacesAreReachableAndCycleExists(this IReadOnlySet<MapSpace> spaces, Predicate<MapSpace> isApplicable)
         {
-            var results = inSpaces.Search(inSpaces.First(), inIsApplicable, space => false);
+            var results = spaces.Search(spaces.First(), isApplicable, space => false);
             return results.CycleFound
-                && results.Visited.Count == inSpaces.Count;
+                && results.Visited.Count == spaces.Count;
         }
 
         /// <summary>
@@ -199,47 +199,47 @@ namespace Parquet.Rooms
         /// <remarks>
         /// Searches in a preorder, depth-first fashion.
         /// </remarks>
-        /// <param name="inSpaces">The group of spaces under consideration.</param>
-        /// <param name="inStart">The <see cref="MapSpace"/> to begin searching from.</param>
-        /// <param name="inIsApplicable"><c>true</c> if a <see cref="MapSpace"/> ought to be considered.</param>
-        /// <param name="inIsGoal"><c>true</c> if a the search goal has been satisfied.</param>
+        /// <param name="spaces">The group of spaces under consideration.</param>
+        /// <param name="start">The <see cref="MapSpace"/> to begin searching from.</param>
+        /// <param name="isApplicable"><c>true</c> if a <see cref="MapSpace"/> ought to be considered.</param>
+        /// <param name="isGoal"><c>true</c> if a the search goal has been satisfied.</param>
         /// <returns>Information about the results of the search procedure.</returns>
-        private static SearchResults Search(this IReadOnlySet<MapSpace> inSpaces, MapSpace inStart, Predicate<MapSpace> inIsApplicable, Predicate<MapSpace> inIsGoal)
+        private static SearchResults Search(this IReadOnlySet<MapSpace> spaces, MapSpace start, Predicate<MapSpace> isApplicable, Predicate<MapSpace> isGoal)
         {
-            Precondition.IsNotNullOrEmpty(inSpaces, nameof(inSpaces));
+            Precondition.IsNotNullOrEmpty(spaces, nameof(spaces));
             var visited = new HashSet<MapSpace>();
             var cycleFound = false;
 
-            return new SearchResults(DepthFirstSearch(inStart), cycleFound, new HashSet<MapSpace>(visited));
+            return new SearchResults(DepthFirstSearch(start), cycleFound, new HashSet<MapSpace>(visited));
 
             // Traverses the given 4-connected grid in a preorder, depth-first fashion.
-            // inSpace indicates the MapSpace under consideration this stack frame.
+            // space indicates the MapSpace under consideration this stack frame.
             // Returns true is the goal was found, false otherwise.
-            bool DepthFirstSearch(MapSpace inSpace)
+            bool DepthFirstSearch(MapSpace space)
             {
                 var goalFound = false;
 
-                if (inIsApplicable(inSpace))
+                if (isApplicable(space))
                 {
-                    if (visited.Contains(inSpace))
+                    if (visited.Contains(space))
                     {
                         cycleFound = true;
                     }
                     else
                     {
-                        visited.Add(inSpace);
+                        visited.Add(space);
 
-                        if (inIsGoal(inSpace))
+                        if (isGoal(space))
                         {
                             goalFound = true;
                         }
                         else
                         {
                             // Continue, examining all neighbors in order.
-                            goalFound = DepthFirstSearch(inSpace.NorthNeighbor())
-                                || DepthFirstSearch(inSpace.SouthNeighbor())
-                                || DepthFirstSearch(inSpace.EastNeighbor())
-                                || DepthFirstSearch(inSpace.WestNeighbor());
+                            goalFound = DepthFirstSearch(space.NorthNeighbor())
+                                || DepthFirstSearch(space.SouthNeighbor())
+                                || DepthFirstSearch(space.EastNeighbor())
+                                || DepthFirstSearch(space.WestNeighbor());
                         }
                     }
                 }
@@ -275,10 +275,10 @@ namespace Parquet.Rooms
         /// <summary>
         /// Returns a <see cref="string"/> that represents the current <see cref="IReadOnlySet{MapSpace}"/>.
         /// </summary>
-        /// <param name="inSpaces">The group of spaces under consideration.</param>
+        /// <param name="spaces">The group of spaces under consideration.</param>
         /// <returns>The representation.</returns>
-        internal static string ToString(this IReadOnlySet<MapSpace> inSpaces)
-            => $"{inSpaces?.Count ?? 0} spaces";
+        internal static string ToString(this IReadOnlySet<MapSpace> spaces)
+            => $"{spaces?.Count ?? 0} spaces";
         #endregion
     }
 }

--- a/ParquetClassLibrary/Rooms/ReadOnlyRoomCollectionExtensions.cs
+++ b/ParquetClassLibrary/Rooms/ReadOnlyRoomCollectionExtensions.cs
@@ -11,17 +11,17 @@ namespace Parquet.Rooms
         /// <summary>
         /// Returns the <see cref="Room"/> at the given position, if there is one.
         /// </summary>
-        /// <param name="inRooms">The current collection of <see cref="Room"/>s.</param>
-        /// <param name="inPosition">An in-bounds position to search for a <see cref="Room"/>.</param>
+        /// <param name="rooms">The current collection of <see cref="Room"/>s.</param>
+        /// <param name="position">An in-bounds position to search for a <see cref="Room"/>.</param>
         /// <returns>The specified <see cref="Room"/> if found; otherwise, null.</returns>
-        public static Room GetRoomAtOrNull(this IReadOnlyCollection<Room> inRooms, Point2D inPosition)
-            => inRooms?.FirstOrDefault(room => room.ContainsPosition(inPosition)) ?? null;
+        public static Room GetRoomAtOrNull(this IReadOnlyCollection<Room> rooms, Point2D position)
+            => rooms?.FirstOrDefault(room => room.ContainsPosition(position)) ?? null;
 
         /// <summary>
         /// Returns a <see cref="string"/> that represents the current <see cref="IReadOnlyCollection{Room}"/>.
         /// </summary>
         /// <returns>The representation.</returns>
-        public static string ToString(this IReadOnlyCollection<Room> inRooms)
-            => $"{inRooms?.Count ?? 0} {nameof(Rooms)}";
+        public static string ToString(this IReadOnlyCollection<Room> rooms)
+            => $"{rooms?.Count ?? 0} {nameof(Rooms)}";
     }
 }

--- a/ParquetClassLibrary/Rooms/Room.cs
+++ b/ParquetClassLibrary/Rooms/Room.cs
@@ -114,12 +114,12 @@ namespace Parquet.Rooms
         /// <summary>
         /// Determines whether the specified <see cref="Room"/> is equal to the current <see cref="Room"/>.
         /// </summary>
-        /// <param name="room">The <see cref="Room"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="Room"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Room room)
-            => room is not null
-            && WalkableArea.SetEquals(room.WalkableArea)
-            && Perimeter.SetEquals(room.Perimeter);
+        public bool Equals(Room other)
+            => other is not null
+            && WalkableArea.SetEquals(other.WalkableArea)
+            && Perimeter.SetEquals(other.Perimeter);
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Room"/>.

--- a/ParquetClassLibrary/Rooms/Room.cs
+++ b/ParquetClassLibrary/Rooms/Room.cs
@@ -58,46 +58,46 @@ namespace Parquet.Rooms
         /// <summary>
         /// Initializes a new instance of the <see cref="Room"/> class.
         /// </summary>
-        /// <param name="inWalkableArea">
+        /// <param name="walkableArea">
         /// The <see cref="MapSpace"/>s on which a <see cref="Beings.BeingModel"/>
         /// may walk within this <see cref="Room"/>.
         /// </param>
-        /// <param name="inPerimeter">
+        /// <param name="perimeter">
         /// The <see cref="MapSpace"/>s whose <see cref="BlockModel"/>s and <see cref="FurnishingModel"/>s
         /// define the limits of this <see cref="Room"/>.
         /// </param>
-        public Room(IReadOnlySet<MapSpace> inWalkableArea, IReadOnlySet<MapSpace> inPerimeter)
+        public Room(IReadOnlySet<MapSpace> walkableArea, IReadOnlySet<MapSpace> perimeter)
         {
-            Precondition.IsNotNullOrEmpty(inWalkableArea, nameof(inWalkableArea));
-            Precondition.IsNotNullOrEmpty(inPerimeter, nameof(inPerimeter));
-            if (inWalkableArea is null
-                || inPerimeter is null)
+            Precondition.IsNotNullOrEmpty(walkableArea, nameof(walkableArea));
+            Precondition.IsNotNullOrEmpty(perimeter, nameof(perimeter));
+            if (walkableArea is null
+                || perimeter is null)
             {
                 return;
             }
 
-            if (inWalkableArea.Count > RoomConfiguration.MaxWalkableSpaces)
+            if (walkableArea.Count > RoomConfiguration.MaxWalkableSpaces)
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfOrderLTE,
-                                                           nameof(inWalkableArea), inWalkableArea,
+                                                           nameof(walkableArea), walkableArea,
                                                            RoomConfiguration.MaxWalkableSpaces));
             }
-            else if (inWalkableArea.Count < RoomConfiguration.MinWalkableSpaces)
+            else if (walkableArea.Count < RoomConfiguration.MinWalkableSpaces)
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorOutOfOrderGTE,
-                                                           nameof(inWalkableArea.Count),
-                                                           inWalkableArea.Count, RoomConfiguration.MinWalkableSpaces));
+                                                           nameof(walkableArea.Count),
+                                                           walkableArea.Count, RoomConfiguration.MinWalkableSpaces));
             }
-            if (!inWalkableArea.Concat(inPerimeter).Any(space
+            if (!walkableArea.Concat(perimeter).Any(space
                 => space.Content.FurnishingID != ModelID.None
                 && (All.Furnishings.GetOrNull<FurnishingModel>(space.Content.FurnishingID)?.Entry ?? EntryType.None) != EntryType.None))
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.ErrorNoExitFound,
-                                                           nameof(inWalkableArea), nameof(inPerimeter)));
+                                                           nameof(walkableArea), nameof(perimeter)));
             }
 
-            WalkableArea = inWalkableArea;
-            Perimeter = inPerimeter;
+            WalkableArea = walkableArea;
+            Perimeter = perimeter;
         }
         #endregion
 
@@ -114,12 +114,12 @@ namespace Parquet.Rooms
         /// <summary>
         /// Determines whether the specified <see cref="Room"/> is equal to the current <see cref="Room"/>.
         /// </summary>
-        /// <param name="inRoom">The <see cref="Room"/> to compare with the current.</param>
+        /// <param name="room">The <see cref="Room"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Room inRoom)
-            => inRoom is not null
-            && WalkableArea.SetEquals(inRoom.WalkableArea)
-            && Perimeter.SetEquals(inRoom.Perimeter);
+        public bool Equals(Room room)
+            => room is not null
+            && WalkableArea.SetEquals(room.WalkableArea)
+            && Perimeter.SetEquals(room.Perimeter);
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Room"/>.
@@ -133,30 +133,30 @@ namespace Parquet.Rooms
         /// <summary>
         /// Determines whether a specified instance of <see cref="Room"/> is equal to another specified instance of <see cref="Room"/>.
         /// </summary>
-        /// <param name="inRoom1">The first <see cref="Room"/> to compare.</param>
-        /// <param name="inRoom2">The second <see cref="Room"/> to compare.</param>
+        /// <param name="room1">The first <see cref="Room"/> to compare.</param>
+        /// <param name="room2">The second <see cref="Room"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(Room inRoom1, Room inRoom2)
-           => inRoom1?.Equals(inRoom2) ?? inRoom2?.Equals(inRoom1) ?? true;
+        public static bool operator ==(Room room1, Room room2)
+           => room1?.Equals(room2) ?? room2?.Equals(room1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="Room"/> is not equal to another specified instance of <see cref="Room"/>.
         /// </summary>
-        /// <param name="inRoom1">The first <see cref="Room"/> to compare.</param>
-        /// <param name="inRoom2">The second <see cref="Room"/> to compare.</param>
+        /// <param name="room1">The first <see cref="Room"/> to compare.</param>
+        /// <param name="room2">The second <see cref="Room"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(Room inRoom1, Room inRoom2)
-           => !(inRoom1 == inRoom2);
+        public static bool operator !=(Room room1, Room room2)
+           => !(room1 == room2);
         #endregion
 
         #region Utilities
         /// <summary>
         /// Determines whether or not the given position is included in this <see cref="Room"/>.
         /// </summary>
-        /// <param name="inPosition">The position to check for.</param>
+        /// <param name="position">The position to check for.</param>
         /// <returns><c>true</c>, if the <see cref="Room"/> contains the given position, <c>false</c> otherwise.</returns>
-        public bool ContainsPosition(Point2D inPosition)
-            => WalkableArea.Concat(Perimeter).Any(space => space.Position == inPosition);
+        public bool ContainsPosition(Point2D position)
+            => WalkableArea.Concat(Perimeter).Any(space => space.Position == position);
 
         /// <summary>
         /// Finds the <see cref="ModelID"/> of the <see cref="RoomRecipe"/> that best matches this <see cref="Room"/>.

--- a/ParquetClassLibrary/Rooms/RoomConfiguration.cs
+++ b/ParquetClassLibrary/Rooms/RoomConfiguration.cs
@@ -25,7 +25,7 @@ namespace Parquet.Rooms
         public static int MaxWalkableSpaces { get; set; } = DefaultMaxWalkableSpaces;
 
         /// <summary>Minimum number of enclosing spaces needed for any room to register.</summary>
-        public static int MinPerimeterSpaces => MinWalkableSpaces * 3;
+        public static int MperimeterSpaces => MinWalkableSpaces * 3;
         #endregion
 
         #region Self Serialization

--- a/ParquetClassLibrary/Rooms/RoomRecipe.cs
+++ b/ParquetClassLibrary/Rooms/RoomRecipe.cs
@@ -42,21 +42,21 @@ namespace Parquet.Rooms
         /// <summary>
         /// Initializes a new instance of the <see cref="RoomRecipe"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="RoomRecipe"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="RoomRecipe"/>.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="RoomRecipe"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="RoomRecipe"/>.</param>
-        /// <param name="inTags">Any additional information about this <see cref="RoomRecipe"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="RoomRecipe"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="RoomRecipe"/>.</param>
+        /// <param name="description">Player-friendly description of the <see cref="RoomRecipe"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="RoomRecipe"/>.</param>
+        /// <param name="tags">Any additional information about this <see cref="RoomRecipe"/>.</param>
         /// <param name="inMinimumWalkableSpaces">The minimum number of walkable <see cref="MapSpace"/>s required by this <see cref="RoomRecipe"/>.</param>
         /// <param name="inOptionallyRequiredFurnishings">An optional list of furnishing categories this <see cref="RoomRecipe"/> requires.</param>
         /// <param name="inOptionallyRequiredWalkableFloors">An optional list of floor categories this <see cref="RoomRecipe"/> requires.</param>
         /// <param name="inOptionallyRequiredPerimeterBlocks">An optional list of block categories this <see cref="RoomRecipe"/> requires as walls.</param>
-        public RoomRecipe(ModelID inID, string inName, string inDescription, string inComment,
-                          IEnumerable<ModelTag> inTags = null, int? inMinimumWalkableSpaces = null,
+        public RoomRecipe(ModelID id, string name, string description, string comment,
+                          IEnumerable<ModelTag> tags = null, int? inMinimumWalkableSpaces = null,
                           IEnumerable<RecipeElement> inOptionallyRequiredFurnishings = null,
                           IEnumerable<RecipeElement> inOptionallyRequiredWalkableFloors = null,
                           IEnumerable<RecipeElement> inOptionallyRequiredPerimeterBlocks = null)
-            : base(All.RoomRecipeIDs, inID, inName, inDescription, inComment, inTags)
+            : base(All.RoomRecipeIDs, id, name, description, comment, tags)
         {
             var nonNullMinimumWalkableSpaces = inMinimumWalkableSpaces ?? RoomConfiguration.MinWalkableSpaces;
             var nonNullOptionallyRequiredFurnishings = (inOptionallyRequiredFurnishings ?? Enumerable.Empty<RecipeElement>()).ToList();

--- a/ParquetClassLibrary/Rooms/RoomRecipe.cs
+++ b/ParquetClassLibrary/Rooms/RoomRecipe.cs
@@ -47,27 +47,27 @@ namespace Parquet.Rooms
         /// <param name="description">Player-friendly description of the <see cref="RoomRecipe"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="RoomRecipe"/>.</param>
         /// <param name="tags">Any additional information about this <see cref="RoomRecipe"/>.</param>
-        /// <param name="inMinimumWalkableSpaces">The minimum number of walkable <see cref="MapSpace"/>s required by this <see cref="RoomRecipe"/>.</param>
-        /// <param name="inOptionallyRequiredFurnishings">An optional list of furnishing categories this <see cref="RoomRecipe"/> requires.</param>
-        /// <param name="inOptionallyRequiredWalkableFloors">An optional list of floor categories this <see cref="RoomRecipe"/> requires.</param>
-        /// <param name="inOptionallyRequiredPerimeterBlocks">An optional list of block categories this <see cref="RoomRecipe"/> requires as walls.</param>
+        /// <param name="minimumWalkableSpaces">The minimum number of walkable <see cref="MapSpace"/>s required by this <see cref="RoomRecipe"/>.</param>
+        /// <param name="optionallyRequiredFurnishings">An optional list of furnishing categories this <see cref="RoomRecipe"/> requires.</param>
+        /// <param name="optionallyRequiredWalkableFloors">An optional list of floor categories this <see cref="RoomRecipe"/> requires.</param>
+        /// <param name="optionallyRequiredPerimeterBlocks">An optional list of block categories this <see cref="RoomRecipe"/> requires as walls.</param>
         public RoomRecipe(ModelID id, string name, string description, string comment,
-                          IEnumerable<ModelTag> tags = null, int? inMinimumWalkableSpaces = null,
-                          IEnumerable<RecipeElement> inOptionallyRequiredFurnishings = null,
-                          IEnumerable<RecipeElement> inOptionallyRequiredWalkableFloors = null,
-                          IEnumerable<RecipeElement> inOptionallyRequiredPerimeterBlocks = null)
+                          IEnumerable<ModelTag> tags = null, int? minimumWalkableSpaces = null,
+                          IEnumerable<RecipeElement> optionallyRequiredFurnishings = null,
+                          IEnumerable<RecipeElement> optionallyRequiredWalkableFloors = null,
+                          IEnumerable<RecipeElement> optionallyRequiredPerimeterBlocks = null)
             : base(All.RoomRecipeIDs, id, name, description, comment, tags)
         {
-            var nonNullMinimumWalkableSpaces = inMinimumWalkableSpaces ?? RoomConfiguration.MinWalkableSpaces;
-            var nonNullOptionallyRequiredFurnishings = (inOptionallyRequiredFurnishings ?? Enumerable.Empty<RecipeElement>()).ToList();
-            var nonNullOptionallyRequiredWalkableFloors = (inOptionallyRequiredWalkableFloors ?? Enumerable.Empty<RecipeElement>()).ToList();
-            var nonNullOptionallyRequiredPerimeterBlocks = (inOptionallyRequiredPerimeterBlocks ?? Enumerable.Empty<RecipeElement>()).ToList();
+            var nonNullMinimumWalkableSpaces = minimumWalkableSpaces ?? RoomConfiguration.MinWalkableSpaces;
+            var nonNullOptionallyRequiredFurnishings = (optionallyRequiredFurnishings ?? Enumerable.Empty<RecipeElement>()).ToList();
+            var nonNullOptionallyRequiredWalkableFloors = (optionallyRequiredWalkableFloors ?? Enumerable.Empty<RecipeElement>()).ToList();
+            var nonNullOptionallyRequiredPerimeterBlocks = (optionallyRequiredPerimeterBlocks ?? Enumerable.Empty<RecipeElement>()).ToList();
 
             if (nonNullMinimumWalkableSpaces < RoomConfiguration.MinWalkableSpaces
                 || nonNullMinimumWalkableSpaces > RoomConfiguration.MaxWalkableSpaces)
             {
                 Logger.Log(LogLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resources.WarningRoomSize,
-                                                           inMinimumWalkableSpaces, RoomConfiguration.MinWalkableSpaces,
+                                                           minimumWalkableSpaces, RoomConfiguration.MinWalkableSpaces,
                                                            RoomConfiguration.MaxWalkableSpaces));
             }
 
@@ -140,26 +140,26 @@ namespace Parquet.Rooms
         /// <summary>
         /// Determines if the given <see cref="Room"/> conforms to this <see cref="RoomRecipe"/>.
         /// </summary>
-        /// <param name="inRoom">The <see cref="Room"/> to check.</param>
+        /// <param name="room">The <see cref="Room"/> to check.</param>
         /// <returns>
-        /// <c>ture</c> if <paramref name="inRoom"/> is an instance of this <see cref="RoomRecipe"/>;
+        /// <c>ture</c> if <paramref name="room"/> is an instance of this <see cref="RoomRecipe"/>;
         /// <c>false</c> otherwise.
         /// </returns>
-        public bool Matches(Room inRoom)
-            => inRoom is not null
-            && inRoom.WalkableArea.Count >= MinimumWalkableSpaces
+        public bool Matches(Room room)
+            => room is not null
+            && room.WalkableArea.Count >= MinimumWalkableSpaces
             && OptionallyRequiredPerimeterBlocks.All(element
-                => inRoom.Perimeter.Count(space
+                => room.Perimeter.Count(space
                     => space.Content.BlockID != ModelID.None
                     && (All.Blocks.GetOrNull<BlockModel>(space.Content.BlockID)?.AddsToRoom.Contains(element.ElementTag) ?? false))
                         >= element.ElementAmount)
             && OptionallyRequiredWalkableFloors.All(element
-                => inRoom.WalkableArea.Count(space
+                => room.WalkableArea.Count(space
                     => space.Content.FloorID != ModelID.None
                     && (All.Floors.GetOrNull<FloorModel>(space.Content.FloorID)?.AddsToRoom.Contains(element.ElementTag) ?? false))
                         >= element.ElementAmount)
             && OptionallyRequiredFurnishings.All(element
-                => inRoom.FurnishingTags.Count(tag
+                => room.FurnishingTags.Count(tag
                     => tag == element.ElementTag) >= element.ElementAmount);
         #endregion
     }

--- a/ParquetClassLibrary/Scripts/InteractionModel.cs
+++ b/ParquetClassLibrary/Scripts/InteractionModel.cs
@@ -32,18 +32,18 @@ namespace Parquet.Scripts
         /// <summary>
         /// Initializes a new instance of the <see cref="InteractionModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="InteractionModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="InteractionModel"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="InteractionModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="InteractionModel"/>.</param>
-        /// <param name="inTags">Any additional information about this <see cref="InteractionModel"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="InteractionModel"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="InteractionModel"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="InteractionModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="InteractionModel"/>.</param>
+        /// <param name="tags">Any additional information about this <see cref="InteractionModel"/>.</param>
         /// <param name="inPrerequisitesIDs">Describes the criteria for beginning this <see cref="InteractionModel"/>.</param>
         /// <param name="inStepsIDs">Describes the criteria for completing this <see cref="InteractionModel"/>.</param>
         /// <param name="inOutcomesIDs">Describes the results of finishing this <see cref="InteractionModel"/>.</param>
-        public InteractionModel(ModelID inID, string inName, string inDescription, string inComment,
-                                IEnumerable<ModelTag> inTags = null, IEnumerable<ModelID> inPrerequisitesIDs = null,
+        public InteractionModel(ModelID id, string name, string description, string comment,
+                                IEnumerable<ModelTag> tags = null, IEnumerable<ModelID> inPrerequisitesIDs = null,
                                 IEnumerable<ModelID> inStepsIDs = null, IEnumerable<ModelID> inOutcomesIDs = null)
-            : base(All.InteractionIDs, inID, inName, inDescription, inComment, inTags)
+            : base(All.InteractionIDs, id, name, description, comment, tags)
         {
             var nonNullPrerequisites = (inPrerequisitesIDs ?? Enumerable.Empty<ModelID>()).ToList();
             var nonNullSteps = (inStepsIDs ?? Enumerable.Empty<ModelID>()).ToList();

--- a/ParquetClassLibrary/Scripts/InteractionModel.cs
+++ b/ParquetClassLibrary/Scripts/InteractionModel.cs
@@ -37,21 +37,21 @@ namespace Parquet.Scripts
         /// <param name="description">Player-friendly description of the <see cref="InteractionModel"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="InteractionModel"/>.</param>
         /// <param name="tags">Any additional information about this <see cref="InteractionModel"/>.</param>
-        /// <param name="inPrerequisitesIDs">Describes the criteria for beginning this <see cref="InteractionModel"/>.</param>
-        /// <param name="inStepsIDs">Describes the criteria for completing this <see cref="InteractionModel"/>.</param>
-        /// <param name="inOutcomesIDs">Describes the results of finishing this <see cref="InteractionModel"/>.</param>
+        /// <param name="prerequisitesIDs">Describes the criteria for beginning this <see cref="InteractionModel"/>.</param>
+        /// <param name="stepsIDs">Describes the criteria for completing this <see cref="InteractionModel"/>.</param>
+        /// <param name="outcomesIDs">Describes the results of finishing this <see cref="InteractionModel"/>.</param>
         public InteractionModel(ModelID id, string name, string description, string comment,
-                                IEnumerable<ModelTag> tags = null, IEnumerable<ModelID> inPrerequisitesIDs = null,
-                                IEnumerable<ModelID> inStepsIDs = null, IEnumerable<ModelID> inOutcomesIDs = null)
+                                IEnumerable<ModelTag> tags = null, IEnumerable<ModelID> prerequisitesIDs = null,
+                                IEnumerable<ModelID> stepsIDs = null, IEnumerable<ModelID> outcomesIDs = null)
             : base(All.InteractionIDs, id, name, description, comment, tags)
         {
-            var nonNullPrerequisites = (inPrerequisitesIDs ?? Enumerable.Empty<ModelID>()).ToList();
-            var nonNullSteps = (inStepsIDs ?? Enumerable.Empty<ModelID>()).ToList();
-            var nonNullOutcomes = (inOutcomesIDs ?? Enumerable.Empty<ModelID>()).ToList();
+            var nonNullPrerequisites = (prerequisitesIDs ?? Enumerable.Empty<ModelID>()).ToList();
+            var nonNullSteps = (stepsIDs ?? Enumerable.Empty<ModelID>()).ToList();
+            var nonNullOutcomes = (outcomesIDs ?? Enumerable.Empty<ModelID>()).ToList();
 
-            Precondition.AreInRange(nonNullPrerequisites, All.ScriptIDs, nameof(inPrerequisitesIDs));
-            Precondition.AreInRange(nonNullSteps, All.ScriptIDs, nameof(inStepsIDs));
-            Precondition.AreInRange(nonNullOutcomes, All.ScriptIDs, nameof(inOutcomesIDs));
+            Precondition.AreInRange(nonNullPrerequisites, All.ScriptIDs, nameof(prerequisitesIDs));
+            Precondition.AreInRange(nonNullSteps, All.ScriptIDs, nameof(stepsIDs));
+            Precondition.AreInRange(nonNullOutcomes, All.ScriptIDs, nameof(outcomesIDs));
 
             PrerequisitesIDs = nonNullPrerequisites;
             StepsIDs = nonNullSteps;

--- a/ParquetClassLibrary/Scripts/InteractionStatus.cs
+++ b/ParquetClassLibrary/Scripts/InteractionStatus.cs
@@ -39,24 +39,24 @@ namespace Parquet.Scripts
         /// <summary>
         /// Initializes a new instance of the <see cref="InteractionStatus"/> class.
         /// </summary>
-        /// <param name="inState">The <see cref="RunState"/> of the tracked <see cref="InteractionModel"/>.</param>
-        /// <param name="inProgramCounter">Index to the current <see cref="ScriptNode"/> in the tracked <see cref="InteractionModel.StepsIDs"/>.</param>
-        public InteractionStatus(RunState inState, int inProgramCounter)
+        /// <param name="state">The <see cref="RunState"/> of the tracked <see cref="InteractionModel"/>.</param>
+        /// <param name="programCounter">Index to the current <see cref="ScriptNode"/> in the tracked <see cref="InteractionModel.StepsIDs"/>.</param>
+        public InteractionStatus(RunState state, int programCounter)
         {
-            State = inState;
-            StepCounter = inProgramCounter;
+            State = state;
+            StepCounter = programCounter;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InteractionStatus"/> class
         /// based on a given <see cref="InteractionModel"/> instance.
         /// </summary>
-        /// <param name="inScript">The script definition whose status is being tracked.</param>
+        /// <param name="script">The script definition whose status is being tracked.</param>
         [SuppressMessage("Usage", "CA1801:Review unused parameters",
             Justification = "This constructor is provided for consistency.  The parameter is currently ignored, but may not be in the future.")]
         [SuppressMessage("Style", "IDE0060:Remove unused parameter",
             Justification = "This constructor is provided for consistency.  The parameter is currently ignored, but may not be in the future.")]
-        public InteractionStatus(InteractionModel inScript)
+        public InteractionStatus(InteractionModel script)
             : this(RunState.Unstarted, 0)
         { }
         #endregion

--- a/ParquetClassLibrary/Scripts/InteractionStatus.cs
+++ b/ParquetClassLibrary/Scripts/InteractionStatus.cs
@@ -74,10 +74,10 @@ namespace Parquet.Scripts
         /// <summary>
         /// Determines whether the specified <see cref="InteractionStatus"/> is equal to the current <see cref="InteractionStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="InteractionStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="InteractionStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is InteractionStatus interactionStatus
+        public override bool Equals<T>(T status)
+            => status is InteractionStatus interactionStatus
             && State == interactionStatus.State
             && StepCounter == interactionStatus.StepCounter;
 
@@ -93,20 +93,20 @@ namespace Parquet.Scripts
         /// <summary>
         /// Determines whether a specified instance of <see cref="InteractionStatus"/> is equal to another specified instance of <see cref="InteractionStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="InteractionStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="InteractionStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="InteractionStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="InteractionStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(InteractionStatus inStatus1, InteractionStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(InteractionStatus status1, InteractionStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="InteractionStatus"/> is not equal to another specified instance of <see cref="InteractionStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="InteractionStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="InteractionStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="InteractionStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="InteractionStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(InteractionStatus inStatus1, InteractionStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(InteractionStatus status1, InteractionStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -116,32 +116,32 @@ namespace Parquet.Scripts
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is InteractionStatus status
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is InteractionStatus status
                 ? $"{status.State}{Delimiters.InternalDelimiter}" +
                   $"{status.StepCounter}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(InteractionStatus), nameof(Unstarted));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(InteractionStatus), nameof(Unstarted));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Unstarted), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Unstarted), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Unstarted;
             }
 
-            var parameterText = inText.Split(Delimiters.SecondaryDelimiter);
+            var parameterText = text.Split(Delimiters.SecondaryDelimiter);
 
             var parsedState = Enum.TryParse(typeof(RunState), parameterText[0], out var temp0)
                 ? (RunState)temp0

--- a/ParquetClassLibrary/Scripts/ScriptModel.cs
+++ b/ParquetClassLibrary/Scripts/ScriptModel.cs
@@ -30,11 +30,11 @@ namespace Parquet.Scripts
         /// <param name="description">Player-friendly description of the <see cref="ScriptModel"/>.</param>
         /// <param name="comment">Comment of, on, or by the <see cref="ScriptModel"/>.</param>
         /// <param name="tags">Any additional information about this <see cref="ScriptModel"/>.</param>
-        /// <param name="inNodes">Describes the criteria for completing this <see cref="InteractionModel"/>.</param>
+        /// <param name="nodes">Describes the criteria for completing this <see cref="InteractionModel"/>.</param>
         public ScriptModel(ModelID id, string name, string description, string comment,
-                           IEnumerable<ModelTag> tags = null, IEnumerable<ScriptNode> inNodes = null)
+                           IEnumerable<ModelTag> tags = null, IEnumerable<ScriptNode> nodes = null)
             : base(All.ScriptIDs, id, name, description, comment, tags)
-            => Nodes = (inNodes ?? Enumerable.Empty<ScriptNode>()).ToList();
+            => Nodes = (nodes ?? Enumerable.Empty<ScriptNode>()).ToList();
         #endregion
 
         #region IMutableScriptModel Implementation

--- a/ParquetClassLibrary/Scripts/ScriptModel.cs
+++ b/ParquetClassLibrary/Scripts/ScriptModel.cs
@@ -25,15 +25,15 @@ namespace Parquet.Scripts
         /// <summary>
         /// Initializes a new instance of the <see cref="ScriptModel"/> class.
         /// </summary>
-        /// <param name="inID">Unique identifier for the <see cref="ScriptModel"/>.  Cannot be null.</param>
-        /// <param name="inName">Player-friendly name of the <see cref="ScriptModel"/>.  Cannot be null or empty.</param>
-        /// <param name="inDescription">Player-friendly description of the <see cref="ScriptModel"/>.</param>
-        /// <param name="inComment">Comment of, on, or by the <see cref="ScriptModel"/>.</param>
-        /// <param name="inTags">Any additional information about this <see cref="ScriptModel"/>.</param>
+        /// <param name="id">Unique identifier for the <see cref="ScriptModel"/>.  Cannot be null.</param>
+        /// <param name="name">Player-friendly name of the <see cref="ScriptModel"/>.  Cannot be null or empty.</param>
+        /// <param name="description">Player-friendly description of the <see cref="ScriptModel"/>.</param>
+        /// <param name="comment">Comment of, on, or by the <see cref="ScriptModel"/>.</param>
+        /// <param name="tags">Any additional information about this <see cref="ScriptModel"/>.</param>
         /// <param name="inNodes">Describes the criteria for completing this <see cref="InteractionModel"/>.</param>
-        public ScriptModel(ModelID inID, string inName, string inDescription, string inComment,
-                           IEnumerable<ModelTag> inTags = null, IEnumerable<ScriptNode> inNodes = null)
-            : base(All.ScriptIDs, inID, inName, inDescription, inComment, inTags)
+        public ScriptModel(ModelID id, string name, string description, string comment,
+                           IEnumerable<ModelTag> tags = null, IEnumerable<ScriptNode> inNodes = null)
+            : base(All.ScriptIDs, id, name, description, comment, tags)
             => Nodes = (inNodes ?? Enumerable.Empty<ScriptNode>()).ToList();
         #endregion
 

--- a/ParquetClassLibrary/Scripts/ScriptNode.cs
+++ b/ParquetClassLibrary/Scripts/ScriptNode.cs
@@ -39,29 +39,29 @@ namespace Parquet.Scripts
         /// <summary>
         /// Transforms the given texts into an <see cref="Action"/> to be invoked.
         /// </summary>
-        /// <param name="inCommandText">The name of the command.</param>
-        /// <param name="inSourceText">The source or subject of the command.</param>
-        /// <param name="inTargetText">The target or object of the command.</param>
+        /// <param name="commandText">The name of the command.</param>
+        /// <param name="sourceText">The source or subject of the command.</param>
+        /// <param name="targetText">The target or object of the command.</param>
         /// <returns>The action to perform.</returns>
-        private static Action ParseCommand(string inCommandText, string inSourceText, string inTargetText)
-            => inCommandText.ToUpperInvariant() switch
+        private static Action ParseCommand(string commandText, string sourceText, string targetText)
+            => commandText.ToUpperInvariant() switch
             {
                 Commands.None => () => { },
-                Commands.Alert => () => Logger.Log(LogLevel.Info, $"UI: [{inTargetText}]"),
-                Commands.CallCharacter => () => Logger.Log(LogLevel.Info, $"The character {inSourceText} stands near the character {inTargetText}."),
-                Commands.ClearFlag => () => Logger.Log(LogLevel.Info, $"The flag {inTargetText} is cleared."),
-                Commands.GiveItem => () => Logger.Log(LogLevel.Info, $"{inTargetText} is awarded the {inSourceText}"),
-                Commands.GiveQuest => () => Logger.Log(LogLevel.Info, $"{inTargetText} is tasked with {inSourceText}"),
-                Commands.Jump => () => Logger.Log(LogLevel.Info, $"Load the script {inTargetText}."),
-                Commands.JumpIf => () => Logger.Log(LogLevel.Info, $"If {inSourceText}, then Load the script {inTargetText}."),
-                Commands.Put => () => Logger.Log(LogLevel.Info, $"Place {inSourceText} at {inTargetText}"),
-                Commands.Say => () => Logger.Log(LogLevel.Info, $"{inSourceText}: {inTargetText}"),
-                Commands.SetBehavior => () => Logger.Log(LogLevel.Info, $"{inTargetText} begins behaving {inSourceText}"),
-                Commands.SetDialogue => () => Logger.Log(LogLevel.Info, $"{inTargetText} can now say {inSourceText}"),
-                Commands.SetPronoun => () => Logger.Log(LogLevel.Info, $"{inTargetText} uses the pronouns {inSourceText}"),
-                Commands.SetFlag => () => Logger.Log(LogLevel.Info, $"The flag {inTargetText} is raised."),
-                Commands.ShowLocation => () => Logger.Log(LogLevel.Info, $"Highlight {inTargetText}"),
-                _ => Logger.DefaultWithUnsupportedNodeLog<Action>(nameof(ScriptNode), inCommandText, () => { }),
+                Commands.Alert => () => Logger.Log(LogLevel.Info, $"UI: [{targetText}]"),
+                Commands.CallCharacter => () => Logger.Log(LogLevel.Info, $"The character {sourceText} stands near the character {targetText}."),
+                Commands.ClearFlag => () => Logger.Log(LogLevel.Info, $"The flag {targetText} is cleared."),
+                Commands.GiveItem => () => Logger.Log(LogLevel.Info, $"{targetText} is awarded the {sourceText}"),
+                Commands.GiveQuest => () => Logger.Log(LogLevel.Info, $"{targetText} is tasked with {sourceText}"),
+                Commands.Jump => () => Logger.Log(LogLevel.Info, $"Load the script {targetText}."),
+                Commands.JumpIf => () => Logger.Log(LogLevel.Info, $"If {sourceText}, then Load the script {targetText}."),
+                Commands.Put => () => Logger.Log(LogLevel.Info, $"Place {sourceText} at {targetText}"),
+                Commands.Say => () => Logger.Log(LogLevel.Info, $"{sourceText}: {targetText}"),
+                Commands.SetBehavior => () => Logger.Log(LogLevel.Info, $"{targetText} begins behaving {sourceText}"),
+                Commands.SetDialogue => () => Logger.Log(LogLevel.Info, $"{targetText} can now say {sourceText}"),
+                Commands.SetPronoun => () => Logger.Log(LogLevel.Info, $"{targetText} uses the pronouns {sourceText}"),
+                Commands.SetFlag => () => Logger.Log(LogLevel.Info, $"The flag {targetText} is raised."),
+                Commands.ShowLocation => () => Logger.Log(LogLevel.Info, $"Highlight {targetText}"),
+                _ => Logger.DefaultWithUnsupportedNodeLog<Action>(nameof(ScriptNode), commandText, () => { }),
             };
         #endregion
 
@@ -77,10 +77,10 @@ namespace Parquet.Scripts
         /// <summary>
         /// Enables <see cref="ScriptNode"/>s to be treated as their backing type.
         /// </summary>
-        /// <param name="inNode">Any tag.</param>
+        /// <param name="node">Any tag.</param>
         /// <returns>The tag's value.</returns>
-        public static implicit operator string(ScriptNode inNode)
-            => inNode?.nodeContent ?? "";
+        public static implicit operator string(ScriptNode node)
+            => node?.nodeContent ?? "";
         #endregion
 
         #region IComparable Implementation

--- a/ParquetClassLibrary/Scripts/ScriptNode.cs
+++ b/ParquetClassLibrary/Scripts/ScriptNode.cs
@@ -69,10 +69,10 @@ namespace Parquet.Scripts
         /// <summary>
         /// Enables <see cref="ScriptNode"/>s to be treated as their backing type.
         /// </summary>
-        /// <param name="inValue">Any valid tag value.  Invalid values will be sanitized.</param>
+        /// <param name="value">Any valid tag value.  Invalid values will be sanitized.</param>
         /// <returns>The given value as a tag.</returns>
-        public static implicit operator ScriptNode(string inValue)
-            => new() { nodeContent = inValue };
+        public static implicit operator ScriptNode(string value)
+            => new() { nodeContent = value };
 
         /// <summary>
         /// Enables <see cref="ScriptNode"/>s to be treated as their backing type.
@@ -87,7 +87,7 @@ namespace Parquet.Scripts
         /// <summary>
         /// Enables <see cref="ScriptNode"/>s to be compared one another.
         /// </summary>
-        /// <param name="inTag">Any valid <see cref="ScriptNode"/>.</param>
+        /// <param name="tag">Any valid <see cref="ScriptNode"/>.</param>
         /// <returns>
         /// A value indicating the relative ordering of the <see cref="ScriptNode"/>s being compared.
         /// The return value has these meanings:
@@ -96,8 +96,8 @@ namespace Parquet.Scripts
         ///     Greater than zero indicates that the current instance follows the given <see cref="ScriptNode"/> in the sort order.
         /// </returns>
         /// <remarks>This comparison is case insensitive.</remarks>
-        public int CompareTo(ScriptNode inTag)
-            => string.Compare(nodeContent, inTag?.nodeContent ?? "", StringComparison.OrdinalIgnoreCase);
+        public int CompareTo(ScriptNode tag)
+            => string.Compare(nodeContent, tag?.nodeContent ?? "", StringComparison.OrdinalIgnoreCase);
         #endregion
 
         #region ITypeConverter Implementation
@@ -108,26 +108,26 @@ namespace Parquet.Scripts
         /// <summary>
         /// Converts the given <see cref="string"/> to a <see cref="ScriptNode"/>.
         /// </summary>
-        /// <param name="inText">The <see cref="string"/> to convert to an object.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The <see cref="string"/> to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <returns>The <see cref="ScriptNode"/> created from the <see cref="string"/>.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
-            => string.IsNullOrEmpty(inText)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+            => string.IsNullOrEmpty(text)
                 ? None
-                : (ScriptNode)$"{char.ToUpperInvariant(inText[0])}{inText[1..]}";
+                : (ScriptNode)$"{char.ToUpperInvariant(text[0])}{text[1..]}";
 
         /// <summary>
         /// Converts the given <see cref="ScriptNode"/> to a record column.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being serialized.</param>
         /// <returns>The <see cref="ScriptNode"/> as a CSV record.</returns>
-        public string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is ScriptNode node
+        public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is ScriptNode node
                 ? (string)node
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(RecipeElement), nameof(None));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(RecipeElement), nameof(None));
         #endregion
 
         #region Utilities

--- a/ParquetClassLibrary/Scripts/ScriptNode.cs
+++ b/ParquetClassLibrary/Scripts/ScriptNode.cs
@@ -87,7 +87,7 @@ namespace Parquet.Scripts
         /// <summary>
         /// Enables <see cref="ScriptNode"/>s to be compared one another.
         /// </summary>
-        /// <param name="tag">Any valid <see cref="ScriptNode"/>.</param>
+        /// <param name="other">Any valid <see cref="ScriptNode"/>.</param>
         /// <returns>
         /// A value indicating the relative ordering of the <see cref="ScriptNode"/>s being compared.
         /// The return value has these meanings:
@@ -96,8 +96,8 @@ namespace Parquet.Scripts
         ///     Greater than zero indicates that the current instance follows the given <see cref="ScriptNode"/> in the sort order.
         /// </returns>
         /// <remarks>This comparison is case insensitive.</remarks>
-        public int CompareTo(ScriptNode tag)
-            => string.Compare(nodeContent, tag?.nodeContent ?? "", StringComparison.OrdinalIgnoreCase);
+        public int CompareTo(ScriptNode other)
+            => string.Compare(nodeContent, other?.nodeContent ?? "", StringComparison.OrdinalIgnoreCase);
         #endregion
 
         #region ITypeConverter Implementation

--- a/ParquetClassLibrary/Scripts/ScriptStatus.cs
+++ b/ParquetClassLibrary/Scripts/ScriptStatus.cs
@@ -36,24 +36,24 @@ namespace Parquet.Scripts
         /// <summary>
         /// Initializes a new instance of the <see cref="ScriptStatus"/> class.
         /// </summary>
-        /// <param name="inState">The <see cref="RunState"/> of the tracked <see cref="ScriptModel"/>.</param>
-        /// <param name="inProgramCounter">Index to the current <see cref="ScriptNode"/> in the tracked <see cref="ScriptModel.Nodes"/>.</param>
-        public ScriptStatus(RunState inState, int inProgramCounter)
+        /// <param name="state">The <see cref="RunState"/> of the tracked <see cref="ScriptModel"/>.</param>
+        /// <param name="programCounter">Index to the current <see cref="ScriptNode"/> in the tracked <see cref="ScriptModel.Nodes"/>.</param>
+        public ScriptStatus(RunState state, int programCounter)
         {
-            State = inState;
-            ProgramCounter = inProgramCounter;
+            State = state;
+            ProgramCounter = programCounter;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ScriptStatus"/> class
         /// based on a given <see cref="ScriptModel"/> instance.
         /// </summary>
-        /// <param name="inScript">The script definition whose status is being tracked.</param>
+        /// <param name="script">The script definition whose status is being tracked.</param>
         [SuppressMessage("Usage", "CA1801:Review unused parameters",
             Justification = "This constructor is provided for consistency.  The parameter is currently ignored, but may not be in the future.")]
         [SuppressMessage("Style", "IDE0060:Remove unused parameter",
             Justification = "This constructor is provided for consistency.  The parameter is currently ignored, but may not be in the future.")]
-        public ScriptStatus(ScriptModel inScript)
+        public ScriptStatus(ScriptModel script)
             : this(RunState.Unstarted, 0)
         { }
         #endregion

--- a/ParquetClassLibrary/Scripts/ScriptStatus.cs
+++ b/ParquetClassLibrary/Scripts/ScriptStatus.cs
@@ -71,10 +71,10 @@ namespace Parquet.Scripts
         /// <summary>
         /// Determines whether the specified <see cref="ScriptStatus"/> is equal to the current <see cref="ScriptStatus"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="ScriptStatus"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="ScriptStatus"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals<T>(T inStatus)
-            => inStatus is ScriptStatus ScriptStatus
+        public override bool Equals<T>(T status)
+            => status is ScriptStatus ScriptStatus
             && State == ScriptStatus.State
             && ProgramCounter == ScriptStatus.ProgramCounter;
 
@@ -90,20 +90,20 @@ namespace Parquet.Scripts
         /// <summary>
         /// Determines whether a specified instance of <see cref="ScriptStatus"/> is equal to another specified instance of <see cref="ScriptStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="ScriptStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="ScriptStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="ScriptStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="ScriptStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(ScriptStatus inStatus1, ScriptStatus inStatus2)
-            => inStatus1?.Equals(inStatus2) ?? inStatus2?.Equals(inStatus1) ?? true;
+        public static bool operator ==(ScriptStatus status1, ScriptStatus status2)
+            => status1?.Equals(status2) ?? status2?.Equals(status1) ?? true;
 
         /// <summary>
         /// Determines whether a specified instance of <see cref="ScriptStatus"/> is not equal to another specified instance of <see cref="ScriptStatus"/>.
         /// </summary>
-        /// <param name="inStatus1">The first <see cref="ScriptStatus"/> to compare.</param>
-        /// <param name="inStatus2">The second <see cref="ScriptStatus"/> to compare.</param>
+        /// <param name="status1">The first <see cref="ScriptStatus"/> to compare.</param>
+        /// <param name="status2">The second <see cref="ScriptStatus"/> to compare.</param>
         /// <returns><c>true</c> if they are NOT equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(ScriptStatus inStatus1, ScriptStatus inStatus2)
-            => !(inStatus1 == inStatus2);
+        public static bool operator !=(ScriptStatus status1, ScriptStatus status2)
+            => !(status1 == status2);
         #endregion
 
         #region ITypeConverter Implementation
@@ -113,32 +113,32 @@ namespace Parquet.Scripts
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public override string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData)
-            => inValue is ScriptStatus status
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            => value is ScriptStatus status
                 ? $"{status.State}{Delimiters.InternalDelimiter}" +
                   $"{status.ProgramCounter}"
-                : Logger.DefaultWithConvertLog(inValue?.ToString() ?? "null", nameof(ScriptStatus), nameof(Unstarted));
+                : Logger.DefaultWithConvertLog(value?.ToString() ?? "null", nameof(ScriptStatus), nameof(Unstarted));
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(Unstarted), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(Unstarted), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return Unstarted;
             }
 
-            var parameterText = inText.Split(Delimiters.SecondaryDelimiter);
+            var parameterText = text.Split(Delimiters.SecondaryDelimiter);
 
             var parsedState = Enum.TryParse(typeof(RunState), parameterText[0], out var temp0)
                 ? (RunState)temp0

--- a/ParquetClassLibrary/SeriesConverter.cs
+++ b/ParquetClassLibrary/SeriesConverter.cs
@@ -28,10 +28,10 @@ namespace Parquet
         /// Converts the given 1D collection into a record column.
         /// </summary>
         /// <param name="inCollection">The collection to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given collection serialized.</returns>
-        public override string ConvertToString(object inCollection, IWriterRow inRow, MemberMapData inMemberMapData)
+        public override string ConvertToString(object inCollection, IWriterRow row, MemberMapData memberMapData)
         {
             Precondition.IsNotNull(inCollection, nameof(inCollection));
             if (inCollection is not TCollection series)
@@ -49,7 +49,7 @@ namespace Parquet
             var result = new StringBuilder();
             foreach (var element in series)
             {
-                result.Append(element.ConvertToString(element, inRow, inMemberMapData));
+                result.Append(element.ConvertToString(element, row, memberMapData));
                 result.Append(Delimiters.SecondaryDelimiter[0]);
             }
             result.Remove(result.Length - Delimiters.SecondaryDelimiter.Length, Delimiters.SecondaryDelimiter.Length);
@@ -60,35 +60,35 @@ namespace Parquet
         /// <summary>
         /// Converts the given record column to a 1D collection.
         /// </summary>
-        /// <param name="inText">The record column to convert to an object.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The record column to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <returns>The <see cref="ICollection{TElement}"/> created from the record column.</returns>
-        public override object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData)
-            => ConvertFromString(inText, inRow, inMemberMapData, Delimiters.SecondaryDelimiter);
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+            => ConvertFromString(text, row, memberMapData, Delimiters.SecondaryDelimiter);
 
         /// <summary>
         /// Converts the given record column to a 1D collection.
         /// </summary>
-        /// <param name="inText">The record column to convert to an object.</param>
-        /// <param name="inRow">The <see cref="IReaderRow"/> for the current record.</param>
-        /// <param name="inMemberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
+        /// <param name="text">The record column to convert to an object.</param>
+        /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
+        /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
         /// <param name="inDelimiter">The string used to separate elements in the series.</param>
         /// <returns>The <see cref="ICollection{TElement}"/> created from the record column.</returns>
-        public object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData, string inDelimiter)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData, string inDelimiter)
         {
             var collection = new TCollection();
-            if (string.IsNullOrEmpty(inText)
-                || string.Compare(nameof(ModelID.None), inText, StringComparison.OrdinalIgnoreCase) == 0
-                || string.Compare(nameof(Enumerable.Empty), inText, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.IsNullOrEmpty(text)
+                || string.Compare(nameof(ModelID.None), text, StringComparison.OrdinalIgnoreCase) == 0
+                || string.Compare(nameof(Enumerable.Empty), text, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return collection;
             }
 
-            var textCollection = inText.Split(inDelimiter);
+            var textCollection = text.Split(inDelimiter);
             foreach (var currentText in textCollection)
             {
-                collection.Add((TElement)ElementFactory.ConvertFromString(currentText, inRow, inMemberMapData));
+                collection.Add((TElement)ElementFactory.ConvertFromString(currentText, row, memberMapData));
             }
             return collection;
         }

--- a/ParquetClassLibrary/SeriesConverter.cs
+++ b/ParquetClassLibrary/SeriesConverter.cs
@@ -27,16 +27,16 @@ namespace Parquet
         /// <summary>
         /// Converts the given 1D collection into a record column.
         /// </summary>
-        /// <param name="inCollection">The collection to convert.</param>
+        /// <param name="collection">The collection to convert.</param>
         /// <param name="row">The current context and configuration.</param>
         /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given collection serialized.</returns>
-        public override string ConvertToString(object inCollection, IWriterRow row, MemberMapData memberMapData)
+        public override string ConvertToString(object collection, IWriterRow row, MemberMapData memberMapData)
         {
-            Precondition.IsNotNull(inCollection, nameof(inCollection));
-            if (inCollection is not TCollection series)
+            Precondition.IsNotNull(collection, nameof(collection));
+            if (collection is not TCollection series)
             {
-                return Logger.DefaultWithConvertLog(inCollection?.ToString() ?? "null", nameof(TCollection), "");
+                return Logger.DefaultWithConvertLog(collection?.ToString() ?? "null", nameof(TCollection), "");
             }
 
             if (series.Count < 1
@@ -73,9 +73,9 @@ namespace Parquet
         /// <param name="text">The record column to convert to an object.</param>
         /// <param name="row">The <see cref="IReaderRow"/> for the current record.</param>
         /// <param name="memberMapData">The <see cref="MemberMapData"/> for the member being created.</param>
-        /// <param name="inDelimiter">The string used to separate elements in the series.</param>
+        /// <param name="delimiter">The string used to separate elements in the series.</param>
         /// <returns>The <see cref="ICollection{TElement}"/> created from the record column.</returns>
-        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData, string inDelimiter)
+        public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData, string delimiter)
         {
             var collection = new TCollection();
             if (string.IsNullOrEmpty(text)
@@ -85,7 +85,7 @@ namespace Parquet
                 return collection;
             }
 
-            var textCollection = text.Split(inDelimiter);
+            var textCollection = text.Split(delimiter);
             foreach (var currentText in textCollection)
             {
                 collection.Add((TElement)ElementFactory.ConvertFromString(currentText, row, memberMapData));

--- a/ParquetClassLibrary/Status.cs
+++ b/ParquetClassLibrary/Status.cs
@@ -107,14 +107,14 @@ namespace Parquet
         /// <summary>
         /// Determines if the given position corresponds to a point within the current array.
         /// </summary>
-        /// <param name="inArray">The array to validate against.</param>
-        /// <param name="inPosition">The position to validate.</param>
+        /// <param name="array">The array to validate against.</param>
+        /// <param name="position">The position to validate.</param>
         /// <returns><c>true</c>, if the position is valid, <c>false</c> otherwise.</returns>
-        public static bool IsValidPosition<T>(this Status<T>[,] inArray, Point2D inPosition)
-            => inArray is not null
-            && inPosition.X > -1
-            && inPosition.Y > -1
-            && inPosition.X < inArray.GetLength(1)
-            && inPosition.Y < inArray.GetLength(0);
+        public static bool IsValidPosition<T>(this Status<T>[,] array, Point2D position)
+            => array is not null
+            && position.X > -1
+            && position.Y > -1
+            && position.X < array.GetLength(1)
+            && position.Y < array.GetLength(0);
     }
 }

--- a/ParquetClassLibrary/Status.cs
+++ b/ParquetClassLibrary/Status.cs
@@ -43,10 +43,10 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified <see cref="Status{T}"/> is equal to the current <see cref="Status{T}"/>.
         /// </summary>
-        /// <param name="status">The <see cref="Status{T}"/> to compare with the current.</param>
+        /// <param name="other">The <see cref="Status{T}"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Status<T> status)
-            => Equals<Status<T>>(status);
+        public bool Equals(Status<T> other)
+            => Equals<Status<T>>(other);
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Status{T}"/>.

--- a/ParquetClassLibrary/Status.cs
+++ b/ParquetClassLibrary/Status.cs
@@ -35,18 +35,18 @@ namespace Parquet
         /// <summary>
         /// Determines whether the specified status is equal to the current status.
         /// </summary>
-        /// <param name="inStatus">The status to compare with the current.</param>
+        /// <param name="status">The status to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public abstract bool Equals<TDerived>(TDerived inStatus)
+        public abstract bool Equals<TDerived>(TDerived status)
             where TDerived : Status<T>;
 
         /// <summary>
         /// Determines whether the specified <see cref="Status{T}"/> is equal to the current <see cref="Status{T}"/>.
         /// </summary>
-        /// <param name="inStatus">The <see cref="Status{T}"/> to compare with the current.</param>
+        /// <param name="status">The <see cref="Status{T}"/> to compare with the current.</param>
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(Status<T> inStatus)
-            => Equals<Status<T>>(inStatus);
+        public bool Equals(Status<T> status)
+            => Equals<Status<T>>(status);
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="Status{T}"/>.
@@ -55,8 +55,8 @@ namespace Parquet
         /// <returns><c>true</c> if they are equal; otherwise, <c>false</c>.</returns>
         public abstract override bool Equals(object obj);
 
-        // NOTE that derived classes should also declare static bool operator ==(Status<T> inStatus1, Status<T> inStatus2)
-        // NOTE that derived classes should also declare static bool operator !=(Status<T> inStatus1, Status<T> inStatus2)
+        // NOTE that derived classes should also declare static bool operator ==(Status<T> status1, Status<T> status2)
+        // NOTE that derived classes should also declare static bool operator !=(Status<T> status1, Status<T> status2)
         #endregion
 
         #region ITypeConverter Implementation
@@ -65,20 +65,20 @@ namespace Parquet
         /// <summary>
         /// Converts the given <see cref="object"/> to a <see cref="string"/> for serialization.
         /// </summary>
-        /// <param name="inText">The text to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="text">The text to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance serialized.</returns>
-        public abstract object ConvertFromString(string inText, IReaderRow inRow, MemberMapData inMemberMapData);
+        public abstract object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData);
 
         /// <summary>
         /// Converts the given <see cref="string"/> to an <see cref="object"/> as deserialization.
         /// </summary>
-        /// <param name="inValue">The instance to convert.</param>
-        /// <param name="inRow">The current context and configuration.</param>
-        /// <param name="inMemberMapData">Mapping info for a member to a CSV field or property.</param>
+        /// <param name="value">The instance to convert.</param>
+        /// <param name="row">The current context and configuration.</param>
+        /// <param name="memberMapData">Mapping info for a member to a CSV field or property.</param>
         /// <returns>The given instance deserialized.</returns>
-        public abstract string ConvertToString(object inValue, IWriterRow inRow, MemberMapData inMemberMapData);
+        public abstract string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData);
         #endregion
 
         #region IDeeplyCloneable Implementation

--- a/ParquetRunner/ParquetRunner.csproj
+++ b/ParquetRunner/ParquetRunner.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -6,9 +6,9 @@
 
     <Product>Runner</Product>
     <PackageId>ParquetRunner</PackageId>
-    <Version>0.4.9.0</Version>
+    <Version>0.4.10.0</Version>
     <AssemblyVersion>0.4.0.0</AssemblyVersion>
-    <FileVersion>0.4.9.0</FileVersion>
+    <FileVersion>0.4.10.0</FileVersion>
     <InformationalVersion>Parquet Pre-Alpha 3</InformationalVersion>
 
     <Authors>Paige Ashlynn</Authors>

--- a/ParquetRunner/RunnerProgram.cs
+++ b/ParquetRunner/RunnerProgram.cs
@@ -231,7 +231,7 @@ namespace ParquetRunner
             Logger.Log(LogLevel.Info, LibraryState.IsDebugMode ? "Debug Mode" : "Release Mode");
             LibraryState.IsPlayMode = true;
 
-            //Logger.Log(LogLevel.Info, All.LoadFromCSVs() ? "Loaded." : "Failed to load!");
+            Logger.Log(LogLevel.Info, All.LoadFromCSVs() ? "Loaded." : "Failed to load!");
 
             var game = new GameModel(All.GameIDs.Minimum + 1, "Sample Game", "", "", null, false, "", -1, All.CharacterIDs.Minimum, All.ScriptIDs.Minimum);
             var episode = new GameModel(All.GameIDs.Minimum + 2, "Sample Episode", "", "", null, true, "In Which A Library Is Tested", 1, All.CharacterIDs.Minimum, All.ScriptIDs.Minimum);
@@ -239,7 +239,7 @@ namespace ParquetRunner
             Logger.Log(LogLevel.Info, episode);
             Logger.Log(LogLevel.Info, $"Item range = {All.ItemIDs}");
 
-            //Logger.Log(LogLevel.Info, All.SaveToCSVs() ? "Saved." : "Failed to save!");
+            Logger.Log(LogLevel.Info, All.SaveToCSVs() ? "Saved." : "Failed to save!");
         }
     }
 }

--- a/ParquetRunner/RunnerProgram.cs
+++ b/ParquetRunner/RunnerProgram.cs
@@ -231,7 +231,7 @@ namespace ParquetRunner
             Logger.Log(LogLevel.Info, LibraryState.IsDebugMode ? "Debug Mode" : "Release Mode");
             LibraryState.IsPlayMode = true;
 
-            Logger.Log(LogLevel.Info, All.LoadFromCSVs() ? "Loaded." : "Failed to load!");
+            //Logger.Log(LogLevel.Info, All.LoadFromCSVs() ? "Loaded." : "Failed to load!");
 
             var game = new GameModel(All.GameIDs.Minimum + 1, "Sample Game", "", "", null, false, "", -1, All.CharacterIDs.Minimum, All.ScriptIDs.Minimum);
             var episode = new GameModel(All.GameIDs.Minimum + 2, "Sample Episode", "", "", null, true, "In Which A Library Is Tested", 1, All.CharacterIDs.Minimum, All.ScriptIDs.Minimum);
@@ -239,7 +239,7 @@ namespace ParquetRunner
             Logger.Log(LogLevel.Info, episode);
             Logger.Log(LogLevel.Info, $"Item range = {All.ItemIDs}");
 
-            Logger.Log(LogLevel.Info, All.SaveToCSVs() ? "Saved." : "Failed to save!");
+            //Logger.Log(LogLevel.Info, All.SaveToCSVs() ? "Saved." : "Failed to save!");
         }
     }
 }

--- a/ParquetRunner/RunnerProgram.cs
+++ b/ParquetRunner/RunnerProgram.cs
@@ -166,12 +166,12 @@ namespace ParquetRunner
                                                     new StrikePanelGrid(StrikePanelGrid.PanelsPerPatternHeight, StrikePanelGrid.PanelsPerPatternWidth));
             TestInteraction = new InteractionModel(-All.InteractionIDs.Minimum, "5 Test Interaction", "Test", "Test", null, null, null, null);
             TestRegionModel = new RegionModel(-All.RegionIDs.Minimum, "7 Test Map Region", "Test", "Test");
-            TestFloor = new FloorModel(-All.FloorIDs.Minimum, "8 Test Floor", "Test", "Test", inAddsToRoom: new List<ModelTag> { TestTag });
-            TestBlock = new BlockModel(-All.BlockIDs.Minimum, "9 Test Block", "Test", "Test", inAddsToRoom: new List<ModelTag> { TestTag });
-            TestLiquid = new BlockModel(-All.BlockIDs.Minimum - 1, "L Test Liquid Block", "Test", "Test", inIsLiquid: true, inAddsToRoom: new List<ModelTag> { TestTag });
+            TestFloor = new FloorModel(-All.FloorIDs.Minimum, "8 Test Floor", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
+            TestBlock = new BlockModel(-All.BlockIDs.Minimum, "9 Test Block", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
+            TestLiquid = new BlockModel(-All.BlockIDs.Minimum - 1, "L Test Liquid Block", "Test", "Test", isLiquid: true, addsToRoom: new List<ModelTag> { TestTag });
             TestFurnishing = new FurnishingModel(-All.FurnishingIDs.Minimum, "10 Test Furnishing", "Test", "Test",
-                                                 inEntry: EntryType.Room, inAddsToRoom: new List<ModelTag> { TestTag });
-            TestCollectible = new CollectibleModel(-All.CollectibleIDs.Minimum, "11 Test Collectible", "Test", "Test", inAddsToRoom: new List<ModelTag> { TestTag });
+                                                 isEntry: EntryType.Room, addsToRoom: new List<ModelTag> { TestTag });
+            TestCollectible = new CollectibleModel(-All.CollectibleIDs.Minimum, "11 Test Collectible", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
             TestRoomRecipe = new RoomRecipe(-All.RoomRecipeIDs.Minimum - 1, "12 Test Room Recipe", "Test", "Test", null,
                                             RoomConfiguration.MinWalkableSpaces + 1, TestRecipeElementList,
                                             TestRecipeElementList, TestRecipeElementList);

--- a/ParquetRunner/RunnerProgram.cs
+++ b/ParquetRunner/RunnerProgram.cs
@@ -170,7 +170,7 @@ namespace ParquetRunner
             TestBlock = new BlockModel(-All.BlockIDs.Minimum, "9 Test Block", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
             TestLiquid = new BlockModel(-All.BlockIDs.Minimum - 1, "L Test Liquid Block", "Test", "Test", isLiquid: true, addsToRoom: new List<ModelTag> { TestTag });
             TestFurnishing = new FurnishingModel(-All.FurnishingIDs.Minimum, "10 Test Furnishing", "Test", "Test",
-                                                 isEntry: EntryType.Room, addsToRoom: new List<ModelTag> { TestTag });
+                                                 entry: EntryType.Room, addsToRoom: new List<ModelTag> { TestTag });
             TestCollectible = new CollectibleModel(-All.CollectibleIDs.Minimum, "11 Test Collectible", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
             TestRoomRecipe = new RoomRecipe(-All.RoomRecipeIDs.Minimum - 1, "12 Test Room Recipe", "Test", "Test", null,
                                             RoomConfiguration.MinWalkableSpaces + 1, TestRecipeElementList,

--- a/ParquetUnitTests/ParquetUnitTests.csproj
+++ b/ParquetUnitTests/ParquetUnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -6,9 +6,9 @@
 
     <Product>Parquet</Product>
     <PackageId>ParquetUnitTests</PackageId>
-    <Version>0.4.9.0</Version>
+    <Version>0.4.10.0</Version>
     <AssemblyVersion>0.4.0.0</AssemblyVersion>
-    <FileVersion>0.4.9.0</FileVersion>
+    <FileVersion>0.4.10.0</FileVersion>
     <InformationalVersion>Parquet Pre-Alpha 3</InformationalVersion>
 
     <Authors>Paige Ashlynn</Authors>

--- a/ParquetUnitTests/Parquets/BlockModelUnitTest.cs
+++ b/ParquetUnitTests/Parquets/BlockModelUnitTest.cs
@@ -64,7 +64,7 @@ namespace ParquetUnitTests.Parquets
         {
             var goodCollectibleID = TestModels.TestCollectible.ID;
 
-            var testBlock = new BlockModel(newBlockID, "will be created", "", "", inCollectibleID: goodCollectibleID);
+            var testBlock = new BlockModel(newBlockID, "will be created", "", "", collectibleID: goodCollectibleID);
 
             Assert.NotNull(testBlock);
         }
@@ -76,7 +76,7 @@ namespace ParquetUnitTests.Parquets
 
             void TestCode()
             {
-                var _ = new BlockModel(newBlockID, "will fail", "", "", inCollectibleID: badCollectibleID);
+                var _ = new BlockModel(newBlockID, "will fail", "", "", collectibleID: badCollectibleID);
             }
 
             Assert.Throws<ArgumentOutOfRangeException>(TestCode);

--- a/ParquetUnitTests/Parquets/FurnishingModelUnitTest.cs
+++ b/ParquetUnitTests/Parquets/FurnishingModelUnitTest.cs
@@ -64,7 +64,7 @@ namespace ParquetUnitTests.Parquets
         {
             var goodItemID = newFurnishingID - 1;
 
-            var testBlock = new FurnishingModel(newFurnishingID, "will be created", "", "", inItemID: goodItemID);
+            var testBlock = new FurnishingModel(newFurnishingID, "will be created", "", "", itemID: goodItemID);
 
             Assert.NotNull(testBlock);
         }
@@ -76,7 +76,7 @@ namespace ParquetUnitTests.Parquets
 
             void TestCode()
             {
-                var _ = new FurnishingModel(newFurnishingID, "will fail", "", "", inItemID: badItemID);
+                var _ = new FurnishingModel(newFurnishingID, "will fail", "", "", itemID: badItemID);
             }
 
             Assert.Throws<ArgumentOutOfRangeException>(TestCode);

--- a/ParquetUnitTests/Point2DUnitTest.cs
+++ b/ParquetUnitTests/Point2DUnitTest.cs
@@ -36,13 +36,13 @@ namespace ParquetUnitTests
         [InlineData(0, 0)]
         [InlineData(1, -1)]
         [InlineData(4096, 4096)]
-        internal void NewPointTest(int inX, int inY)
+        internal void NewPointTest(int x, int y)
         {
-            var testPoint = new Point2D(inX, inY);
-            var magnitude = Convert.ToInt32(Math.Floor(Math.Sqrt((inX * inX) + (inY * inY))));
+            var testPoint = new Point2D(x, y);
+            var magnitude = Convert.ToInt32(Math.Floor(Math.Sqrt((x * x) + (y * y))));
 
-            Assert.Equal(inX, testPoint.X);
-            Assert.Equal(inY, testPoint.Y);
+            Assert.Equal(x, testPoint.X);
+            Assert.Equal(y, testPoint.Y);
             Assert.Equal(magnitude, testPoint.Magnitude);
         }
 

--- a/ParquetUnitTests/Regions/RegionStatusUnitTestExtensions.cs
+++ b/ParquetUnitTests/Regions/RegionStatusUnitTestExtensions.cs
@@ -10,27 +10,27 @@ namespace ParquetUnitTests.Maps
     internal static class RegionStatusUnitTestExtensions
     {
         /// <summary>Fills the region with a test pattern.</summary>
-        internal static RegionModel FillTestPattern(this RegionModel inRegionModel)
+        internal static RegionModel FillTestPattern(this RegionModel regionModel)
         {
             for (var x = 0; x < RegionStatus.ParquetsPerRegionDimension; x++)
             {
                 for (var y = 0; y < RegionStatus.ParquetsPerRegionDimension; y++)
                 {
-                    inRegionModel.ParquetDefinitions[y, x].FloorID = TestModels.TestFloor.ID;
+                    regionModel.ParquetDefinitions[y, x].FloorID = TestModels.TestFloor.ID;
                 }
 
-                inRegionModel.ParquetDefinitions[0, x].BlockID = TestModels.TestBlock.ID;
-                inRegionModel.ParquetDefinitions[RegionModel.ParquetsPerRegionDimension, 1].BlockID = TestModels.TestBlock.ID;
+                regionModel.ParquetDefinitions[0, x].BlockID = TestModels.TestBlock.ID;
+                regionModel.ParquetDefinitions[RegionModel.ParquetsPerRegionDimension, 1].BlockID = TestModels.TestBlock.ID;
             }
             for (var y = 0; y < RegionStatus.ParquetsPerRegionDimension; y++)
             {
-                inRegionModel.ParquetDefinitions[y, 0].BlockID = TestModels.TestBlock.ID;
-                inRegionModel.ParquetDefinitions[y, RegionModel.ParquetsPerRegionDimension - 1].BlockID = TestModels.TestBlock.ID;
+                regionModel.ParquetDefinitions[y, 0].BlockID = TestModels.TestBlock.ID;
+                regionModel.ParquetDefinitions[y, RegionModel.ParquetsPerRegionDimension - 1].BlockID = TestModels.TestBlock.ID;
             }
-            inRegionModel.ParquetDefinitions[2, 1].FurnishingID = TestModels.TestFurnishing.ID;
-            inRegionModel.ParquetDefinitions[3, 3].CollectibleID = TestModels.TestCollectible.ID;
+            regionModel.ParquetDefinitions[2, 1].FurnishingID = TestModels.TestFurnishing.ID;
+            regionModel.ParquetDefinitions[3, 3].CollectibleID = TestModels.TestCollectible.ID;
 
-            return inRegionModel;
+            return regionModel;
         }
     }
 }

--- a/ParquetUnitTests/TestModels.cs
+++ b/ParquetUnitTests/TestModels.cs
@@ -165,12 +165,12 @@ namespace ParquetUnitTests
                                                     new StrikePanelGrid(StrikePanelGrid.PanelsPerPatternHeight, StrikePanelGrid.PanelsPerPatternWidth));
             TestInteraction = new InteractionModel(-All.InteractionIDs.Minimum, "5 Test Interaction", "Test", "Test", null, null, null, null);
             TestRegionModel = new RegionModel(-All.RegionIDs.Minimum, "7 Test Map Region", "Test", "Test");
-            TestFloor = new FloorModel(-All.FloorIDs.Minimum, "8 Test Floor", "Test", "Test", inAddsToRoom: new List<ModelTag> { TestTag });
-            TestBlock = new BlockModel(-All.BlockIDs.Minimum, "9 Test Block", "Test", "Test", inAddsToRoom: new List<ModelTag> { TestTag });
-            TestLiquid = new BlockModel(-All.BlockIDs.Minimum - 1, "L Test Liquid Block", "Test", "Test", inIsLiquid: true, inAddsToRoom: new List<ModelTag> { TestTag });
+            TestFloor = new FloorModel(-All.FloorIDs.Minimum, "8 Test Floor", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
+            TestBlock = new BlockModel(-All.BlockIDs.Minimum, "9 Test Block", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
+            TestLiquid = new BlockModel(-All.BlockIDs.Minimum - 1, "L Test Liquid Block", "Test", "Test", isLiquid: true, addsToRoom: new List<ModelTag> { TestTag });
             TestFurnishing = new FurnishingModel(-All.FurnishingIDs.Minimum, "10 Test Furnishing", "Test", "Test",
-                                                 inEntry: EntryType.Room, inAddsToRoom: new List<ModelTag> { TestTag });
-            TestCollectible = new CollectibleModel(-All.CollectibleIDs.Minimum, "11 Test Collectible", "Test", "Test", inAddsToRoom: new List<ModelTag> { TestTag });
+                                                 isEntry: EntryType.Room, addsToRoom: new List<ModelTag> { TestTag });
+            TestCollectible = new CollectibleModel(-All.CollectibleIDs.Minimum, "11 Test Collectible", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
             TestRoomRecipe = new RoomRecipe(-All.RoomRecipeIDs.Minimum - 1, "12 Test Room Recipe", "Test", "Test", null,
                                             RoomConfiguration.MinWalkableSpaces + 1, TestRecipeElementList,
                                             TestRecipeElementList, TestRecipeElementList);

--- a/ParquetUnitTests/TestModels.cs
+++ b/ParquetUnitTests/TestModels.cs
@@ -169,7 +169,7 @@ namespace ParquetUnitTests
             TestBlock = new BlockModel(-All.BlockIDs.Minimum, "9 Test Block", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
             TestLiquid = new BlockModel(-All.BlockIDs.Minimum - 1, "L Test Liquid Block", "Test", "Test", isLiquid: true, addsToRoom: new List<ModelTag> { TestTag });
             TestFurnishing = new FurnishingModel(-All.FurnishingIDs.Minimum, "10 Test Furnishing", "Test", "Test",
-                                                 isEntry: EntryType.Room, addsToRoom: new List<ModelTag> { TestTag });
+                                                 entry: EntryType.Room, addsToRoom: new List<ModelTag> { TestTag });
             TestCollectible = new CollectibleModel(-All.CollectibleIDs.Minimum, "11 Test Collectible", "Test", "Test", addsToRoom: new List<ModelTag> { TestTag });
             TestRoomRecipe = new RoomRecipe(-All.RoomRecipeIDs.Minimum - 1, "12 Test Room Recipe", "Test", "Test", null,
                                             RoomConfiguration.MinWalkableSpaces + 1, TestRecipeElementList,


### PR DESCRIPTION
This update makes Parquet method calls more idiomatic to C# by removing the "in", "out", and "ref" prefixes on parameter names.
These prefixes help me when implementing the API, but as Parquet approaches Alpha it makes more sense to prioritize the experience of the API consumers.